### PR TITLE
Add final Publishing (Blue) 1.1 DTD to GitHub repository from FTP site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+all: publishing/1.1
+
+publishing/1.1:
+	@mkdir -p $@
+	bash merge.sh ftp://ftp.ncbi.nih.gov/pub/jats/$@/JATS-Publishing-1-1-MathML2-DTD.zip $@
+	bash merge.sh ftp://ftp.ncbi.nih.gov/pub/jats/$@/JATS-Publishing-1-1-MathML3-DTD.zip $@
+	bash merge.sh ftp://ftp.ncbi.nih.gov/pub/jats/$@/JATS-Publishing-1-1-OASIS-MathML2-DTD.zip $@
+	bash merge.sh ftp://ftp.ncbi.nih.gov/pub/jats/$@/JATS-Publishing-1-1-OASIS-MathML3-DTD.zip $@

--- a/merge.sh
+++ b/merge.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Download a zip from the first argument, merge into the directory specified by the second argument, and clean up
+# Example:
+#   bash merge-zip.sh ftp://ftp.ncbi.nih.gov/pub/jats/publishing/1.1/JATS-Publishing-1-1-MathML2-DTD.zip publishing/1.1
+
+# download, unzip, and remove zip
+NAME=$(basename -s .zip $1)
+curl $1 > $NAME.zip
+unzip -o $NAME.zip
+rm $NAME.zip
+
+# merge and remove directory
+cp -fR $NAME/* $2/
+rm -rf $NAME
+mv Publishing-Readme.txt $2/README.txt

--- a/publishing/1.1/JATS-XHTMLtablesetup1.ent
+++ b/publishing/1.1/JATS-XHTMLtablesetup1.ent
@@ -1,0 +1,501 @@
+<!-- ============================================================= -->
+<!--  MODULE:    XHTML Table Setup Module                          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.1 201501215//EN"
+     Delivered as file "JATS-XHTMLtablesetup1.ent"                 -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the XHTML 1.1 -->
+<!--             table model                                       -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Invokes the inline style attribute module      -->
+<!--                  to pick up the "style" attribute             -->
+<!--             2) Overrides to standard parameter entities used  -->
+<!--                in the XHTML 1.1 table model                   -->
+<!--             3) Invokes the XHTML 1.1 table model              -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) XHTML inline style module                      -->
+<!--                  (-%xhtml-inlstyle-1.mod;)                    -->
+<!--             2) XHTML 1.1 table model (-%xhtml-table-1.mod;)   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 16. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 15. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 14. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. TABLE ATTRIBUTES
+     - Added @specific-use to the attributes for <table>,
+       primarily for use when <table> is used inside <alternatives>.
+     - This entailed creating a new PE "additional-table-atts",
+       which is defined and called AFTER the full table setup,
+       so that XML tools that do not recognize a 2nd ATTLIST for
+       an element will lose only the @specific-use. This new PE
+       could also be sued to add other attributes to an XHTML-
+       inspired <table>.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 11. CAPTION ATTRIBUTES - This module has been changed to alter
+      the mechanism by which the @style attribute is associated 
+      with the element <caption>. 
+          Previously, the <caption> element's base attributes  
+      were declared in the JATS-display.ent module and additional 
+      attributes (in the published XHTML, only @style) for it 
+      were declared in the XHTML Table Module. The @style 
+      attribute is now declared with all the other <caption>
+      attributes in the  JATS-display.ent module, and the caption 
+      attributes in the XHTML table model have been set to IGNORE. 
+      This was done to prevent duplicate (harmless but annoying)
+      attribute warning messages. 
+                        
+           CAUTION: If your XHTML customization has added attributes
+                    by redefining the parameter entity 
+                            "Core.extra.attrib"
+                    you will need to uncomment the lines in this
+                    module that add that parameter entity to the
+                    contents of the <caption> attribute list.
+                    Otherwise, your new attributes will not be
+                    added to <caption>. When you uncomment this
+                    line, you will get a duplicative attribute
+                    warning message on the @style attribute,
+                    which you may ignore.  
+                    
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added an attribute list to the parameter entity 
+     "Common.attrib".
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. OASIS NAMESPACE - Added the OASIS table namespace handling,
+     which, by default, places a namespace prefix of "oasis" on
+     the OASIS CALS Exchange Table Model.
+      - Added call to JATS-oasis-namespace.ent (which sets up
+          the OASIS namespace URI and the prefix "oasis")
+      - Added  %oasis.xmlns.attrib; attribute to <article>
+      - Altered the custom classes module to use the new
+         namespaced OASIS element names for <table> and <tbody>
+         (%otable.qname; and %otbody.qname;)
+     NOTE: The XHTML table material was not removed, so both table
+     models still work (using <table> and <oasis:table> respectively.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            --> 
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE XHTML 1.1 TABLE MODULE      -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    THE XHTML TABLE STYLE ATTRIBUTE MODULE     -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE INLINE STYLE MODULE            -->
+<!--                    This module declares the 'style' attribute,
+                        used to support inline style markup for the
+                        <td> and <tr> elements. Copyright 1998-2005
+                        W3C (MIT, ERCIM, Keio), All Rights Reserved.
+                        Revision: $Id: xhtml-inlstyle-1.mod,v 4.0
+                        2001/04/02 22:42:49 altheim Exp $
+                        PUBLIC identifier
+                        "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+                        SYSTEM identifier
+                "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"-->
+%xhtml-inlstyle-1.mod;
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR TABLE ELEMENT NAMES           -->
+<!-- ============================================================= -->
+
+
+<!ENTITY % table.qname  "table"                                      >
+<!ENTITY % caption.qname
+                        "caption"                                    >
+<!ENTITY % thead.qname  "thead"                                      >
+<!ENTITY % tfoot.qname  "tfoot"                                      >
+<!ENTITY % tbody.qname  "tbody"                                      >
+<!ENTITY % colgroup.qname
+                        "colgroup"                                   >
+<!ENTITY % col.qname    "col"                                        >
+<!ENTITY % tr.qname     "tr"                                         >
+<!ENTITY % th.qname     "th"                                         >
+<!ENTITY % td.qname     "td"                                         >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR DATATYPE PARAMETER ENTITIES   -->
+<!-- ============================================================= -->
+
+
+<!ENTITY % Text.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Number.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % MultiLength.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Length.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Pixels.datatype
+                        "CDATA"                                      >
+
+
+<!ENTITY % Character.datatype
+                        "CDATA"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE PARAMETER ENTITIES  -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES (used all over)          -->
+<!--         style      Defined in the PE -%Core.extra.attrib; and
+                        used to support inline style markup. This
+                        attribute is defined in the XHTML Table
+                        Inline Style Module called in with the PE:
+                           -%xhtml-inlstyle-1.mod
+                        which must be invoked before the attribute
+                        PE is used. 
+                        Warning: The definitions below will lead to
+                        the element <caption> having the attributes
+                        @id and @content-type defined twice. This is
+                        just a validity warning, not an error and 
+                        should be ignored.                         -->
+<!ENTITY % Common.attrib
+            "%jats-common-atts;
+             content-type
+                        CDATA                             #IMPLIED
+             %Core.extra.attrib;"                                    >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES TO REMOVE CAPTION               -->
+<!-- ============================================================= -->
+
+
+<!--                   CAPTION FOR A TABLE                         -->
+<!--                   Modification of the standard XHMTL model
+                       Removed the definition of caption, so the
+                       element would not be multiply defined       -->
+<!ENTITY % caption.element
+                       "IGNORE"                                      >
+
+
+<!ENTITY % caption.attlist  
+                       "IGNORE"                                      >
+
+
+<!--                    CAPTION ATTRIBUTES                         -->
+<!--                    Attributes for <caption> element           -->
+<!--                    In the lines directly above this declaration,
+                        the attribute list for caption, as defined
+                        in the XHTML Table Model, has been removed
+                        using the IGNORE mechanism. This was done 
+                        to prevent duplicate (harmless but annoying)
+                        attribute warning messages. 
+                        
+                        CAUTION: If your XHTML customization has
+                        redefined the parameter entity 
+                                   "Core.extra.attrib"
+                        you will need to uncomment the lines
+                        below. You will get a duplicative attribute
+                        warning message on the @style attribute,
+                        which you may ignore.                      -->
+<!--
+<!ENTITY % caption-atts
+                        "%Core.extra.attrib;                         >
+-->
+            
+            
+<!-- ============================================================= -->
+<!--                    OVER-RIDES FOR CONTENT PARAMETER ENTITIES  -->
+<!-- ============================================================= -->
+
+
+<!--                   INLINE ELEMENTS                             -->
+<!--                   Modification of the standard XHMTL model
+                       for inline elements used in the <caption>
+                       Set to the null because the <caption>
+                       element is now inside the table wrapper,
+                       not inside the table, as the original XHTML
+                       table intended                              -->
+<!ENTITY % Inline.mix  ""                                            >
+
+
+<!--                   CONTENTS OF A TABLE CELL                    -->
+<!--                   Modification of the standard XHMTL model
+                       used for the content of tables cells <th>
+                       and <td>                                    -->
+<!ENTITY % Flow.mix    "%inside-cell;"                               >
+
+
+<!--                   CONTENTS OF A TABLE                         -->
+<!--                   Modification of the standard XHMTL model
+                       This has been modified from the XHTML model
+                       to remove the <caption> element from the
+                       <table> model, since in the JATS DTD Suite 
+                       modular library, the <caption> element is part  
+                       of the Table Wrapper <table-wrap> element. 
+                       No other changes were made to the XHTML table 
+                       content model.                              -->
+<!ENTITY % table.content
+     "( ( %col.qname;* | %colgroup.qname;* ),
+        ( ( %thead.qname;?, %tfoot.qname;?, %tbody.qname;+ ) |
+          ( %tr.qname;+ )
+        )
+      )"                                                             >
+
+
+<!-- ============================================================= -->
+<!--                    THE XHTML V1.1 TABLE INVOCATION            -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE MODEL                          -->
+<!--                    This module declares element types and
+                        attributes used to provide table markup
+                        similar to HTML 4, including features that
+                        enable better accessibility for non-visual
+                        user agents. This is the XHTML reformulation
+                        of HTML as a modular XML application.
+                        Copyright 1998-2005 W3C (MIT, ERCIM, Keio),
+                        All Rights Reserved.
+                        Revision: $Id: xhtml-table-1.mod,v 4.1
+                        2001/04/10 09:42:30 altheim Exp $ SMI
+                        PUBLIC identifier
+                        "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+                        SYSTEM identifier:
+                  "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod" -->
+%xhtml-table-1.mod;
+
+<!-- ============================================================= -->
+<!--                    ADDITIONAL ATTRIBUTE(S) FOR TABLE          -->
+<!-- ============================================================= -->
+
+<!ENTITY % additional-table-atts
+            "specific-use 
+                        CDATA                              #IMPLIED" >
+
+<!ATTLIST %table.qname;
+            %additional-table-atts;                                  >
+
+<!-- ================== End XHTML Table Setup Module ============= -->

--- a/publishing/1.1/JATS-ali-namespace1.ent
+++ b/publishing/1.1/JATS-ali-namespace1.ent
@@ -1,0 +1,154 @@
+<!-- ============================================================= -->
+<!--  MODULE:    ALI Namespace Module (NISO RP-22-2015)            -->
+<!--             NISO Access License and Indicators (ALI)          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS ALI Namespace Module v1.1 20151215//EN"
+     Delivered as file "JATS-ali-namespace1.ent"                   -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Establish the prefix for the NISO Access and      -->
+<!--             Indicators elements (prefix "ali:").              -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2015                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  1. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+
+     Details concerning ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/
+                                                                   -->
+<!-- ============================================================= -->
+<!--                    ALI NAMESPACE SETUP                        -->
+<!-- ============================================================= -->
+
+
+<!--                    NAME ALI NAMESPACE BASE URI                -->
+<!--                    Set the ALI namespace URI,as named in
+                        NISO RP-22-2015                            -->
+<!ENTITY % ali.xmlns   
+      "http://www.niso.org/schemas/ali/1.0/"                         >
+
+
+<!--                    NAME ALI NAMESPACE PREFIX                  -->
+<!--                    Set the namespace prefix for the ALI
+                        elements to the JATS-named prefix "ali". 
+                        Implementor's Note: This parameter entity
+                        should always be set, even if you need to turn
+                        off the namespace prefix.                  -->
+<!ENTITY % ali.prefix   "ali"                                        >
+
+
+<!--                    NAME OASIS NAMESPACE PREFIX                -->
+<!--                    Construct the ALI namespace prefix to be 
+                        used in the xmlns pseudo-attribute from:
+                          - the word "xmlns", 
+                          - a colon, and 
+                          - the prefix just defined in %ali.prefix;
+                                                                   -->
+<!ENTITY % ali.xmlns.attrname
+                        "xmlns:%ali.prefix;"                         >
+
+
+<!--                    DEFAULT ALI NAMESPACE                       -->
+<!--                    The default namespace to be used when
+                        calling in the ALI elements. This is set on 
+                        the article level as well as on the ALI
+                        elements themselves.
+                        Implementor's Note: The parameter entity is
+                        constructed from the parameter entities set 
+                        above.                                     -->
+<!ENTITY % ali.xmlns.attrib
+     "%ali.xmlns.attrname; 
+                        CDATA               #FIXED '%ali.xmlns;'"    >
+
+
+<!-- ================== End ALI Namespace Setup  ================= -->

--- a/publishing/1.1/JATS-articlemeta1.ent
+++ b/publishing/1.1/JATS-articlemeta1.ent
@@ -1,0 +1,1817 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Article Metadata Elements                 -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.1 20151215//EN"
+     Delivered as file "JATS-articlemeta1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements used to describe the journal   -->
+<!--             in which the journal article is published.        -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 31. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 30. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 29. <VOLUME> INSIDE <ARTICLE-META>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+   
+ 28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 27. NEW <era> ELEMENT
+     Added <era> through date-model
+      - <pub-date>
+
+ 26. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - article-categories
+      - article-meta
+      - counts
+      - history
+      - title-group                          
+
+ 25. ABSTRACTS AND KEYWORDS
+       Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - article-meta (through %article-meta-model;)
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 24. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <article-meta> using article-meta-model.
+
+ 23. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+     and <contrib-group> to common.ent, since they are now used
+     in both article metadata and journal metadata.
+
+ 22. CONTRIBUTOR MODEL - Added "contrib-id.class" to the beginning
+     at the <contrib> model, to hold identifiers for people,
+     such as publishers-specific IDs, ORCIDs, and JST and NII 
+     identifiers.
+   
+ 21. COUNTS - Generic <count> element added to the <counts>
+     wrapper. This element is allowed to repeat, to count
+     anything a publisher or archive may wish to count.
+     The @count-type attribute will name what is being counted
+     (such as figures, tables, sections, contributors, images,
+     etc.) The @count attribute will state how many of the 
+     objects are in the document.
+     
+     Although a publisher or archive could choose to label
+     all the counted objects in a document this way, the
+     specific count elements (fig-count, equation-count,
+     word-count, etc.) will be retained for backwards
+     compatibility.
+     
+     New parameter entities: count-atts.
+   
+ 20. PUBLICATION DATE ATTRIBUTES - Added to the attributes for
+     <pub-date> (through @pub-date-atts):
+       a) @iso-8601-date - ISO 8601 standard date format
+          of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+       b) @calendar - Name of the calendar used (@calendar) in
+          naming this publication date (such as "Gregorian", 
+          "Japanese" (Emperor years), or "Islamic").
+       c) @date-type to record lifecycle information as to which
+          publication date is involved (such as retracted, corrected,
+          preprint).
+       d) @publication-format to hold what format or media was 
+          published on this date (such as "print" or
+          "electronic").
+       e) @xml:lang (comments below said was this added for 0.4).
+   
+ 19. COMPOUND KEYWORD PARTS - Allowed the individual compound 
+     keyword parts (<compound-kwd-part> to be as complex as 
+     ordinary keywords <kwd>), by giving them the same model 
+     as <kwd>.
+   
+ 18. NESTED KEYWORDS - Added new keyword type element for nested
+     keywords (<nested-kwd>), to hold hierarchical keywords such
+     as taxonomic structures. New PEs %nested-kwd-model; and
+     %nested-kwd-atts;
+   
+ 17. MODULE MOVEMENT (from increased reference content)
+
+     a) Element <degrees> - Moved <degrees> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     b) Element <supplement> - Moved <supplement> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+        entities from this module from JATS-common.ent.
+   
+     d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+        entities from this module from JATS-common.ent.
+   
+ 16. Added name comment to %counts-model;
+
+ 15. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 14. Updated the DTD-version attribute to "0.4" 
+   
+ 13. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+ 12. UNSTRUCTURED KEYWORD GROUP ATTRIBUTES - Made
+     %unstructured-kwd-group-atts; into its own PE, as
+     documentation stated had already been done.
+
+ 11. KEYWORD ATTRIBUTES - To make the tag set more consistent,
+     added @content-type to <kwd>, since <compound-kwd> already
+     took this attribute. Through %kwd-atts;
+
+ 10. I18N - At the request of the SBJ Working Group (Japan)
+     made <series-text> repeatable inside <article-categories> using
+     %article-categories-model;
+
+  9. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break. Models changed:
+       - alt-title    %alt-title-elements; defined in common.ent
+       - subtitle     %subtitle-elements; (moved to this
+           module)
+
+  8. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <article-meta> through %article meta-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  7. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - alt-title through alt-title-atts (both)
+      - article-id through article-id-atts (@specific-use only)
+      - author-comment through author-comment-atts (both)
+      - author-notes through author-notes-atts (both)
+      - article-id through article-id-atts (@xml:lang)
+      - contrib through contrib-atts (@specific-use only)
+      - contrib-group through contrib-group-atts (@xml:lang)
+      - corresp through corresp-atts (@specific-use)
+      - degrees through degrees-atts (both)
+      - kwd-group through kwd-group-atts (@specific-use only
+             @xml:lang already there)
+      - on-behalf-of through on-behalf-of-atts (both) NEW PE
+      - product through product-atts (both)
+      - pub-date through pub-date-atts (@xml:lang)
+      - self-uri through self-uri-atts (both)
+      - series-text through series-text-atts (both)
+      - series-title through series-title-atts (both)
+      - string-conf through string-conf-atts (both)
+      - subj-group through subj-group-atts (both)
+      - subtitle through subtitle-atts (@specific only
+             @xml:lang already there)
+      - supplement through supplement-atts (both)
+
+  6. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break.
+
+  5. COUNT ATTRIBUTES - Removed the dependency which had all of
+     the count elements using a single attribute list (%count-atts;)
+     Created new attributes list PEs for each of them: equation-count,
+     fig-count, page-count, ref-count, table-count, and word-count.
+     *****Customization Alert: New parameter entities could break
+     some customizations. Check the attribute list parameter entity
+     for each of the count elements. *****
+
+  4. COMPOUND SUBJECT - Created a new element <compound-subject>
+     that acts just like <compound-kwd>, in that it takes one or
+     more <compound-subject-part>s to allow a complex, multi-
+     part subject to be captured. New elements, attribute lists,
+     and parameter entities. (An example of a compound subject
+     is a code with a textual keyword (A11 Permeability).
+     Allowed <compound-subject> as an alternative to <subject>
+     inside a <subj-group>.
+
+  3. SERIES TEXT ATTRIBUTES - Both <series-title> and
+     <series-text> used to use the PE %series-title-atts;. Added the
+     PE %series-text-atts;, which is the only one <series-text>
+     uses. No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <series-text> attributes. *****
+
+  2. TRANSLATED ABSTRACT ATTRIBUTES - Both <abstract> and
+     <trans-abstract> used to use the PE %abstract-atts;. Added the
+     PE %trans-abstract-atts;, which is the only one <trans-abstract>
+     uses. No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <trans-abstract> attributes. *****
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT ATTRIBUTES                        -->
+<!--                    Attributes for the <abstract> element      -->
+<!ENTITY % abstract-atts
+            "%jats-common-atts;                                       
+             abstract-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ALTERNATE TITLE ATTRIBUTES                 -->
+<!--                    Attributes for the <alt-title> element     -->
+<!ENTITY % alt-title-atts
+            "%jats-common-atts;                                       
+             alt-title-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ARTICLE CATEGORIES ATTRIBUTES              -->
+<!--                    Attributes for the <article-categories> 
+                        element                                    -->
+<!ENTITY % article-categories-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    ARTICLE METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <article-meta> element  -->
+<!ENTITY % article-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    AUTHOR COMMENT ATTRIBUTES                  -->
+<!--                    Attributes for the <author-comment> element-->
+<!ENTITY % author-comment-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AUTHOR NOTES ATTRIBUTES                    -->
+<!--                    Attributes for the <author-notes> element  -->
+<!ENTITY % author-notes-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ARTICLE IDENTIFIER ATTRIBUTES              -->
+<!--                    Attributes for the <article-id> element    -->
+<!ENTITY % article-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type
+                        (%pub-id-types;)                  #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND KEYWORD ATTRIBUTES                -->
+<!--                    Attributes for the <compound-kwd> element
+                                                                   -->
+<!ENTITY % compound-kwd-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND KEYWORD PART ATTRIBUTES           -->
+<!--                    Attributes for the <compound-kwd-part>
+                        element                                    -->
+<!ENTITY % compound-kwd-part-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND SUBJECT ATTRIBUTES                -->
+<!--                    Attributes for the <compound-subject> element
+                                                                   -->
+<!ENTITY % compound-subject-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COMPOUND SUBJECT PART ATTRIBUTES           -->
+<!--                    Attributes for the <compound-subject-part>
+                        element                                    -->
+<!ENTITY % compound-subject-part-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CONFERENCE ACRONYM ATTRIBUTES              -->
+<!--                    Attributes for the <conf-acronym> element  -->
+<!ENTITY % conf-acronym-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE NUMBER ATTRIBUTES               -->
+<!--                    Attributes for the <conf-num> element      -->
+<!ENTITY % conf-num-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE THEME ATTRIBUTES                -->
+<!--                    Attributes for the <conf-theme> element    -->
+<!ENTITY % conf-theme-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE ATTRIBUTES                      -->
+<!--                    Attributes for the <conference> element    -->
+<!ENTITY % conference-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CORRESPONDING ATTRIBUTES                   -->
+<!--                    Attributes for the <corresp> element       -->
+<!ENTITY % corresp-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COUNT ATTRIBUTES                           -->
+<!--                    Attributes for the <count> element         -->
+<!ENTITY % count-atts
+            "%jats-common-atts;                                       
+             count-type CDATA                             #REQUIRED 
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    COUNTS ATTRIBUTES                          -->
+<!--                    Attributes for the <counts> element        -->
+<!ENTITY % counts-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    EQUATION COUNT ATTRIBUTES                  -->
+<!--                    Attributes for the <equation-count> element-->
+<!ENTITY % equation-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    FIGURE COUNT ATTRIBUTES                    -->
+<!--                    Attributes for the <fig-count> element     -->
+<!ENTITY % fig-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    HISTORY ATTRIBUTES                         -->
+<!--                    Attributes for the <history> element       -->
+<!ENTITY % history-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    KEYWORD ATTRIBUTES                         -->
+<!--                    Attributes for the <kwd> element           -->
+<!ENTITY % kwd-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    KEYWORD GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <kwd-group> element     -->
+<!ENTITY % kwd-group-atts
+            "%jats-common-atts;                                       
+             kwd-group-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NESTED KEYWORD ATTRIBUTES                  -->
+<!--                    Attributes for the <nested-kwd> element    -->
+<!ENTITY % nested-kwd-atts
+            "%jats-common-atts;                                       
+            content-type
+                       CDATA                             #IMPLIED"  >
+
+
+<!--                    PAGE COUNT ATTRIBUTES                      -->
+<!--                    Attributes for the <page-count> element    -->
+<!ENTITY % page-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    PRODUCT ATTRIBUTES                         -->
+<!--                    Attributes for the <product> element       -->
+<!ENTITY % product-atts
+            "%jats-common-atts;                                       
+             product-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    PUBLICATION DATE ATTRIBUTES                -->
+<!--                    Attributes for the <pub-date> element      -->
+<!ENTITY % pub-date-atts
+            "%jats-common-atts;                                       
+             pub-type   CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             date-type  CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    REFERENCE (CITATION) COUNT ATTRIBUTES      -->
+<!--                    Attributes for the <ref-count> element     -->
+<!ENTITY % ref-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    SELF URI ATTRIBUTES                        -->
+<!--                    Attributes for the <self-uri> element      -->
+<!ENTITY % self-uri-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    SERIES TEXT ATTRIBUTES                     -->
+<!--                    Attributes for the <series-text> element   -->
+<!ENTITY % series-text-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SERIES TITLE ATTRIBUTES                    -->
+<!--                    Attributes for the <series-title> element  -->
+<!ENTITY % series-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING CONFERENCE ATTRIBUTES               -->
+<!--                    Attributes for the <string-conf> element   -->
+<!ENTITY % string-conf-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUBJECT GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <subj-group> element    -->
+<!ENTITY % subj-group-atts
+            "%jats-common-atts;                                       
+             subj-group-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUBJECT ATTRIBUTES                         -->
+<!--                    Attributes for the <subject> element       -->
+<!ENTITY % subject-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUBTITLE ATTRIBUTES                        -->
+<!--                    Attributes for the <subtitle> element      -->
+<!ENTITY % subtitle-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TABLE COUNT ATTRIBUTES                     -->
+<!--                    Attributes for the <table-count> element   -->
+<!ENTITY % table-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!--                    TITLE GROUP ATTRIBUTES                     -->
+<!--                    Attributes for the <title-group> element   -->
+<!ENTITY % title-group-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TRANSLATED ABSTRACT ATTRIBUTES             -->
+<!--                    Attributes for the <trans-abstract> element-->
+<!ENTITY % trans-abstract-atts
+            "%jats-common-atts;                                       
+             abstract-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP ATTRIBUTES      -->
+<!--                    Attributes for the <unstructured-kwd-group>
+                                                       element     -->
+<!ENTITY % unstructured-kwd-group-atts
+            "%jats-common-atts;                                       
+             kwd-group-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    WORD COUNT ATTRIBUTES                      -->
+<!--                    Attributes for the <word-count> element    -->
+<!ENTITY % word-count-atts
+            "%jats-common-atts;                                       
+             count      NMTOKEN                           #REQUIRED" >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA                           -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA MODEL                     -->
+<!--                    Complete content model for the <article-meta>
+                        element, which names the journal article
+                        metadata                                   -->
+<!ENTITY % article-meta-model
+                       "(article-id*, article-categories?,
+                         title-group?,
+                         (%contrib-group.class; |
+                          %aff-alternatives.class;)*,
+                         author-notes?, pub-date*,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id )?,
+                         (%address-link.class; | product |
+                          supplementary-material)*,
+                         history?, permissions?, self-uri*,
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*,
+                         trans-abstract*, (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?, 
+                         custom-meta-group?)"                        >
+
+
+<!--ELEM   address links (email | ext-link | uri)
+                        Defined in %funding.ent;                   -->
+<!--ELEM   aff          Defined in %common.ent;                    -->
+<!--ELEM   copyright-statement
+                        Defined in %common.ent;                    -->
+<!--ELEM   copyright-year
+                        Defined in %common.ent;                    -->
+<!--ELEM   custom-meta-group
+                        Defined in %common.ent;                    -->
+<!--ELEM   elocation-id Defined in %common.ent;                    -->
+<!--ELEM   ext-link     Defined in %common.ent;                    -->
+<!--ELEM   fpage        Defined in %common.ent;                    -->
+<!--ELEM   funding-group
+                        Defined in %funding.ent;                   -->
+<!--ELEM   isbn         Defined in %common.ent;                    -->
+<!--ELEM   issue        Defined in %common.ent;                    -->
+<!--ELEM   issue-id     Defined in %common.ent;                    -->
+<!--ELEM   issue-title  Defined in %common.ent;                    -->
+<!--ELEM   issue-sponsor
+                        Defined in %common.ent;                    -->
+<!--ELEM   license      Defined in %common.ent;                    -->
+<!--ELEM   lpage        Defined in %common.ent;                    -->
+<!--ELEM   page-range   Defined in %common.ent;                    -->
+<!--ELEM   permissions  Defined in %common.ent;                    -->
+<!--ELEM   related-article and related-object
+                        Defined in %common.ent;                    -->
+<!--ELEM   supplementary-material
+                        Defined in %display.ent;                   -->
+<!--ELEM   volume       Defined in %common.ent;                    -->
+<!--ELEM   volume-id    Defined in %common.ent;                    -->
+<!--ELEM   volume-series
+                        Defined in %common.ent;                    -->
+
+
+<!--                    ARTICLE METADATA                           -->
+<!--                    Metadata that identifies this article, for
+                        example, bibliographic information such as
+                        the title, author, and copyright year.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=article-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article-meta
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=article-meta
+                                                                   -->
+<!ELEMENT  article-meta %article-meta-model;                         >
+<!ATTLIST  article-meta
+             %article-meta-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE IDENTIFIER                         -->
+<!--                    Optional element, used to hold one of the
+                        "unique identifiers" that have been assigned
+                        at various times to an article.  Such
+                        identifiers may come from a publisher, a
+                        jobber, from PubMed Central, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=article-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article-id
+                                                                   -->
+<!ELEMENT  article-id   (#PCDATA)                                    >
+<!ATTLIST  article-id
+             %article-id-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE GROUPING DATA (ARTICLE METADATA)   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE CATEGORIES MODEL                   -->
+<!--                    Complete content model for the
+                        <article-categories> element               -->
+<!ENTITY % article-categories-model
+                        "(subj-group*, series-title*, series-text*)" >
+
+
+<!--                    ARTICLE GROUPING DATA                      -->
+<!--                    Container for elements that may be used to
+                        group articles into related clusters
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=article-categories
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article-categories
+                                                                   -->
+<!ELEMENT  article-categories
+                        %article-categories-model;                   >
+<!ATTLIST  article-categories
+             %article-categories-atts;                               >
+
+
+<!--                    SUBJECT GROUP MODEL                        -->
+<!--                    Complete content model for the <subj-group>
+                        element                                    -->
+<!ENTITY % subj-group-model
+                        "((subject | compound-subject)+, subj-group*)"
+                                                                     >
+
+
+<!--                    GROUPING ARTICLES IN TITLED CATEGORIES
+                        Container element that collects multiple
+                        subjects and/or hierarchically lower subject
+                        groups.
+                        Remarks: For some journals, articles are
+                        grouped into categories, with the category
+                        indicated in the article's display.
+                        Sometimes the grouping or category refers
+                        to the type of article, such as "Essay",
+                        "Commentary", or "Article".  Sometimes the
+                        grouping refers to subject areas, such as
+                        "Physical Sciences", "Biological Sciences",
+                        or "Social Sciences".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=subj-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=subj-group
+                                                                   -->
+<!ELEMENT  subj-group   %subj-group-model;                           >
+<!ATTLIST  subj-group
+             %subj-group-atts;                                       >
+
+
+<!--                    SUBJECT ELEMENTS                           -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <subject> element                          -->
+<!ENTITY % subject-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    SUBJECT NAME                               -->
+<!--                    The name of one of the subject groups used
+                        to describe an article.  Such groups are
+                        used, typically, to provide headings for
+                        groups of articles in a printed or online
+                        generated Table of Contents.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=subject
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=subject
+                                                                   -->
+<!ELEMENT  subject      (#PCDATA %subject-elements;)*                >
+<!ATTLIST  subject
+             %subject-atts;                                          >
+
+
+<!--                    COMPOUND SUBJECT MODEL                     -->
+<!--                    Complete content model for the
+                        <compound-subject> element                 -->
+<!ENTITY % compound-subject-model
+                        "(compound-subject-part+)"                   >
+
+
+<!--                    COMPOUND SUBJECT NAME                      -->
+<!--                    Container element to hold all the parts of a
+                        multi-part subject, for example, a subject that
+                        is comprised of both a term and a code value
+                        that represents that term.
+                        Related Elements: If a subject is only a word
+                        or phrase (Neuroscience, Physical Sciences),
+                        the simple <subject> element can be used to
+                        capture this information. If a subject is
+                        logically both a term and a code
+                        (A11 Permeability) but only one of those
+                        objects needs to be captured, a <subject>
+                        element may also be used. If it is useful to
+                        record both the code and the term, they can
+                        each be captured as one
+                        <compound-subject-part>s inside a
+                        <compound-subject>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=compound-subject
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=compound-subject
+                                                                   -->
+<!ELEMENT  compound-subject
+                        %compound-subject-model;                     >
+<!ATTLIST  compound-subject
+             %compound-subject-atts;                                 >
+
+
+<!--                    COMPOUND SUBJECT PART ELEMENTS             -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <compound-subject> element                 -->
+<!ENTITY % compound-subject-part-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    COMPOUND SUBJECT PART NAME                 -->
+<!--                    The name of one of the subject groups used
+                        to describe an article, when that article is
+                        a multi-part rather than a simple subject.
+                        Such groups are used, typically, to provide
+                        headings for groups of articles in a printed
+                        or online generated Table of Contents. The
+                        @content type attribute should be used to
+                        indicate the type of part ("text", "code",
+                        "sponsor", etc.).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=compound-subject-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=compound-subject-part
+                                                                   -->
+<!ELEMENT  compound-subject-part
+                        (#PCDATA %compound-subject-part-elements;)*  >
+<!ATTLIST  compound-subject-part
+             %compound-subject-part-atts;                            >
+
+
+<!-- ============================================================= -->
+<!--                    SERIES INFORMATION                         -->
+<!-- ============================================================= -->
+
+
+<!--                    GROUPING ARTICLES IN SERIES
+                        Series (as used in the <series-title> and
+                        <series-text> elements described below) is
+                        used in two different senses. Some issues of
+                        journals are part of a series and will have
+                        series information just as they have an
+                        issue number as part of the article metadata,
+                        to describe the issue of the journal in which
+                        the article is published.  The second usage
+                        is for groupings of articles within one
+                        issue of a journal. For example, in some
+                        journals, articles are grouped into a
+                        series such as "From the Cover" and
+                        identified as part of a series.
+                        The Series Title element names the series
+                        and the Series Text element provides textual
+                        description (if any) describing the series.-->
+
+
+<!--                    SERIES TITLE ELEMENTS                      -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <series-title> element                     -->
+<!ENTITY % series-title-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES TITLE                               -->
+<!--                    Title of the journal series (bibliographic
+                        meaning) or the title of a  series of
+                        articles internal to one issue of a journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=series-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=series-title
+                                                                   -->
+<!ELEMENT  series-title (#PCDATA %series-title-elements;)*           >
+<!ATTLIST  series-title
+             %series-title-atts;                                     >
+
+
+<!--                    SERIES TEXT ELEMENTS                       -->
+<!--                    Elements that may be used, along with data
+                        characters inside the content model of the
+                        <series-text> element                      -->
+<!ENTITY % series-text-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES TEXT: HEADER TEXT to DESCRIBE       -->
+<!--                    Textual description of the series of articles
+                        that are named in a <series-title> element
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=series-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=series-text
+                                                                   -->
+<!ELEMENT  series-text  (#PCDATA %series-text-elements;)*            >
+<!ATTLIST  series-text
+             %series-text-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    TOP-LEVEL ARTICLE METADATA CONTINUED       -->
+<!-- ============================================================= -->
+
+
+<!--                    AUTHOR NOTES MODEL                         -->
+<!--                    Content model for an <author-notes> element.
+                                                                   -->
+<!ENTITY % author-notes-model
+                        "(label?, title?,
+                          (%corresp.class; | %fn-link.class; |
+                           %just-para.class;)+ )"                    >
+
+
+<!--                    AUTHOR NOTE GROUP                          -->
+<!--                    Footnotes to authors or notes about authors
+                        (and, potentially other contributors) are
+                        collected in the Author note group.
+                        References to these footnotes are made
+                        using the <xref> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=author-notes
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=author-notes
+                                                                   -->
+<!ELEMENT  author-notes %author-notes-model;                         >
+<!ATTLIST  author-notes
+             %author-notes-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                 PRODUCT REVIEW INFORMATION (PRODUCT METADATA) -->
+<!-- ============================================================= -->
+
+
+<!--                    PRODUCT ELEMENTS                           -->
+<!--                    Elements that may be used inside the
+                        <product> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % product-elements
+                        "| %article-link.class; | %break.class; |
+                         %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %phrase.class; |
+                         %price.class; | %references.class; |
+                         %simple-link.class; | %subsup.class; "      >
+
+
+<!--                    PRODUCT INFORMATION                        -->
+<!--                    Used as a wrapper for metadata for a product
+                        (such as a book, software package, hardware
+                        component, web site, etc.) that is being
+                        reviewed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=product
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=product
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=product
+                                                                   -->
+<!ELEMENT  product      (#PCDATA %product-elements;)*                >
+<!ATTLIST  product
+             %product-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    PUBLICATION HISTORY ELEMENTS               -->
+<!-- ============================================================= -->
+
+
+<!--                    HISTORY MODEL                              -->
+<!--                    The content model for the <history> element
+                                                                   -->
+<!ENTITY % history-model
+                        "(%date.class;)+"                            >
+
+
+<!--                    HISTORY:  DOCUMENT HISTORY                 -->
+<!--                    Used as a container for dates related to the
+                        processing history of the document, such as
+                        received date and accepted date.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=history
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=history
+                                                                   -->
+<!ELEMENT  history      %history-model;                              >
+<!ATTLIST  history
+             %history-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FURTHER METADATA ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    SELF-URI ELEMENTS                          -->
+<!--                    Elements to be mixed with data characters
+                        inside the <self-uri> element              -->
+<!ENTITY % self-uri-elements
+                        ""                                           >
+
+
+<!--                    URI FOR THIS SAME ARTICLE ONLINE           -->
+<!--                    Sometimes an article is available in several
+                        forms, for example there is the version that
+                        was published in print and there is the same
+                        article (possibly expanded or with different
+                        graphics) available online.
+                           The URI (such as a URL) may be used as a
+                        live link, typically naming a web site or the
+                        element content may name the URL, e.g., and
+                        use the link attributes to hold the real link:
+                           <self-uri xlink:href="...">An expanded
+                           version of this article is available
+                           online</self-uri>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=self-uri
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=self-uri
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=self-uri
+                                                                   -->
+<!ELEMENT  self-uri     (#PCDATA %self-uri-elements;)*               >
+<!ATTLIST  self-uri
+             %self-uri-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    ABSTRACTS                                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT MODEL                             -->
+<!--                    Content model for an <abstract> element    -->
+<!ENTITY % abstract-model
+                        "((%id.class;)*, %sec-opt-title-model; )"    >
+
+
+<!--                    ABSTRACT                                   -->
+<!--                    A short summation of the content of an
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=abstract
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=abstract
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=abstract
+                                                                   -->
+<!ELEMENT  abstract     %abstract-model;                             >
+<!ATTLIST  abstract
+             %abstract-atts;                                         >
+
+
+<!--                    TRANSLATED ABSTRACT MODEL                  -->
+<!--                    Content model for an <trans-abstract> element.
+                                                                   -->
+<!ENTITY % trans-abstract-model
+                        "%sec-opt-title-model;"                      >
+
+
+<!--                    TRANSLATED ABSTRACT                        -->
+<!--                    An abstract that has been translated into
+                        another language
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=trans-abstract
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=trans-abstract
+                                                                   -->
+<!ELEMENT  trans-abstract
+                        %trans-abstract-model;                       >
+<!ATTLIST  trans-abstract
+             %trans-abstract-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    KEYWORD ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    KEYWORD GROUP MODEL                        -->
+<!--                    Content model for a <kwd-group> element    -->
+<!ENTITY % kwd-group-model
+                        "(label?, title?, (%kwd.class;)+ )"          >
+
+
+<!--                    KEYWORD GROUP                              -->
+<!--                    Container element for one set of keywords
+                        <kwd>s used to describe a document.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=kwd-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=kwd-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=kwd-group
+                                                                   -->
+<!ELEMENT  kwd-group    %kwd-group-model;                            >
+<!ATTLIST  kwd-group
+             %kwd-group-atts;                                        >
+
+
+<!--ELEM   title        Defined in %common.ent;                    -->
+
+
+<!--                    KEYWORD CONTENT ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a keyword.                                 -->
+<!ENTITY % kwd-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    KEYWORD                                    -->
+<!--                    One subject term, critical expression, key
+                        phrase, abbreviation, indexing word, etc.
+                        that is associated with the whole document
+                        and can be used for identification and
+                        indexing purposes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=kwd
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=kwd
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=kwd
+                                                                   -->
+<!ELEMENT  kwd          (#PCDATA %kwd-elements;)*                    >
+<!ATTLIST  kwd
+             %kwd-atts;                                              >
+
+
+<!--                    COMPOUND KEYWORD MODEL                     -->
+<!--                    The content model of the <compound-kwd>
+                        element                                    -->
+<!ENTITY % compound-kwd-model
+                        "(compound-kwd-part+)"                       >
+
+
+<!--                    COMPOUND KEYWORD                           -->
+<!--                    Some keywords are simple, a text word or
+                        phrase; such keywords can be tagged using the
+                        <kwd> element. But other keywords are more
+                        complicated:
+                         - a code and a term
+                         - an abbreviation and its expansion
+                         - a hierarchical keyword that carries all
+                           the parts of its hierarchy (as index
+                           terms do)
+                        This element was created to handle these
+                        special cases.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=compound-kwd
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=compound-kwd
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=compound-kwd
+                                                                   -->
+<!ELEMENT  compound-kwd %compound-kwd-model;                         >
+<!ATTLIST  compound-kwd
+             %compound-kwd-atts;                                     >
+
+
+<!--                    COMPOUND KEYWORD PART ELEMENTS             -->
+<!--                    Elements to be mixed with data characters
+                        inside the <compound-kwd-part> element     -->
+<!ENTITY % compound-kwd-part-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %phrase-content.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    COMPOUND KEYWORD PART                      -->
+<!--                    This element was created to hold one
+                        component of a complex keyword, for example
+                        one for the code and one for the term.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=compound-kwd-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=compound-kwd-part
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=compound-kwd-part
+                                                                   -->
+<!ELEMENT  compound-kwd-part
+                        (#PCDATA %compound-kwd-part-elements;)*      >
+<!ATTLIST  compound-kwd-part
+             %compound-kwd-part-atts;                                >
+
+
+<!--                    NESTED KEYWORD MODEL                       -->
+<!--                    The content model of the <nested-kwd>
+                        element                                    -->
+<!ENTITY % nested-kwd-model
+                        "((%nested-kwd.class;)+, nested-kwd*)"       >
+
+
+<!--                    NESTED KEYWORD                             -->
+<!--                    Hierarchical or nested keyword, in which the
+                        levels of a taxonomy that describe the
+                        article can be described.                  -->
+<!ELEMENT  nested-kwd   %nested-kwd-model;                           >
+<!ATTLIST  nested-kwd
+            %nested-kwd-atts;                                        >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP ELEMENTS        -->
+<!--                    Content model for a <kwd-group> element    -->
+<!ENTITY % unstructured-kwd-group-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP                 -->
+<!--                    Container element for one set of keywords
+                        used to describe a document where the
+                        individual keywords are not tagged as
+                        separate <kwd>s but instead are all run
+                        together in one long text field.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=unstructured-kwd-group
+                                                                   -->
+<!ELEMENT  unstructured-kwd-group
+                        (#PCDATA %unstructured-kwd-group-elements;)* >
+<!ATTLIST  unstructured-kwd-group
+             %unstructured-kwd-group-atts;                           >
+
+
+<!-- ============================================================= -->
+<!--                    STILL FURTHER ARTICLE METADATA             -->
+<!-- ============================================================= -->
+
+
+<!--                    CORRESPONDENCE INFORMATION ELEMENTS        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the correspondence information.            -->
+<!ENTITY % corresp-elements
+                        "| %address.class; | %address-link.class;|
+                         %emphasis.class; | %label.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    CORRESPONDENCE INFORMATION                 -->
+<!--                    Optional element, used as a container for
+                        information concerning which of the authors
+                        (or other contributors) is the corresponding
+                        contributor, to whom information requests
+                        should be addressed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=corresp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=corresp
+                                                                   -->
+<!ELEMENT  corresp      (#PCDATA %corresp-elements;)*                >
+<!ATTLIST  corresp
+             %corresp-atts;                                          >
+
+
+<!--                    PUBLICATION DATE MODEL                     -->
+<!--                    The content model for the element <pub-date>
+                                                                   -->
+<!ENTITY % pub-date-model
+                        "%date-model;"                               >
+
+
+<!--                    PUBLICATION DATE                           -->
+<!--                    Date of publication or release of the
+                        material in one particular format.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=pub-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=pub-date
+                                                                   -->
+<!ELEMENT  pub-date     %pub-date-model;                             >
+<!ATTLIST  pub-date
+             %pub-date-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    CONFERENCE INFORMATION ELEMENTS            -->
+<!-- ============================================================= -->
+
+
+<!--                    CONFERENCE MODEL                           -->
+<!--                    Content model for the <conference> element -->
+<!ENTITY % conference-model
+                        "(%conference.class;)*"                      >
+
+
+<!--                    CONFERENCE INFORMATION                     -->
+<!--                    The container element for the information
+                        about a single conference and its
+                        proceedings.
+                        Design Note: Conference elements were largely
+                        based on Cross-Ref.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conference
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conference
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conference
+                                                                   -->
+<!ELEMENT  conference   %conference-model;                           >
+<!ATTLIST  conference
+             %conference-atts;                                       >
+
+
+<!--ELEM   conf-date     Defined in %common.ent;                   -->
+<!--ELEM   conf-loc      Defined in %common.ent;                   -->
+<!--ELEM   conf-name     Defined in %common.ent;                   -->
+<!--ELEM   conf-sponsor  Defined in %common.ent;                   -->
+
+
+<!--                    CONFERENCE ACRONYM ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference acronym.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an online
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-acronym-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE ACRONYM                         -->
+<!--                    The short name, popular name, or "jargon
+                        name" for a conference, for example,
+                        "Extreme" for "Extreme Markup Languages" or
+                        "SIGGRAPH" for "Special Interest Group on
+                        Computer Graphics".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-acronym
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-acronym
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-acronym
+                                                                   -->
+<!ELEMENT  conf-acronym (#PCDATA %conf-acronym-elements;)*           >
+<!ATTLIST  conf-acronym
+             %conf-acronym-atts;                                     >
+
+
+<!--                    CONFERENCE NUMBER ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference number.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-num-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE NUMBER                          -->
+<!--                    The sequential number of the conference.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-num
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-num
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-num
+                                                                   -->
+<!ELEMENT  conf-num     (#PCDATA %conf-num-elements;)*               >
+<!ATTLIST  conf-num
+             %conf-num-atts;                                         >
+
+
+<!--                    CONFERENCE THEME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference theme.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an online
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-theme-elements
+                        "%simple-text;"                              >
+
+
+<!--                    CONFERENCE THEME                           -->
+<!--                    The theme, slogan, or major subject area of
+                        the conference.  For example, the name of an
+                        annual conference may be "16th ACH Gathering"
+                        but each year has different theme topic,
+                        such as "Database Integration" or "Topic
+                        Map Subject Access".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-theme
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-theme
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-theme
+                                                                   -->
+<!ELEMENT  conf-theme   (#PCDATA %conf-theme-elements;)*             >
+<!ATTLIST  conf-theme
+             %conf-theme-atts;                                       >
+
+
+<!--                    STRING CONFERENCE NAME ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the extended text name of the conference
+                        <string-conf>
+                        Design Note: %simple-text; begins with an
+                        OR bar.                                    -->
+<!ENTITY % string-conf-elements
+                        "%simple-text;| %conference.class;"          >
+
+
+<!--                    STRING CONFERENCE NAME                     -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=string-conf
+                                                                   -->
+<!ELEMENT  string-conf  (#PCDATA %string-conf-elements;)*            >
+<!ATTLIST  string-conf
+             %string-conf-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    COUNTING INFORMATION (ARTICLE METADATA)    -->
+<!-- ============================================================= -->
+
+
+<!--                    COUNTS MODEL                               -->
+<!--                    Content model for the <counts> element.    -->
+<!ENTITY % counts-model "(count*, fig-count?, table-count?, 
+                          equation-count?, ref-count?, page-count?, 
+                          word-count?)"                              >
+
+
+<!--                    COUNTS                                     -->
+<!--                    Wrapper element to hold all metadata that
+                        "counts how many of something appear in the
+                        article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=counts
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=counts
+                                                                   -->
+<!ELEMENT  counts       %counts-model;                               >
+<!ATTLIST  counts
+             %counts-atts;                                           >
+
+
+<!--                    COUNT                                      -->
+<!--                    Generic <count> element to count anything a 
+                        publisher or archive may wish to count in a 
+                        document. The @count-type attribute will name 
+                        what is being counted (such as figures, 
+                        tables, sections, contributors, images,
+                        etc.) The @count attribute will state how 
+                        many of the objects are in the document. 
+     
+                        Although a publisher or archive could choose 
+                        to label all the counted objects in a document
+                        using this element, the specific count 
+                        elements (fig-count, equation-count,
+                        word-count, etc.) will be retained for 
+                        backwards compatibility, and may still be
+                        used.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=count
+                                                                   -->
+<!ELEMENT  count        EMPTY                                        >
+<!ATTLIST  count
+             %count-atts;                                            >
+
+
+<!--                    EQUATION COUNT                             -->
+<!--                    Number of display equations <disp-formula>
+                        that appear in the article. Inline-equations
+                        <inline-formula> are not counted. No
+                        distinction is made between numbered and
+                        unnumbered equations, both are counted.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=equation-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=equation-count
+                                                                   -->
+<!ELEMENT  equation-count
+                        EMPTY                                        >
+<!ATTLIST  equation-count
+             %equation-count-atts;                                   >
+
+
+<!--                    FIGURE COUNT                               -->
+<!--                    Number of Figures <fig> that appear in the
+                        article. Loose <graphic>s that appear
+                        outside figures are not counted.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fig-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fig-count
+                                                                   -->
+<!ELEMENT  fig-count    EMPTY                                        >
+<!ATTLIST  fig-count
+             %fig-count-atts;                                        >
+
+
+<!--                    TABLE COUNT                                -->
+<!--                    Number of tables (Table Wrapper <table-wrap>
+                        elements that appear in the article. Arrays
+                        are not counted as tables.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=table-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=table-count
+                                                                   -->
+<!ELEMENT  table-count  EMPTY                                        >
+<!ATTLIST  table-count
+             %table-count-atts;                                      >
+
+
+<!--                    REFERENCE COUNT                            -->
+<!--                    Number of reference citations (whether
+                        <mixed-citation>s, <element-citation>s, or
+                        <nlm-citation>s) that appear in the
+                        bibliographic reference list <ref-list>
+                        in the article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ref-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ref-count
+                                                                   -->
+<!ELEMENT  ref-count    EMPTY                                        >
+<!ATTLIST  ref-count
+             %ref-count-atts;                                        >
+
+
+<!--                    PAGE COUNT                                 -->
+<!--                    Number of pages in a print article, counting
+                        each page or partial page as one. Electronic
+                        articles do not have page counts.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=page-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=page-count
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=page-count
+                                                                   -->
+<!ELEMENT  page-count   EMPTY                                        >
+<!ATTLIST  page-count
+             %page-count-atts;                                       >
+
+
+<!--                    WORD COUNT                                 -->
+<!--                    Approximate number of words that appear in
+                        the textual portion of an
+                        article (not including the words in the
+                        metadata or header information)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=word-count
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=word-count
+                                                                   -->
+<!ELEMENT  word-count   EMPTY                                        >
+<!ATTLIST  word-count
+             %word-count-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    TITLE GROUP ELEMENTS (BIBLIOGRAPHIC)       -->
+<!-- ============================================================= -->
+
+
+<!--                    TITLE GROUP MODEL                          -->
+<!--                    Content model for the <title-group> element-->
+<!ENTITY % title-group-model
+                        "(article-title, subtitle*,
+                          trans-title-group*, alt-title*, fn-group?)">
+
+
+<!--                    TITLE GROUP                                -->
+<!--                    Wrapper element to hold the various article
+                        titles.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=title-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=title-group
+                                                                   -->
+<!ELEMENT  title-group  %title-group-model;                          >
+<!ATTLIST  title-group
+             %title-group-atts;                                      >
+
+
+<!--ELEM   article-title
+                        Defined in %common.ent;                    -->
+<!--ELEM   trans-title  Defined in %common.ent;                    -->
+
+
+<!--                    SUBTITLE ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <subtitle>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <subtitle>.       -->
+<!ENTITY % subtitle-elements
+                        "%title-elements;"                           >
+
+
+<!--                    ARTICLE SUBTITLE                           -->
+<!--                    Secondary title of a journal article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=subtitle
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=subtitle
+                                                                   -->
+<!ELEMENT  subtitle     (#PCDATA %subtitle-elements;)*               >
+<!ATTLIST  subtitle
+             %subtitle-atts;                                         >
+
+
+<!--                    ALTERNATE TITLE                            -->
+<!--                    A "different" version of an article title,
+                        usually created so that it can be processed
+                        in a special way, for example a short
+                        version of the title for use in a Table of
+                        Contents, an ASCII title, a right-running-
+                        head title, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=alt-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=alt-title
+                                                                   -->
+<!ELEMENT  alt-title    (#PCDATA %alt-title-elements;)*              >
+<!ATTLIST  alt-title
+             %alt-title-atts;                                        >
+
+
+<!--                    AUTHOR COMMENT MODEL                       -->
+<!--                    Content model for the <author-comment>
+                        element                                    -->
+<!ENTITY % author-comment-model
+                        "(title?, (%just-para.class;)+ )"            >
+
+
+<!--                    AUTHOR COMMENT                             -->
+<!--                    Used for extra textual material associated
+                        with a contributor such as an author or
+                        editor
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=author-comment
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=author-comment
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=author-comment
+                                                                   -->
+<!ELEMENT  author-comment
+                        %author-comment-model;                       >
+<!ATTLIST  author-comment
+             %author-comment-atts;                                   >
+
+
+<!-- ================== End Article Metadata Elements  =========== -->

--- a/publishing/1.1/JATS-backmatter1.ent
+++ b/publishing/1.1/JATS-backmatter1.ent
@@ -1,0 +1,393 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Back Matter Elements                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.1 20151215//EN"
+     Delivered as file "JATS-backmatter1.ent"                      -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names elements that are not part of the main      -->
+<!--             textual flow of a work, but are considered to be  -->
+<!--             ancillary material.                               -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base to every element, whether 
+     metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  7. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - app (through %sec-model;)
+        - app-group (through %app-group-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  2. @XML:LANG - Added @xml:lang to the following elements:
+      - app through app-atts
+      - app-group through app-group-atts
+      - fn-group through fn-group-atts
+      - glossary through glossary-atts
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    BACKMATTER ELEMENTS                        -->
+<!-- ============================================================= -->
+
+
+<!--ELEM   bio          Defined in %common.ent;                    -->
+<!--ELEM   ref-list     Defined in %references.ent;                -->
+<!--ELEM   sec          Defined in %section.ent;                   -->
+<!--ELEM   ack          Defined in %common.ent;                    -->
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    APPENDIX ATTRIBUTES                        -->
+<!--                    Attributes for the Appendix <app> element  -->
+<!ENTITY % app-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    APPENDIX GROUP ATTRIBUTES                  -->
+<!--                    Attributes for the Appendix Group <app-group>
+                        element                                    -->
+<!ENTITY % app-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FOOTNOTE GROUP ATTRIBUTES                  -->
+<!--                    Attributes for the Footnote Group <fn-group>
+                        element                                    -->
+<!ENTITY % fn-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    GLOSSARY ATTRIBUTES                        -->
+<!--                    Attributes for the Glossary <glossary>
+                        element                                    -->
+<!ENTITY % glossary-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    APPENDIX ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    APPENDIX GROUP MODEL                       -->
+<!--                    Content model for the <app-group> element  -->
+<!ENTITY % app-group-model
+                        "(label?, title?, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%para-level;)*,
+                          (%app.class; | %ref-list.class;)*)"        >
+
+
+<!--                    APPENDIX GROUP                             -->
+<!--                    A container element to hold one or more
+                        Appendices.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=app-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=app-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=app-group
+                                                                   -->
+<!ELEMENT  app-group    %app-group-model;                            >
+<!ATTLIST  app-group
+             %app-group-atts;                                        >
+
+
+<!--                    APPENDIX MODEL                             -->
+<!--                    Content model for the <app> element.       -->
+<!ENTITY % app-model    "(%sec-model;, permissions?)"                >
+
+
+<!--                    APPENDIX                                   -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=app
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=app
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=app
+                                                                   -->
+<!ELEMENT  app          %app-model;                                  >
+<!ATTLIST  app
+             %app-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    FOOTNOTE GROUPING ELEMENTS                 -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE GROUP MODEL                       -->
+<!--                    Content model for the <fn-group> element   -->
+<!ENTITY % fn-group-model
+                        "(label?, title?, (%fn-link.class;)+ )"      >
+
+
+<!--                    FOOTNOTE GROUP                             -->
+<!--                    Footnotes in a journal article may be
+                        scattered throughout the text, at the places
+                        they occur, or collected in groups at the
+                        end of structural units.  This element is a
+                        wrapper tag for such groups of footnotes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fn-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fn-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fn-group
+                                                                   -->
+<!ELEMENT  fn-group     %fn-group-model;                             >
+<!ATTLIST  fn-group
+             %fn-group-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    GLOSSARY                                   -->
+<!-- ============================================================= -->
+
+
+<!--                    GLOSSARY MODEL                             -->
+<!--                    Content model for the <glossary> element   -->
+<!ENTITY % glossary-model
+                        "(label?, title?, (%para-level;)*, glossary*)"
+                                                                     >
+
+
+<!--                    GLOSSARY ELEMENTS                          -->
+<!--                    Glossary or list of definitions.  Typically
+                        the content will be one or more <def-list>s.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=glossary
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=glossary
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=glossary
+                                                                   -->
+<!ELEMENT  glossary     %glossary-model;                             >
+<!ATTLIST  glossary
+             %glossary-atts;                                         >
+
+
+<!-- ================== End Back Matter Module =================== -->

--- a/publishing/1.1/JATS-chars1.ent
+++ b/publishing/1.1/JATS-chars1.ent
@@ -1,0 +1,525 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Custom Special Characters Module                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.1 20151215//EN"
+     Delivered as file "JATS-chars1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    XML special character entities                    -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Definitions of DTD-specific and custom         -->
+<!--                special characters (as general entities        -->
+<!--                defined as hexadecimal or decimal character    -->
+<!--                entities - Unicode numbers)                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+ 
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+ 
+  7. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+       - private-char through private-char-atts (@specific-use)
+
+  3. PEs FOR CONTENT MODELS - Added parameter entity redefinitions
+     for the model of the <private-char> element.
+
+  2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+     attribute lists of the following elements: (no attributes or
+     values were changed)
+       - glyph-ref         glyph-ref-atts
+       - glyph-data        glyph-data-atts
+       - private-char      private-char-atts
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+<!-- ============================================================= -->
+<!--                    DESIGN COMMENT                             -->
+<!-- ============================================================= -->
+<!--                    This DTD Suite has been designed with Unicode
+                        as the basic representation of all special
+                        characters. The use of combining characters
+                        is supported and encouraged as is the use
+                        of entities defined by the STIX project
+                        (http://www.ams.org/STIX/). Unicode values
+                        in planes other than Plane 0 may be freely
+                        used.
+
+                        Use of private publisher entities and Unicode
+                        Private Use Area is discouraged, but supported
+                        with the <private-char> element, for which a
+                        corresponding bitmap must be submitted.
+
+                        In cases where an entity name has been generally
+                        accepted with a corresponding Unicode number
+                        and the entity has not been added to
+                        the ISO standard entity sets, a named entity
+                        may be defined below (e.g. &euro;).
+
+                        Because of the potential for conflicts in
+                        assignments by different publishers,
+                        the JATS DTD Suite does not support assignment 
+                        of values in the Unicode Private Use Area.
+                        Publishers who have defined characters in the
+                        Private Use Area must remap those characters
+                        to existing Unicode values (using combining
+                        characters for special accented characters
+                        where appropriate), or must submit bitmaps of
+                        those characters using one of the two methods
+                        supported under the <private-char> element.
+
+                        Those custom publisher entities for which
+                        corresponding Unicode values have not been
+                        determined must be tagged with the
+                        <private-char> element. Publishers must submit
+                        bitmaps of those characters using one of the
+                        two methods supported in the <private-char>
+                        element.                                   -->
+
+<!-- ============================================================= -->
+<!--                    COMMONLY ACCEPTED ENTITIES FOR UNICODE
+                        GLYPHS                                     -->
+<!-- ============================================================= -->
+
+<!--                    For each of the following entities a name
+                        and a Unicode numerical character reference
+                        is given. Where a unique Unicode character
+                        could be determined, that character was used.
+                        For some of the symbols combining characters
+                        have been used. Do not use this space to
+                        redefine characters already found in standard
+                        ISO entity sets. Do not use this space to
+                        define any character that cannot be
+                        represented with Unicode.                  -->
+
+<!--                    LATIN SMALL LETTER G WITH CARON            -->
+<!ENTITY  gcaron        "&#x01E7;"                                   >
+
+
+<!--                    LATIN CAPITAL LETTER H WITH MACRON         -->
+<!ENTITY  Hmacr         "&#x0048;&#x0304;"                           >
+
+
+<!--                    EURO CURRENCY                              -->
+<!ENTITY  euro          "&#x20AC;"                                   >
+
+
+<!--                    FRANC CURRENCY                             -->
+<!ENTITY  franc         "&#x20A3;"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    ATTRIBUTE LISTS FOR PRIVATE CHARACTERS     -->
+<!-- ============================================================= -->
+
+
+<!--                    GLYPH DATA ATTRIBUTES                      -->
+<!--                    Attribute list for the <glyph-data>
+                        element                                    -->
+<!ENTITY % glyph-data-atts
+            "%jats-common-atts;                                       
+             fontchar   CDATA                              #IMPLIED
+             fontname   CDATA                              #IMPLIED
+             format     NMTOKEN                            #IMPLIED
+             resolution CDATA                              #IMPLIED
+             xml:space  (preserve)                 #FIXED 'preserve'
+             x-size     CDATA                              #IMPLIED
+             y-size     CDATA                              #IMPLIED" >
+
+
+<!--                    GLYPH REFERENCE ATTRIBUTES                 -->
+<!--                    Attribute list for the <glyph-ref>
+                        element                                    -->
+<!ENTITY % glyph-ref-atts
+            "%jats-common-atts;                                       
+             glyph-data IDREF                             #IMPLIED"  >
+
+
+<!--                    PRIVATE USE AREA AND CUSTOM CHARACTERS
+                        ATTRIBUTES                                 -->
+<!--                    Attribute list for the <private-char>
+                        element                                    -->
+<!ENTITY % private-char-atts
+            "%jats-common-atts;                                       
+             description
+                        CDATA                             #IMPLIED
+             name       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PRIVATE USE AREA AND CUSTOM CHARACTERS     -->
+<!-- ============================================================= -->
+<!--
+                        Special characters defined by publishers as
+                        custom entities or in the Unicode Private Use
+                        Area may not be deposited as is. If they
+                        cannot be remapped to existing Unicode values,
+                        they must be submitted as a bitmap using
+                        the <private-char> element. The most
+                        repository-friendly technique is <glyph-data>
+                        although individual bitmap files may be
+                        submitted with inline-graphic.
+
+                        We would like to thank Beacon Publishing and
+                        the APS (American Physical Society) for
+                        providing us with this technique.          -->
+
+
+<!--                    PRIVATE CHARACTER MODEL                    -->
+<!--                    The content model for the <private-char>
+                        element                                    -->
+<!ENTITY % private-char-model
+                        "((glyph-data | glyph-ref) | inline-graphic*)"
+                                                                     >
+
+
+<!--                    PRIVATE CHARACTER (CUSTOM OR UNICODE)      -->
+<!--                    A custom character entity defined by a
+                        publisher or a custom character from the
+                        Unicode private-use area for which a bitmap
+                        is submitted for the glyph.
+
+                        Since there are no completely standard/public
+                        agreements on how such characters are to be
+                        named and displayed, this technique is to be
+                        used instead of a custom general entity
+                        reference, to provide complete information
+                        on the intended character.
+                        A document should contain a <private-char>
+                        element at each location where a private
+                        character is used within the document. The
+                        corresponding image for the glyph may be
+                        given in the <glyph-data> element or as an
+                        external bitmap file referenced by an
+                        <inline-graphic> element.
+
+                        Implementation Note: <inline-graphic> should
+                        only be used outside <private-char> when the
+                        graphic is something other than a special
+                        character.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=private-char
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=private-char
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=private-char
+                                                                   -->
+<!ELEMENT  private-char %private-char-model;                         >
+<!--         description
+                        A human-readable description of the
+                        character, for example, "Arrow, normal
+                        weight, single line, two-headed, Northwest
+                        to Southeast".
+             name       Unique name for the character in all
+                        uppercase ASCII, similar to names found
+                        in Unicode standard (e.g., "NORTHWEST
+                        SOUTHEAST ARROW"                           -->
+<!ATTLIST  private-char
+             %private-char-atts;                                     >
+
+
+<!--                    GLYPH DATA FOR A PRIVATE CHARACTER         -->
+<!--                    This element is used when there is known to
+                        be no font available to render the private
+                        character. The <glyph-data> element can be
+                        used to provide information on the actual
+                        glyph that is associated with the private-use
+                        character. The element includes an inline
+                        bitmap of the glyph encoded in plain
+                        PBM (Plain Bit Map) format so that it is
+                        human-readable.
+
+                        For example:
+                        <private-char name="NORTHWEST SOUTHEAST ARROW"
+                        description="Arrow, normal weight, single
+                        line, two-headed, Northwest to Southeast">
+                        <glyph-data format="PBM" resolution="300"
+                        x-size="34" y-size="34">
+                        0000000000000000000000000000000000
+                        0111111111111100000000000000000000
+                        0111111111111100000000000000000000
+                        0111110000000000000000000000000000
+                        0111110000000000000000000000000000
+                        0111111000000000000000000000000000
+                        0110111100000000000000000000000000
+                        0110011110000000000000000000000000
+                        0110001111000000000000000000000000
+                        0110000111100000000000000000000000
+                        0110000011110000000000000000000000
+                        0110000001111000000000000000000000
+                        0110000000111100000000000000000000
+                        0110000000011110000000000000000000
+                        0110000000001111000000000000000000
+                        0110000000000111100000000000000000
+                        0110000000000011110000000000000000
+                        0000000000000001111000000000000000
+                        0000000000000000111100000000000110
+                        0000000000000000011110000000000110
+                        0000000000000000001111000000000110
+                        0000000000000000000111100000000110
+                        0000000000000000000011110000000110
+                        0000000000000000000001111000000110
+                        0000000000000000000000111100000110
+                        0000000000000000000000011110000110
+                        0000000000000000000000001111000110
+                        0000000000000000000000000111100110
+                        0000000000000000000000000011110110
+                        0000000000000000000000000001111110
+                        0000000000000000000000000001111110
+                        0000000000000000011111111111111110
+                        0000000000000000011111111111111110
+                        0000000000000000000000000000000000
+                        </glyph-data></private-char>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=glyph-data
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=glyph-data
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=glyph-data
+                                                                   -->
+<!ELEMENT  glyph-data   (#PCDATA)                                    >
+<!--         id         Identifier so that the full glyph data need
+                        not be repeated every time the character is
+                        used. The <glyph-ref> element can be used
+                        to point to this ID, to reuse a character
+                        in subsequent text.
+             fontchar   The offset of the character into a glyph
+                        table, such as a Unicode character.
+             fontname   The name of the character
+             format     Names the image format of the bitmap. Should
+                        be "PBM" if the plain bitmap is included
+                        inline.
+             resolution Resolution of the bitmap in dots per inch,
+                        expressed as a decimal integer (e.g. 72, 300)
+             xml:space  Preserve whitespace within this element.
+             x-size     Number of pixels per row in the bit-mapped
+                        glyph
+             y-size     Number of rows of the bit-mapped glyph     -->
+<!ATTLIST  glyph-data
+             %glyph-data-atts;                                       >
+
+
+<!--                    GLYPH REFERENCE FOR A PRIVATE CHARACTER    -->
+<!--                    Once a private character has been declared
+                        using a <glyph-data> element, the character
+                        can be reused by using this element to
+                        point to the full <glyph-data> element.
+                        The pointing uses the ID/IDREF mechanism,
+                        using the "glyph-data" attribute of this
+                        element to point to the "id" attribute of
+                        another <glyph-data> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=glyph-ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=glyph-ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=glyph-ref
+                                                                   -->
+<!ELEMENT  glyph-ref    EMPTY                                        >
+<!--         glyph-data An IDREF-type attribute that points to the
+                        "id" attribute of a <glyph-data> character.
+                        The idea is to use the full glyph data once,
+                        then point to an existing character instead
+                        of repeating the entire glyph data again.  -->
+<!ATTLIST  glyph-ref
+             %glyph-ref-atts;                                        >
+
+<!-- ================== End Custom XML Special Characters ======== -->

--- a/publishing/1.1/JATS-common-atts1.ent
+++ b/publishing/1.1/JATS-common-atts1.ent
@@ -1,0 +1,221 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Common Attributes (for all elements)              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.1 20151215//EN"
+     Delivered as file "JATS-common-atts1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines attributes intended to be used on ALL the -->
+<!--             elements defined in the NISO JATS, including the  -->
+<!--             elements for the XHTML-inspired and OASIS-inspired-->
+<!--             table models, excluding only <mml:math> and       -->
+<!--             <xi:include>, whose namespaces JATS does not      -->
+<!--             control.                                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  5. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  4. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  3. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  2. XML Base
+     Added the attribute @xml:base to the Global (common)
+     attributes used on all elements.
+   
+     =============================================================
+                                                                   -->
+
+
+<!-- ============================================================= -->
+<!--                    NISO JATS COMMON ATTRIBUTES                -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    BASE ATTRIBUTES                            -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+<!-- ================== End JATS Common Attributes Module ======== -->

--- a/publishing/1.1/JATS-common1.ent
+++ b/publishing/1.1/JATS-common1.ent
@@ -1,0 +1,4273 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Common (Shared) Elements Module                   -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.1 20151215//EN"
+Delivered as file "JATS-common1.ent"                               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the common parameter entities, calls the  -->
+<!--             shared modules (such as special characters and    -->
+<!--             notations) and provides declarations for elements -->
+<!--             that do not properly fit into one class, since    -->
+<!--             they can be used at more than one structural level-->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) Standard XML Special Characters Module         -->
+<!--                                       (%xmlspecchars.ent;)    -->
+<!--             2) Custom XML Special Characters (%chars.ent;)    -->
+<!--             3) Notation Declarations    (%notat.ent;)         -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 51. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 50. ALI (NISO Access and License Indicators)
+     - Added <ali:license_ref> to license-p.class, as 
+       alternatives inside <license>
+     - Use the new class: license.class to hold the new ALI
+       element <ali:free_to_read>, as an alternative to
+       <license> inside <permissions>.
+     - Created new parameter entity 'anyURI' to act as 
+       documentation concerning the content of any element whose
+       content is intended to be a URI.  
+
+ 49. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+
+ 48. VOLUME ISSUE GROUPING
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta), following all volume and issue elements,
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+
+ 47. NEW ATTRIBUTE VALUES FOR @PUB-ID-TYPE
+     Added three new values to @pub-id-types:
+      - accession
+      - arc
+      - handle
+ 
+ 46. NEW ATTRIBUTE FOR EXT-LINK
+     Added the CDATA attribute @assigning-authority to <ext-link>
+     to the authority (such as CrossRef) responsible for the
+     link
+
+ 45. NEW ATTRIBUTE FOR CONTRIB-ID
+     Added the boolean attribute @authenticated to <contrib-id> to 
+     record whether the agency that assigned the <contrib-id>
+     says the identifier is authenticated. The default value
+     is "false"
+
+ 44. MORE LINKING POSSIBILITIES
+     Added the might-link-atts to:
+      - volume-id
+      - issue-id
+     so that these potentially external identifiers can link,
+     for example to a DOI.
+
+ 43. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+ 42. NEW ADDRESS ELEMENTS
+      - Added 3 new elements: <city>, <state>, <postal-code>
+      - Therefore introduced new PEs: city-element, state-elements,
+        and postal-code-elements, all set initially to null strings.
+      - Therefore introduced new PEs: city-atts, state-atts,
+        and postal-code-atts.
+      - Added the elements (in the default classes module) to:
+          - address.class
+          - addrress-line.class
+        which adds then to: address, addr-line, aff, collab, 
+        conf-loc, corresp, publisher-loc
+
+ 41. CHANGES TO <collab>
+     Added @symbol attribute.
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 40. CHANGES TO <on-behalf-of>
+     Added <institution>, <institution-wrap>, and <xref>
+
+ 39. NEW <contrib> ATTRIBUTE
+     Added @xml:lang as requested with <institution-id>
+
+ 38. NEW <era> ELEMENT
+     Added <era> through date-parts.class to:
+      - <string-date>
+
+ 37. NEW ELEMENT <era>
+     Added to the model of <date>, optional following year,
+     through date-model.
+
+ 36. XML Base
+     Added the attribute @xml:base to the Global (common)
+     attributes used on all elements.
+
+ 35. INSTITUTION WRAP ADDED
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <copyright-holder>
+      - <on-behalf-of>
+      - <publisher-name>
+      - <std-organization>
+
+ 34. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - aff-alternatives
+      - alternatives
+      - citation-alternatives
+      - collab-alternatives
+      - custom-meta-group
+      - institution-wrap
+      - meta-name
+      - meta-value
+      - name-alternatives
+      - permissions                          
+
+ 33. INSTITUTIONAL IDENTIFIERS
+     - Added <institution-id> to hold institutional identifiers
+       whether publisher specific ("AIP") or from an established 
+       authorities ("Ringgold" and "ISNI").
+
+     - Added <institution-wrap> to hold both the name of an
+       institution <institution> and all of its institutional 
+       identifiers <institution-id>. This element will be allowed
+       everywhere institution is allowed.
+                          
+
+ 32. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - sec-meta (through %sec-meta-model;)
+
+ 31. ATTRIBUTE ALIGNMENT
+     - Added @publication-format and @content-type to <issn>
+       through %issn-atts The idea is to make the attributes
+       for <issn> and <isbn> as similar as possible.
+
+     - Added @publication-format to <isbn> through %isbn-atts 
+     
+     The idea is to make the attributes for <issn> and <isbn> as 
+     similar as possible. <issn> retains @pub-type for historical
+     reasons. <issn-l> attributes do not change.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 30. CONTRIB-GROUP AND CONTRIB MODULE SHIFT - Moved <contrib>
+     and <contrib-group> to common.ent from the module
+     articlemeta.ent, since they are now used
+     in both article metadata and journal metadata.
+
+ 29. CONTRIB ID - Added new element <contrib-id> using new PE 
+     contrib-id.class, contrib-id-atts, contrib-id-model.
+     Element holds one identifier, such as an ORCID, for a
+     person such as a contributor or principal investigator.
+
+ 28. COLLABORATION ALTERNATIVES - Added new element 
+     <collab-alternatives> using new PE %collab-alternatives-model;.
+     Element holds different versions (for example, different
+     language renderings) of a single collaboration.   
+   
+ 27. DATE ATTRIBUTES - Added date attributes
+      - to <conf-date> through %conf-date-atts
+      - to <date> through %date-atts
+      - to <string-date> through %string-date-atts
+      - to <year> through %year-atts
+      
+       a) @iso-8601-date - ISO 8601 standard date format
+          of the publication date. Format  YYYY-MM-DDThh:mm:ss 
+
+       b) @calendar - Name of the calendar used (@calendar) in
+          naming this publication date (such as "Gregorian", 
+          "Japanese" (Emperor years), or "Islamic").
+
+       c) Added @publication-format, so that both publication
+          dates and history dates can separate the for amt of the
+          publication from the version/lifecycle event. Thus
+          both an "article" and a "manuscript" might be received.
+
+ 27. PUBLICATION IDENTIFIER @pub-id-type
+      - Added "std-designation" as value in predefined  list 
+        for @pub-id-type (%pub-id-types;).
+      - Added new value "arxiv" as value in predefined  list 
+        for @pub-id-type (%pub-id-types;).
+     "pub-id-types" are used within citations for 
+     <object-id> and <pub-id>; 
+     used within the article metadata for <article-id>, 
+     <issue-id>, and <volume-id>; 
+     used within many body elements for <object-id>.
+       
+ 26. LONG DESCRIPTION - Added the might-link attributes to
+     <long-desc> because of an argument over what <long-desc>
+     should be. The semantic web folks want it to be a URI, the
+     librarians and accessibility (for pronouncing readers) want
+     to find a real description there, not a link. So JATS needs
+     to handle both.
+   
+ 25. ISSN Linking - Added new element <issn-l> with the usual
+     %issn-l-elements; and %issn-l-atts;.
+   
+ 24. MODULE MOVEMENT (from increased reference content)
+
+     a) Element <degrees> - Moved <degrees> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     b) Element <supplement> - Moved <supplement> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     c) Element <conf-sponsor> - Moved <conf-sponsor> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+     d) Element <on-behalf-of> - Moved <on-behalf-of> and its parameter
+        entities into this module from JATS-articlemeta.ent.
+   
+ 23. Element <license-p> - Added @content-type, which can hold
+     values such as "open-access", "CCC-statement",
+     "non-commercial-use".
+   
+ 22. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 21. Updated the DTD-version attribute to "0.4" 
+   
+ 18. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+ 17. MIXED CITATION ATTS PE - Was defined twice, identically,
+     deleted one of them.
+
+ 16. ACCESSIBILITY - Added @alt to <label> thru %label-atts;
+
+ 15. ALTERNATIVES ATTRIBUTES- Created a new parameter entity for
+     attributes for <alternatives>; currently null
+
+ 14. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+       - anonymous through anonymous-atts (both) NEW PE
+       - conf-acronym through conf-acronym-atts (both)
+       - conf-date through conf-date-atts (both)
+       - conf-loc through conf-loc-atts (both)
+       - conf-name through conf-name-atts (both)
+       - conf-num through conf-num-atts (both)
+       - conf-sponsor through conf-sponsor-atts (both)
+       - conf-theme through conf-theme-atts (both)
+       - day through day-atts (@specific-use)
+       - degrees through degrees-atts (both)
+       - element-citation through citation-atts (both)
+       - etal through etal-atts (both) NEW PE
+       - ext-link through ext-link-atts (@xml:lang; @specific-use
+           already)
+       - institution through institution-atts (both)
+       - issue-part through issue-part (both + content-type) NEW PE
+       - isbn through isbn-atts (both) NEW PE
+       - label through label-atts (both) NEW PE
+       - mixed-citation through citation-atts (both)
+       - name through name-atts (@xml:lang; @specific-use already)
+       - notes through notes-atts (both)
+       - prefix through prefix-atts (both)
+       - publisher-loc through publisher-loc-atts (both)
+       - publisher-name through publisher-name-atts (both)
+       - string-name through string-name-atts (both and
+            content-type and name-style) NEW PE
+       - suffix through suffix-atts (both)
+       - textual-form through textual-form-atts (both)
+       - trans-subtitle through trans-subtitle-atts
+          (@xml:lang only) NEW PE
+       - x through x-atts (both)
+
+ 13. AFFILIATION ALTERNATIVES - Created new the element
+     <aff-alternatives> to hold multiple <aff>s that are
+     representations of a single affiliation, for example, the
+     name of an institution in two languages or two scripts.
+     New PE; New attribute PE (currently null)
+
+ 12. RELATED-ARTICLE-ATTS - Removed the dependency that tied
+     %related-article-atts to journal-id-atts and added all
+     the journal-id attributes to related-article-atts explicitly.
+
+ 11. TITLE ELEMENTS - Removed the dependency which had both
+     <subtitle> and <alt-title> modeled with the same parameter
+     entity %title-elements;. Created new PEs for each element
+     but set them (as the default) to %title-elements so that no
+     customization would break. Models changed:
+       - alt-title      %alt-title-elements;
+       - subtitle       %subtitle-elements; (defined in
+                                article-meta3.ent;)
+       - trans-title    %trans-title-elements;
+       - trans-subtitle %trans-subtitle-elements;
+
+ 10. TEXTUAL FORM MODEL - Changed the textual-form-elements
+     parameter entity to begin with an OR bar, since it names
+     elements to be mixed with #PCDATA.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your %textual-form-elements parameter
+     entity. *****
+
+  9. PUBLISHER - Allowed <publisher-name> and <publisher-loc> to
+     repeat (as an unnamed-parenthetical) inside <publisher>.
+     This will allow co-publishers and publisher names and locations
+     in more than one language. Added to facilitate multiple
+     languages. Also added @specific-use and @xml:lang to
+     both publisher-name and publisher-loc.
+
+  8. ATTLIST PARAMETER ENTITIES - Changed the attribute lists
+     from using the same parameter entity (%day-atts;) to using:
+       - day    %day-atts;   (no change)
+       - month  %month-atts;
+       - season %season-atts;
+
+  7. ISBN - Added "isbn" as value in predefined list for
+     @pub-id-type (%pub-id-types;)
+
+  6. TEXTUAL FORM - Added the following attributes: (new)
+       - @specific-use
+       - @xml:lang
+
+  5. NAME ALTERNATIVES - Created a new wrapper element for more
+     than one version of a personal name, for example, the name in
+     Japanese kana characters and a transliterated form of the name
+     in Latin alphabet, or a regular name and a search version
+     that transliterates umlauts to unaccented characters.
+      - new element <name-alternatives>
+      - new PE name-alternatives-model
+      - new PE name-alternatives-atts (currently null)
+
+  4. STRING NAME - Added the following attributes: (new)
+       - @content-type
+       - @specific-use
+       - @name-style
+       - @xml:lang
+
+  3. PERSON'S NAME STYLE
+       - Added the value "given-only" to the @name-style on <name>
+
+  2. PERSON'S NAME - Allowed <given-names> as an alternative
+     to <surname, given-names?) to accommodate the Indian
+     names that are only a given name.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CONTENT MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    ANY URI SCHEMA TYPE (as documentation)     -->
+<!--                    Indicates that in an XSD or RNG Schema, this
+                        element would be typed as the simple type
+                        'anyURI". This has no enforcement power in a 
+                        DTD, it is intended for human guidance.
+                        but is only for human guidance in a DTD   -->
+<!ENTITY % anyURI       "(#PCDATA)"                                 >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE VALUES    -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE/PUBLICATION IDENTIFIER TYPES       -->
+<!--                    Values for the @pub-id attribute. Used:
+                        1) Within citations with the <pub-id> and 
+                        <object-id> elements to name the type of
+                        identifier (such as DOI) or the organization 
+                        or system that defined the identifier for the 
+                        identifier of the journal article or a cited 
+                        publication, such as a book or standard.
+                        2) Within article metadata with the
+                        <article-id>, <issue-id>, and <volume-id>
+                        elements to name the type of identifier or 
+                        identifying agency.
+                        4) Within many body elements to perform a 
+                        similar function for the <object-id> element.
+                                                                   -->
+<!ENTITY % pub-id-types  "accession | ark | art-access-id | arxiv | 
+                          coden | doaj | doi | handle | isbn | 
+                          manuscript | medline | other | 
+                          pii | pmcid |  pmid | publisher-id | sici |
+                          std-designation"                           >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR FULL CONTENT MODELS -->
+<!-- ============================================================= -->
+
+
+<!--                    DATE ELEMENTS MODEL                        -->
+<!--                    The content models for elements that describe
+                        dates, such as Publication Date <pub-date>
+                        and History Dates <date>.                  -->
+<!ENTITY % date-model   "( ( (day?, month?) | season)?,
+                          year?, era?, string-date?)"                >
+
+
+<!--                    CONTENT MODEL FOR A STRUCTURAL SECTION     -->
+<!--                    The model for a section that requires that a
+                        section title be present, used for elements
+                        such as Section and Appendix.              -->
+<!ENTITY % sec-model    "(sec-meta?, label?, title, (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!--                    CONTENT MODEL FOR A SECTION METADATA       -->
+<!--                    In some works, each section has a different
+                        author or some sections are authored by
+                        different contributors from the enclosing
+                        article. This wrapper element for
+                        section-level metadata is used to capture
+                        information such as those contributors.
+                                                                   -->
+<!ENTITY % sec-meta-model
+                        "((%contrib-group.class;)*, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          permissions?)"       >
+
+
+<!--                    CONTENT MODEL FOR AN UNTITLED SECTION      -->
+<!--                    The model for a section-like structure that
+                        may or may not have an initial title       -->
+<!ENTITY % sec-opt-title-model
+                        "(sec-meta?, label?, title?, (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR MIXED CONTENT       -->
+<!-- ============================================================= -->
+
+
+<!--                    LINK ELEMENTS                              -->
+<!--                    Elements for use in the linking elements
+                        such as <xref>, <target>, and <ext-link>   -->
+<!ENTITY % link-elements
+                        "| %emphasis.class; | %phrase-content.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    PARAGRAPH ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <p>.
+                        Design Note: There is a major overlap between
+                        this parameter entity and the mix for elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph, some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % p-elements   "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class; |
+                         %citation.class; |  %emphasis.class; |
+                         %funding.class; |  %inline-math.class; |
+                         %inline-display-noalt.class; |
+                         %list.class; | %math.class; |
+                         %phrase.class; | %rest-of-para.class; |
+                         %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR TITLES              -->
+<!-- ============================================================= -->
+
+
+<!--                    TITLE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <title>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % title-elements
+                        "%simple-phrase; | %break.class;"            >
+
+
+<!--                    ALTERNATE TITLE ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <alt-title>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <alt-title>.      -->
+<!ENTITY % alt-title-elements
+                        "%title-elements;"                           >
+
+
+<!--                    TRANSLATED TITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <trans-title>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <trans-title>.    -->
+<!ENTITY % trans-title-elements
+                        "%title-elements;"                           >
+
+
+<!--                    TRANSLATED SUBTITLE ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a paragraph <subtitle>.
+                        An earlier version of this tag set used the
+                        parameter entity %title-elements; for many
+                        title elements including <trans-subtitle>. -->
+<!ENTITY % trans-subtitle-elements
+                        "%title-elements;"                           >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR LINKING ATTRIBUTES  -->
+<!--                    THE FOLLOWING FEW ARE SHARED ATTRIBUTES    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    BASE ATTRIBUTES                            -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+
+<!--                    XLINK LINK ATTRIBUTES                      -->
+<!--                    Used for elements that are a link by
+                        definition, such as the <xref> element.    -->
+<!ENTITY % link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #REQUIRED 
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!--                    MIGHT LINK XLINK ATTRIBUTES                -->
+<!--                    Used for elements which may need to link to
+                        external sources or other objects within
+                        the document, but may not necessarily act
+                        as a link at all.  The attribute
+                        "xlink:href" identifies the object to which
+                        the link points.                           -->
+<!ENTITY % might-link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #IMPLIED
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!--                    CITATION ATTRIBUTES                        -->
+<!--                    Attributes for all two kinds of citations:
+                        <element-citation> and <mixed-citation>    -->
+<!ENTITY % citation-atts
+            "%jats-common-atts;                                        
+             publication-type
+                        CDATA                             #IMPLIED
+             publisher-type
+                        CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTES LISTS    -->
+<!--                    (ALPHABETICAL ORDER)                       -->
+<!-- ============================================================= -->
+
+
+<!--                    AFFILIATION ATTRIBUTES                     -->
+<!--                    Attributes for the <ack> element           -->
+<!ENTITY % ack-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ADDRESS ATTRIBUTES                         -->
+<!--                    Attributes for the <address> element       -->
+<!ENTITY % address-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ADDRESS LINE ATTRIBUTES                    -->
+<!--                    Attributes for the <addr-line> element     -->
+<!ENTITY % addr-line-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AFFILIATION ATTRIBUTES                     -->
+<!--                    Attributes for the Affiliation <aff>
+                        element                                    -->
+<!ENTITY % aff-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    AFFILIATION ALTERNATIVES ATTRIBUTES        -->
+<!--                    Attributes for the <aff-alternatives>
+                        element                                    -->
+<!ENTITY % aff-alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    ALTERNATE TEXT ATTRIBUTES                  -->
+<!--                    Attributes for the <alt-text> element      -->
+<!ENTITY % alt-text-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ANONYMOUS ATTRIBUTES                       -->
+<!--                    Attributes for the <anonymous> element     -->
+<!ENTITY % anonymous-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ALTERNATIVES ATTRIBUTES                    -->
+<!--                    Attributes for the <alternatives> element  -->
+<!ENTITY % alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    ARTICLE TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <article-title> element -->
+<!ENTITY % article-title-atts
+            "%jats-common-atts;                                        
+             xml:lang   NMTOKEN                            #IMPLIED" >
+
+
+<!--                    ATTRIBUTION ATTRIBUTES                     -->
+<!--                    Attributes for the <attrib> element        -->
+<!ENTITY % attrib-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    BIOGRAPHY ATTRIBUTES                       -->
+<!--                    Attributes for <bio> element               -->
+<!ENTITY % bio-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CITATION ALTERNATIVES ATTRIBUTES           -->
+<!--                    Attributes for the <citation-alternatives>
+                        element                                    -->
+<!ENTITY % citation-alternatives-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    CITY ATTRIBUTES                            -->
+<!--                    Attributes for the <city> element          -->
+<!ENTITY % city-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COLLABORATION ATTRIBUTES                   -->
+<!--                    Attributes for <collab>                    -->
+<!ENTITY % collab-atts
+            "%jats-common-atts;                                        
+             collab-type
+                        CDATA                             #IMPLIED
+             symbol     CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    COLLABORATION ALTERNATIVES ATTRIBUTES      -->
+<!--                    Attributes for the <collab-alternatives>
+                        element                                    -->
+<!ENTITY % collab-alternatives-atts
+            "%jats-common-atts;"                                      >                                        
+
+
+<!--                    CONFERENCE DATE ATTRIBUTES                 -->
+<!--                    Attributes for the <conf-date> element     -->
+<!ENTITY % conf-date-atts
+            "%jats-common-atts;                                        
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE LOCATION ATTRIBUTES             -->
+<!--                    Attributes for the <conf-loc> element      -->
+<!ENTITY % conf-loc-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE NAME ATTRIBUTES                 -->
+<!--                    Attributes for the <conf-name> element.    -->
+<!ENTITY % conf-name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONFERENCE SPONSOR ATTRIBUTES              -->
+<!--                    Attributes for the <conf-sponsor> element. -->
+<!ENTITY % conf-sponsor-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CONTRIBUTOR ATTRIBUTES                     -->
+<!--                    Attributes for the <contrib> element       -->
+<!ENTITY % contrib-atts
+            "%jats-common-atts;                                        
+             contrib-type
+                        CDATA                             #IMPLIED
+             corresp    (no | yes)                        #IMPLIED
+             equal-contrib
+                        (no | yes)                        #IMPLIED
+             deceased   (no | yes)                        #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CONTRIBUTOR GROUP ATTRIBUTES               -->
+<!--                    Attributes for the <contrib-group> element -->
+<!ENTITY % contrib-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER ATTRIBUTES          -->
+<!--                    Attributes for the <contrib-id> 
+                        element.                                   -->
+<!ENTITY % contrib-id-atts
+            "%jats-common-atts;                                        
+             contrib-id-type
+                        CDATA                             #IMPLIED
+             authenticated
+                        (true | false)                    'false'
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT HOLDER ATTRIBUTES                -->
+<!--                    Attributes for the <copyright-holder>
+                        element.                                   -->
+<!ENTITY % copyright-holder-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT STATEMENT ATTRIBUTES             -->
+<!--                    Attributes for the <copyright-statement>
+                        element.                                   -->
+<!ENTITY % copyright-statement-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COPYRIGHT YEAR ATTRIBUTES                  -->
+<!--                    Attributes for the <copyright-year>
+                        element                                    -->
+<!ENTITY % copyright-year-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    COUNTRY ATTRIBUTES                         -->
+<!--                    Attributes for the <country> element       -->
+<!ENTITY % country-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CUSTOM METADATA ATTRIBUTES                 -->
+<!--                    Attributes for the <custom-meta> element   -->
+<!ENTITY % custom-meta-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CUSTOM METADATA GROUP ATTRIBUTES           -->
+<!--                    Attributes for the <custom-meta-group>
+                        element                                    -->
+<!ENTITY % custom-meta-group-atts
+            "%jats-common-atts;"                                      >                                        
+
+
+<!--                    DATE (HISTORICAL) ATTRIBUTES               -->
+<!--                    Attributes for the <date> element          -->
+<!ENTITY % date-atts
+            "%jats-common-atts;                                        
+             date-type  CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    DAY ATTRIBUTES                             -->
+<!--                    Attributes for the <day> element           -->
+<!ENTITY % day-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: DEFINITION ATTRIBUTES     -->
+<!--                    Attribute list for the <def> element       -->
+<!ENTITY % def-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEGREES ATTRIBUTES                         -->
+<!--                    Attributes for the <degrees> element       -->
+<!ENTITY % degrees-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ELEMENT CITATION ATTRIBUTES                -->
+<!--                    Attributes for <element-citation>          -->
+<!ENTITY % element-citation-atts
+            "%citation-atts;"                                        >
+
+
+<!--                    ELECTRONIC LOCATION IDENTIFIER ATTRIBUTES
+                        Attribute list for the <elocation-id>
+                        element                                    -->
+<!ENTITY % elocation-id-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    EMAIL ATTRIBUTES                           -->
+<!--                    Attribute list for the <email> element     -->
+<!ENTITY % email-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ERA ATTRIBUTES                             -->
+<!--                    Attributes for the <era> element           -->
+<!ENTITY % era-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ET AL. ATTRIBUTES                          -->
+<!--                    Attribute list for the <etal> element      -->
+<!ENTITY % etal-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    EXTERNAL LINK ATTRIBUTES                   -->
+<!--                    Attribute list for external links, such as
+                        <ext-link>                                 -->
+<!ENTITY % ext-link-atts
+            "%jats-common-atts;                                        
+             ext-link-type
+                        CDATA                             #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    FAX ATTRIBUTES                             -->
+<!--                    Attribute list for the <fax> element       -->
+<!ENTITY % fax-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FIRST PAGE ATTRIBUTES                      -->
+<!--                    Attribute list for the <fpage> element     -->
+<!ENTITY % fpage-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FREE TO READ ATTRIBUTES                    -->
+<!--                    Attributes for the ALI namespaced
+                        <ali:free_to_read> element                 -->
+<!ENTITY % free-to-read-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             end_date   CDATA                             #IMPLIED
+             start_date CDATA                             #IMPLIED
+             %ali.xmlns.attrib;"                                     >
+
+
+<!--                    GIVEN NAMES ATTRIBUTES                     -->
+<!--                    Attribute list for the <given-names> element
+                                                                   -->
+<!ENTITY % given-names-atts
+            "%jats-common-atts;                                        
+             initials  CDATA                             #IMPLIED"  >
+
+
+<!--                    INSTITUTION ATTRIBUTES                     -->
+<!--                    Attribute list for <institution>           -->
+<!ENTITY % institution-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    INSTITUTION IDENTIFIER ATTRIBUTES          -->
+<!--                    Attribute list for <institution-id>        -->
+<!ENTITY % institution-id-atts
+            "%jats-common-atts;                                        
+             institution-id-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INSTITUTION WRAPPER ATTRIBUTES             -->
+<!--                    Attributes for the <institution-wrap>
+                        element                                    -->
+<!ENTITY % institution-wrap-atts
+            "%jats-common-atts;"                                          >                                        
+
+
+<!--                    ISBN ATTRIBUTES                            -->
+<!--                    Attributes for the <isbn> element          -->
+<!ENTITY % isbn-atts
+            "%jats-common-atts;                                        
+             publication-format
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSN ATTRIBUTES                            -->
+<!--                    Attribute list for the <issn> element      -->
+<!ENTITY % issn-atts
+            "%jats-common-atts;                                        
+             pub-type   CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSN-L (INKING ISSN) ATTRIBUTES            -->
+<!--                    Attribute list for the <issn-l> element    -->
+<!ENTITY % issn-l-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ISSUE ATTRIBUTES                           -->
+<!--                    Attribute list for the <issue> element     -->
+<!ENTITY % issue-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             seq        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE IDENTIFIER ATTRIBUTES                -->
+<!--                    Attributes for the <issue-id> element      -->
+<!ENTITY % issue-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ISSUE PART ATTRIBUTES                      -->
+<!--                    Attribute list for <issue-part> element    -->
+<!ENTITY % issue-part-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE SPONSOR ATTRIBUTES                   -->
+<!--                    Attribute list for <issue-sponsor> element -->
+<!ENTITY % issue-sponsor-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    ISSUE TITLE ATTRIBUTES                     -->
+<!--                    Attribute list for <issue-title> element   -->
+<!ENTITY % issue-title-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL IDENTIFIER ATTRIBUTES              -->
+<!--                    Attribute list for journal identifier
+                        <journal-id> element                       -->
+<!ENTITY % journal-id-atts
+            "%jats-common-atts;                                        
+             journal-id-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    LABEL ATTRIBUTES                           -->
+<!--                    Attributes for the <label> element         -->
+<!ENTITY % label-atts
+            "%jats-common-atts;                                        
+             alt        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    LICENSE ATTRIBUTES                         -->
+<!--                    Attributes for the <license> element       -->
+<!ENTITY % license-atts
+            "%jats-common-atts;                                        
+             license-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    LICENSE PARAGRAPH ATTRIBUTES               -->
+<!--                    Attributes for the <license> element       -->
+<!ENTITY % license-p-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    LICENSE REFERENCE ATTRIBUTES               -->
+<!--                    Attributes for the ALI namespaced
+                        <ali:license_ref> element                  -->
+<!ENTITY % license-ref-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             start_date CDATA                             #IMPLIED
+             %ali.xmlns.attrib;"                                     >
+
+
+<!--                    LONG DESCRIPTION ATTRIBUTES                -->
+<!--                    Attributes for the <long-desc> element     -->
+<!ENTITY % long-desc-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    LPAGE ATTRIBUTES                           -->
+<!--                    Attributes for the <lpage> element         -->
+<!ENTITY % lpage-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    METADATA NAME (CUSTOM) ATTRIBUTES          -->
+<!--                    Attributes for <meta-name> element         -->
+<!ENTITY % meta-name-atts
+            "%jats-common-atts;"                                     >                                       
+
+
+<!--                    METADATA VALUE (CUSTOM) ATTRIBUTES          -->
+<!--                    Attributes for <meta-value> element         -->
+<!ENTITY % meta-value-atts
+            "%jats-common-atts;"                                       >                                       
+
+
+<!--                    MIXED CITATION ATTRIBUTES                  -->
+<!--                    Attributes for <mixed-citation> element    -->
+<!ENTITY % mixed-citation-atts
+            "%citation-atts;"                                        >
+
+
+<!--                    MONTH ATTRIBUTES                           -->
+<!--                    Attributes for the <month> element         -->
+<!ENTITY % month-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NAME ATTRIBUTES                            -->
+<!--                    Attribute list for the <name> element      -->
+<!ENTITY % name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             name-style (western | eastern | islensk |
+                         given-only)                      'western'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    NAME ALTERNATIVES ATTRIBUTES               -->
+<!--                    Attributes for the <name-alternatives>
+                        element                                    -->
+<!ENTITY % name-alternatives-atts
+            "%jats-common-atts;"                                      >                                       
+
+
+<!--                    NOTES ATTRIBUTES                           -->
+<!--                    Attribute list for the <note> element      -->
+<!ENTITY % notes-atts
+            "%jats-common-atts;                                        
+             notes-type CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    OBJECT IDENTIFIER ATTRIBUTES               -->
+<!--                    Attributes for the <object-id> element     -->
+<!ENTITY % object-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ON BEHALF OF ATTRIBUTES                    -->
+<!--                    Attributes for the <on-behalf-of> element  -->
+<!ENTITY % on-behalf-of-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PAGE RANGE ATTRIBUTES                      -->
+<!--                    Attributes for the <page-range> element    -->
+<!ENTITY % page-range-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PERMISSIONS ATTRIBUTES                     -->
+<!--                    Attributes for the <permission> element    -->
+<!ENTITY % permissions-atts
+            "%jats-common-atts;"                                     >                                        
+
+
+<!--                    PHONE ATTRIBUTES                           -->
+<!--                    Attributes for the <phone> element         -->
+<!ENTITY % phone-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    POSTAL CODE ATTRIBUTES                     -->
+<!--                    Attributes for the <postal-code> element   -->
+<!ENTITY % postal-code-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PREFIX ATTRIBUTES                          -->
+<!--                    Attributes for the <prefix> element        -->
+<!ENTITY % prefix-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRICE ATTRIBUTES                           -->
+<!--                    Attributes for the <price> element         -->
+<!ENTITY % price-atts
+            "%jats-common-atts;                                        
+             currency   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PUBLISHER ATTRIBUTES                       -->
+<!--                    Attributes for the <publisher> element     -->
+<!ENTITY % publisher-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    PUBLISHER LOCATION ATTRIBUTES              -->
+<!--                    Attributes for the <publisher-loc> element -->
+<!ENTITY % publisher-loc-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    PUBLISHER NAME ATTRIBUTES                  -->
+<!--                    Attributes for the <publisher-name> element-->
+<!ENTITY % publisher-name-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    RELATED ARTICLE ATTRIBUTES                 -->
+<!--                    Attributes for <related-article>           -->
+<!ENTITY % related-article-atts
+            "%jats-common-atts;                                        
+             related-article-type
+                        CDATA                             #REQUIRED
+             ext-link-type
+                       CDATA                              #IMPLIED
+             vol       CDATA                              #IMPLIED
+             page      CDATA                              #IMPLIED
+             issue     CDATA                              #IMPLIED
+             elocation-id
+                       CDATA                              #IMPLIED
+             journal-id
+                       CDATA                              #IMPLIED
+             journal-id-type
+                        CDATA                             #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    ROLE ATTRIBUTES                            -->
+<!--                    Attributes for the <role> element          -->
+<!ENTITY % role-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SEASON ATTRIBUTES                          -->
+<!--                    Attributes for the <season> element        -->
+<!ENTITY % season-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SIGNATURE ATTRIBUTES                       -->
+<!--                    Attributes for the <sig> element           -->
+<!ENTITY % sig-atts
+            "%jats-common-atts;                                        
+             rid        IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SIGNATURE BLOCK ATTRIBUTES                 -->
+<!--                    Attributes for the <sig-block> element     -->
+<!ENTITY % sig-block-atts
+            "%jats-common-atts;                                        
+             rid       IDREFS                            #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SIZE ATTRIBUTES                            -->
+<!--                    Attribute list for the <size> element      -->
+<!ENTITY % size-atts
+            "%jats-common-atts;                                        
+             units      CDATA                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STATE ATTRIBUTES                           -->
+<!--                    Attributes for the <state> element         -->
+<!ENTITY % state-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING DATE ATTRIBUTES                     -->
+<!--                    Attributes for the <string-date> element   -->
+<!ENTITY % string-date-atts
+            "%jats-common-atts;                                        
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STRING NAME ATTRIBUTES                     -->
+<!--                    Attribute list for the <string-name> element
+                                                                   -->
+<!ENTITY % string-name-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             name-style
+                        (western | eastern | islensk | given-only)
+                                                          'western'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUFFIX ATTRIBUTES                          -->
+<!--                    Attributes for the <suffix> element        -->
+<!ENTITY % suffix-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SUPPLEMENT ATTRIBUTES                      -->
+<!--                    Attributes for the <supplement> element    -->
+<!ENTITY % supplement-atts
+            "%jats-common-atts;                                        
+             supplement-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SURNAME ATTRIBUTES                         -->
+<!--                    Attribute list for the <surname> element   -->
+<!ENTITY % surname-atts
+            "%jats-common-atts;                                        
+             initials  CDATA                              #IMPLIED"  >
+
+
+<!--                    TEXTUAL FORM ATTRIBUTES                    -->
+<!--                    Attributes for the <textual-form> element  -->
+<!ENTITY % textual-form-atts
+            "%jats-common-atts;                                        
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    TITLE ATTRIBUTES                           -->
+<!--                    Attributes for the <title> element         -->
+<!ENTITY % title-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED"  >
+
+
+<!--                    TRANSLATED SUBTITLE ATTRIBUTES             -->
+<!--                    Attributes for the <trans-subtitle>
+                        element                                    -->
+<!ENTITY % trans-subtitle-atts
+            "%jats-common-atts;                                        
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TRANSLATED TITLE ATTRIBUTES                -->
+<!--                    Attribute list for the <trans-title>       -->
+<!ENTITY % trans-title-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TRANSLATED TITLE GROUP ATTRIBUTES          -->
+<!--                    Attribute list for the <trans-title-group> -->
+<!ENTITY % trans-title-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                       CDATA                              #IMPLIED
+             specific-use
+                       CDATA                              #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!--                    URI ATTRIBUTES                             -->
+<!--                    Attributes for the <uri> element           -->
+<!ENTITY % uri-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    VOLUME NUMBER ATTRIBUTES                   -->
+<!--                    Attribute list for the <volume> element    -->
+<!ENTITY % volume-atts
+            "%jats-common-atts;                                        
+             seq        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VOLUME IDENTIFIER ATTRIBUTES               -->
+<!--                    Attributes for the <volume-id> element     -->
+<!ENTITY % volume-id-atts
+            "%jats-common-atts;                                        
+             pub-id-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    VOLUME ISSUE GROUPING ATTRIBUTES           -->
+<!--                    Attribute list for the <volume-issue-group>
+                        element                                    -->
+<!ENTITY % volume-issue-group-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VOLUME SERIES ATTRIBUTES                   -->
+<!--                    Attribute list for the <volume-series>
+                        element                                    -->
+<!ENTITY % volume-series-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    YEAR ATTRIBUTES                            -->
+<!--                    Attributes for the <year> element          -->
+<!ENTITY % year-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    METADATA USED BY MORE THAN ONE CLASS       -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    NISO ACCESS AND INDICATOR ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    FREE TO READ (NISO ALI) MODEL              -->
+<!--                    Content model for the ALI namespaced  
+                        <ali:free_to_read> element.                -->
+<!ENTITY % free-to-read-model
+                        "EMPTY"                                      >
+
+
+<!--                    FREE TO READ (NISO ALI)                    -->
+<!--                    An EMPTY element whose presence indicates 
+                        that a document or portion of a document 
+                        is free to be read. 
+                        Remarks: Defined in "NISO Access License and 
+                        Indicators (ALI) NISO RP-22-2015".    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ali:free_to_read
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ali:free_to_read
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ali:free_to_read
+                                                                   -->
+<!ELEMENT  ali:free_to_read 
+                        %free-to-read-model;                         >
+<!ATTLIST  ali:free_to_read
+             %free-to-read-atts;                                     >
+
+
+<!--                    LICENSE REFERENCE (NISO ALI) MODEL         -->
+<!--                    Content model for the ALI namespaced  
+                        <ali:license_ref> element.                 -->
+<!ENTITY % license-ref-model
+                        "%anyURI;"                                   >
+
+
+<!--                    LICENSE REFERENCE (NISO ALI)               -->
+<!--                    A URI that is a pointer to a public license
+                        or waiver. If the element has content, it 
+                        must be a URI.
+                        Remarks: Defined in "NISO Access License and 
+                        Indicators (ALI) NISO RP-22-2015".    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ali:license_ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ali:license_ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ali:license_ref
+                                                                   -->
+<!ELEMENT  ali:license_ref  
+                        %license-ref-model;                          >
+<!ATTLIST  ali:license_ref
+             %license-ref-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    CONTRIBUTOR GROUP (AUTHOR/EDITOR) ELEMENTS -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR GROUP MODEL                    -->
+<!--                    Content model for the <contrib-group>
+                        element                                    -->
+<!ENTITY % contrib-group-model
+                        "((%contrib.class;)+, 
+                          (%contrib-info.class;)* )"                 >
+
+
+<!--                    CONTRIBUTOR GROUP                          -->
+<!--                    Wrapper element for information concerning
+                        a grouping of contributors, such as the
+                        primary authors
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=contrib-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=contrib-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=contrib-group
+                                                                   -->
+<!ELEMENT  contrib-group
+                        %contrib-group-model;                        >
+<!ATTLIST  contrib-group
+             %contrib-group-atts;                                    >
+
+
+<!--                    CONTRIBUTOR MODEL                          -->
+<!--                    Content model for the <contrib> element    -->
+<!ENTITY % contrib-model
+                        "((%contrib-id.class;)*, (%name.class;)*,
+                          (%degree.class; | %contrib-info.class;)* )">
+
+
+<!--                    CONTRIBUTOR                                -->
+<!--                    Wrapper element to contain the information
+                        about a single contributor, for example an
+                        author or editor.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=contrib
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=contrib
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=contrib
+                                                                   -->
+<!ELEMENT  contrib      %contrib-model;                              >
+<!ATTLIST  contrib
+             %contrib-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON COPYRIGHT/PERMISSION ELEMENTS       -->
+<!-- ============================================================= -->
+
+
+<!--                    COPYRIGHT HOLDER ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <copyright-holder> element.                -->
+<!ENTITY % copyright-holder-elements
+                        "| %institution-wrap.class; | %subsup.class;">
+
+
+<!--                    COPYRIGHT HOLDER                           -->
+<!--                    Name of the organizational or personal
+                        entity that holds the copyright.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=copyright-holder
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=copyright-holder
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=copyright-holder
+                                                                   -->
+<!ELEMENT  copyright-holder
+                        (#PCDATA %copyright-holder-elements;)*       >
+<!ATTLIST  copyright-holder
+             %copyright-holder-atts;                                 >
+
+
+<!--                    COPYRIGHT STATEMENT ELEMENTS               -->
+<!--                    Content model for <copyright-statement>    -->
+<!ENTITY % copyright-statement-elements
+                        "| %address-link.class; | %emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    COPYRIGHT STATEMENT                        -->
+<!--                    Copyright notice or statement, suitable for
+                        printing or display. Within the statement the
+                        copyright year should be identified, if
+                        expected to be displayed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=copyright-statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=copyright-statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=copyright-statement
+                                                                   -->
+<!ELEMENT  copyright-statement
+                        (#PCDATA %copyright-statement-elements;)*    >
+<!ATTLIST  copyright-statement
+             %copyright-statement-atts;                              >
+
+
+<!--                    COPYRIGHT YEAR                             -->
+<!--                    Year of the copyright. Need not be used, if,
+                        for example, having the year as part of the
+                        copyright statement is sufficient.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=copyright-year
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=copyright-year
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=copyright-year
+                                                                   -->
+<!ELEMENT  copyright-year
+                        (#PCDATA)                                    >
+<!ATTLIST  copyright-year
+             %copyright-year-atts;                                   >
+
+
+<!--                    LICENSE MODEL                              -->
+<!--                    Content model for an <license> element     -->
+<!ENTITY % license-model
+                        "((%license-p.class;)+)"                     >
+
+
+<!--                    LICENSE INFORMATION                        -->
+<!--                    The set of conditions under which people are
+                        allowed to use this article or other
+                        license-related information or restrictions.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=license
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=license
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=license
+                                                                   -->
+<!ELEMENT  license      %license-model;                              >
+<!ATTLIST  license
+             %license-atts;                                          >
+
+
+<!--                    LICENSE PARAGRAPH ELEMENTS                 -->
+<!--                    Elements that can be included with the text
+                        inside a <license-p> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %p-elements; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % license-p-elements
+                        "%p-elements; | %price.class;"               >
+
+
+<!--                    LICENSE PARAGRAPH                          -->
+<!--                    Paragraphs of text within the description of
+                        a <license>. Not defined as an ordinary
+                        paragraph, so that it can have special
+                        content.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=license-p
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=license-p
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=license-p
+                                                                   -->
+<!ELEMENT  license-p    (#PCDATA %license-p-elements;)*              >
+<!ATTLIST  license-p
+             %license-p-atts;                                        >
+
+
+<!--                    PERMISSIONS MODEL                          -->
+<!--                    Model for <permissions> wrapper element    -->
+<!ENTITY % permissions-model
+                        "(copyright-statement*, copyright-year*,
+                          copyright-holder*, (%license.class;)*)"    >
+
+
+<!--                    PERMISSIONS                                -->
+<!--                    Wrapper element to hold the copyright
+                        information, license material, and any
+                        future similar metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=permissions
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=permissions
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=permissions
+                                                                   -->
+<!ELEMENT  permissions  %permissions-model;                          >
+<!ATTLIST  permissions
+             %permissions-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON METADATA/BIBLIOGRAPHIC ELEMENTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE TITLE ELEMENTS                     -->
+<!--                    Elements that can be included with the text
+                        inside an <article-title> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % article-title-elements
+                        "%simple-phrase; | %break.class;"            >
+
+
+<!--                    ARTICLE TITLE                              -->
+<!--                    The title of the article in the language
+                        in which the article was originally
+                        published
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=article-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=article-title
+                                                                   -->
+<!ELEMENT  article-title
+                        (#PCDATA %article-title-elements;)*          >
+<!ATTLIST  article-title
+             %article-title-atts;                                    >
+
+
+<!--                    AFFILIATION ELEMENTS                       -->
+<!--                    Elements for use in the <aff> element      -->
+<!ENTITY % aff-elements "| %address.class; | %address-link.class; |
+                         %article-link.class; | %break.class; |
+                         %emphasis.class; | %label.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    AFFILIATION                                -->
+<!--                    Name of a institution or organization such as
+                        a university or corporation.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=aff
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=aff
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=aff
+                                                                   -->
+<!ELEMENT  aff          (#PCDATA %aff-elements;)*                    >
+<!ATTLIST  aff
+             %aff-atts;                                              >
+
+
+<!--                    AFFILIATION ALTERNATIVES MODEL             -->
+<!--                    Content model for the element
+                        <aff-alternatives>                         -->
+<!ENTITY % aff-alternatives-model
+                        "(aff+)"                                     >
+
+
+<!--                    AFFILIATION ALTERNATIVES                   -->
+<!--                    Container element to hold one or more
+                        representations of a single affiliation, for
+                        example the name of an institution in two
+                        languages or two scripts.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=aff-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=aff-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=aff-alternatives
+                                                                   -->
+<!ELEMENT  aff-alternatives
+                        %aff-alternatives-model;                     >
+<!ATTLIST  aff-alternatives
+             %aff-alternatives-atts;                                 >
+
+
+<!--                    CONFERENCE DATE ELEMENTS                   -->
+<!--                    Elements for use in the <conf-date> element-->
+<!ENTITY % conf-date-elements
+                        ""                                           >
+
+
+<!--                    CONFERENCE DATE                            -->
+<!--                    The date(s) on which the conference was held.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-date
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-date
+                                                                   -->
+<!ELEMENT  conf-date    (#PCDATA %conf-date-elements;)*              >
+<!ATTLIST  conf-date
+             %conf-date-atts;                                        >
+
+
+<!--                    CONFERENCE LOCATION ELEMENTS               -->
+<!--                    Elements for use in the <conf-loc> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-loc-elements
+                        "%simple-text; | %address.class;"            >
+
+
+<!--                    CONFERENCE LOCATION                        -->
+<!--                    The physical location(s) of the conference.
+                        This may include a city, a country, or a
+                        campus or organization location if that is
+                        the only location available.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-loc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-loc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-loc
+                                                                   -->
+<!ELEMENT  conf-loc     (#PCDATA %conf-loc-elements;)*               >
+<!ATTLIST  conf-loc
+             %conf-loc-atts;                                         >
+
+
+<!--                    CONFERENCE NAME ELEMENTS                   -->
+<!--                    Elements for use in the <conf-name> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-name-elements
+                        "%simple-text;"                            >
+
+
+<!--                    CONFERENCE NAME                            -->
+<!--                    The full name of the conference, including any
+                        qualifiers such as "43rd Annual".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-name
+                                                                   -->
+<!ELEMENT  conf-name    (#PCDATA %conf-name-elements;)*              >
+<!ATTLIST  conf-name
+             %conf-name-atts;                                        >
+
+
+<!--                    CONFERENCE SPONSOR  ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference sponsor.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % conf-sponsor-elements
+                        "%simple-text; | %institution-wrap.class;"   >
+
+
+<!--                    CONFERENCE SPONSOR                         -->
+<!--                    One organization that sponsored the
+                        conference. If more than one organization
+                        sponsored the conference, multiple
+                        <conf-sponsor> elements should be used.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=conf-sponsor
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=conf-sponsor
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=conf-sponsor
+                                                                   -->
+<!ELEMENT  conf-sponsor (#PCDATA %conf-sponsor-elements;)*           >
+<!ATTLIST  conf-sponsor
+             %conf-sponsor-atts;                                     >
+
+
+<!--                    OBJECT IDENTIFIER                          -->
+<!--                    Used to record an identifier such as a DOI
+                        for an interior element such as an <abstract>
+                        or <figure>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=object-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=object-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=object-id
+                                                                   -->
+<!ELEMENT  object-id    (#PCDATA)                                    >
+<!ATTLIST  object-id
+             %object-id-atts;                                        >
+
+
+<!--                    ISBN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <isbn> element           -->
+<!ENTITY % isbn-elements
+                        ""                                           >
+
+
+<!--                    ISBN                                       -->
+<!--                    International Standard Book Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=isbn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=isbn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=isbn
+                                                                   -->
+<!ELEMENT  isbn         (#PCDATA %isbn-elements;)*                   >
+<!ATTLIST  isbn
+             %isbn-atts;                                             >
+
+
+<!--                    ISSN ELEMENTS                              -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issue> element          -->
+<!ENTITY % issn-elements
+                        ""                                           >
+
+
+<!--                    ISSN                                       -->
+<!--                    International Standard Serial Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issn
+                                                                   -->
+<!ELEMENT  issn         (#PCDATA %issn-elements;)*                   >
+<!ATTLIST  issn
+             %issn-atts;                                             >
+
+
+<!--                    ISSN-L ELEMENTS                            -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issn-l> element         -->
+<!ENTITY % issn-l-elements
+                        ""                                           >
+
+
+<!--                    ISSN LINKING                               -->
+<!--                    International Standard Linking Serial Number
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issn-l
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issn-l
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issn-l
+                                                                   -->
+<!ELEMENT  issn-l       (#PCDATA %issn-l-elements;)*                 >
+<!ATTLIST  issn-l
+             %issn-l-atts;                                           >
+
+
+<!--                    ISSUE ELEMENTS                             -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issue> element          -->
+<!ENTITY % issue-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE NUMBER                               -->
+<!--                    The issue number, issue name, or other
+                        identifier of an issue of a journal that
+                        is displayed or printed with the issue.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issue
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issue
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issue
+                                                                   -->
+<!ELEMENT  issue        (#PCDATA %issue-elements;)*                  >
+<!ATTLIST  issue
+             %issue-atts;                                            >
+
+
+<!--                    ISSUE IDENTIFIER                           -->
+<!--                    Used to record an identifier such as a DOI
+                        that describes an entire issue of a
+                        journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issue-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issue-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issue-id
+                                                                   -->
+<!ELEMENT  issue-id     (#PCDATA)                                    >
+<!ATTLIST  issue-id
+             %issue-id-atts;                                         >
+
+
+<!--                    ISSUE PART ELEMENTS                        -->
+<!--                    Elements that can be added to the text
+                        within the element <issue-part>            -->
+<!ENTITY % issue-part-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE PART                         -->
+<!--                    A publisher may split an issue into two or
+                        more separately bound or separately issued
+                        parts. This element holds the identifiers
+                        (titles, part numbers, etc.) for those
+                        publishing components.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issue-part
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issue-part
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issue-part
+                                                                   -->
+<!ELEMENT  issue-part   (#PCDATA %issue-part-elements;)*             >
+<!ATTLIST  issue-part
+             %issue-part-atts;                                       >
+
+
+<!--                    ISSUE SPONSOR ELEMENTS                     -->
+<!--                    Elements for use in the <issue-sponsor>
+                        element                                    -->
+<!ENTITY % issue-sponsor-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE TITLE                                -->
+<!--                    Used to record the sponsor for an issue of
+                        the journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issue-sponsor
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issue-sponsor
+                                                                   -->
+<!ELEMENT  issue-sponsor
+                        (#PCDATA %issue-sponsor-elements;)*          >
+<!ATTLIST  issue-sponsor
+             %issue-sponsor-atts;                                      >
+
+
+<!--                    ISSUE TITLE ELEMENTS                       -->
+<!--                    Elements for use in the <issue-title> element
+                                                                   -->
+<!ENTITY % issue-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ISSUE TITLE                                -->
+<!--                    Used to record the theme or special issue
+                        title for an issue of the journal
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=issue-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=issue-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=issue-title
+                                                                   -->
+<!ELEMENT  issue-title  (#PCDATA %issue-title-elements;)*            >
+<!ATTLIST  issue-title
+             %issue-title-atts;                                      >
+
+
+<!--                    JOURNAL IDENTIFIER                         -->
+<!--                    Short code that represents the journal; used
+                        as an alternative to or short form of the
+                        journal title; used for identification of
+                        the journal domain.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=journal-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=journal-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=journal-id
+                                                                   -->
+<!ELEMENT  journal-id   (#PCDATA)                                    >
+<!ATTLIST  journal-id
+             %journal-id-atts;                                       >
+
+
+<!--                    ROLE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <role>
+                        Design Note: All inline mixes begin with an
+                        OR bar; since %rendition-plus; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % role-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    ROLE OR FUNCTION TITLE OF CONTRIBUTOR      -->
+<!--                    A title or the role of a contributor
+                        (such as an author) in this work. For example,
+                        Editor-in-Chief, Contributor, Chief
+                        Scientist, Photographer, Research Associate,
+                        etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=role
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=role
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=role
+                                                                   -->
+<!ELEMENT  role         (#PCDATA %role-elements;)*                   >
+<!ATTLIST  role
+             %role-atts;                                             >
+
+
+<!--                    TRANSLATED TITLE GROUP MODEL               -->
+<!--                    Content model for the element
+                        <trans-title-group>                        -->
+<!ENTITY % trans-title-group-model
+                        "(trans-title, trans-subtitle*)"             >
+
+
+<!--                    TRANSLATED TITLE GROUP                     -->
+<!--                    Container element for all translated, and
+                        transliterated journal titles.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=trans-title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=trans-title-group
+                                                                   -->
+<!ELEMENT  trans-title-group
+                        %trans-title-group-model;                    >
+<!ATTLIST  trans-title-group
+             %trans-title-group-atts;                                >
+
+
+<!--                    TRANSLATED SUBTITLE                        -->
+<!--                    An alternate version of an article subtitle
+                        that has been translated out of the original
+                        language of the article subtitle <subtitle>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=trans-subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=trans-subtitle
+                                                                   -->
+<!ELEMENT  trans-subtitle
+                        (#PCDATA %trans-subtitle-elements;)*         >
+<!ATTLIST  trans-subtitle
+             %trans-subtitle-atts;                                   >
+
+
+<!--                    TRANSLATED TITLE                           -->
+<!--                    An alternate version of the title that has
+                        been translated into a language other than
+                        that of the original article title
+                        <article-title>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=trans-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=trans-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=trans-title
+                                                                   -->
+<!ELEMENT  trans-title  (#PCDATA %trans-title-elements;)*            >
+<!ATTLIST  trans-title
+            %trans-title-atts;                                       >
+
+
+<!--                    VOLUME NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume>                                 -->
+<!ENTITY % volume-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME NUMBER                              -->
+<!--                    NEW DEFINITION FOR RELEASE 2.0:
+                        The volume number, volume name, or other
+                        identifier of an volume of a journal that
+                        is displayed or printed with the volume.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=volume
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=volume
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=volume
+                                                                   -->
+<!ELEMENT  volume       (#PCDATA %volume-elements;)*                 >
+<!ATTLIST  volume
+            %volume-atts;                                            >
+
+
+<!--                    VOLUME IDENTIFIER ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume-id>                              -->
+<!ENTITY % volume-id-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME IDENTIFIER                          -->
+<!--                    Used to record an identifier such as a DOI
+                        that describes an entire volume of a
+                        journal.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=volume-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=volume-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=volume-id
+                                                                   -->
+<!ELEMENT  volume-id    (#PCDATA %volume-id-elements;)*              >
+<!ATTLIST  volume-id
+             %volume-id-atts;                                        >
+
+
+<!--                    VOLUME SERIES ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume>                                 -->
+<!ENTITY % volume-series-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    VOLUME SERIES                              -->
+<!--                    This is a rare metadata element, intended to
+                        hold the series number, in those odd cases
+                        where, for example, a Publisher has reissued
+                        a journal, restarting the volume numbers
+                        with "1", so duplicate volume numbers
+                        would exist and need to be differentiated.
+                        Such a publisher typically adds a series
+                        number to their volume numbers, and
+                        this element has been created to hold such
+                        a series number.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=volume-series
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=volume-series
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=volume-series
+                                                                   -->
+<!ELEMENT  volume-series
+                        (#PCDATA %volume-series-elements;)*          >
+<!ATTLIST  volume-series
+            %volume-series-atts;                                     >
+
+
+<!--                    VOLUME ISSUE GROUP                         -->
+<!--                    Content model for the element
+                        <volume-issue-group>.                      -->
+<!ENTITY % volume-issue-group-model
+                        "(volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?)"               >
+
+
+<!--                    TRANSLATED TITLE GROUP                     -->
+<!--                    Container element to hold together related
+                        volume and issue elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=volume-issue-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=volume-issue-group
+                                                                   -->
+<!ELEMENT  volume-issue-group
+                        %volume-issue-group-model;                   >
+<!ATTLIST  volume-issue-group
+             %volume-issue-group-atts;                               >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ARTICLE METADATA/BIBLIOGRAPHIC      -->
+<!--                    CONTRIBUTOR IDENTIFICATION ELEMENTS        -->
+<!-- ============================================================= -->
+
+
+<!--                    ANONYMOUS ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <anonymous> element                     -->
+<!ENTITY % anonymous-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ANONYMOUS CONTENT MODEL                    -->
+<!--                    The content model for the <anonymous> 
+                        element                                    -->
+<!ENTITY % anonymous-model
+                        "(#PCDATA %anonymous-elements;)*"            >
+
+
+<!--                    ANONYMOUS                                  -->
+<!--                    Place holder for the name of a contributor
+                        whose name is unknown or not disclosed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=anonymous
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=anonymous
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=anonymous
+                                                                   -->
+<!ELEMENT  anonymous    %anonymous-model;                            >
+<!ATTLIST  anonymous
+             %anonymous-atts;                                        >
+
+
+<!--                    ET AL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <etal> element                          -->
+<!ENTITY % etal-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ET AL CONTENT MODEL                        -->
+<!--                    The content model for the <etal> element   -->
+<!ENTITY % etal-model   "(#PCDATA %etal-elements;)*"                 >
+
+
+<!--                    ET AL                                      -->
+<!--                    Most journals model this as an EMPTY element,
+                        typically used to generate the text "et al."
+                        from a stylesheet. However, a few journal
+                        DTDs (Blackwell's, for example) expect
+                        content for this element, with such text as
+                        "Associates, coworkers, and colleagues".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=etal
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=etal
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=etal
+                                                                   -->
+<!ELEMENT  etal         %etal-model;                                 >
+<!ATTLIST  etal
+             %etal-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ARTICLE METADATA/BIBLIOGRAPHIC      -->
+<!--                    PUBLISHER IDENTIFICATION ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    ON BEHALF OF CONTENT ELEMENTS              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <on-behalf-of>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix beguines with
+                        an OR bar.                                 -->
+<!ENTITY % on-behalf-of-elements
+                        "%rendition-plus; | %institution-wrap.class;"
+                                                                     >
+
+<!--                    ON BEHALF OF                               -->
+<!--                    When a contributor has written or edited
+                        a work  "on-behalf-of" an organization or
+                        group the contributor is acting as a
+                        representative of the organization, which
+                        may or may not be his/her usual affiliation.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=on-behalf-of
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=on-behalf-of
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=on-behalf-of
+                                                                   -->
+<!ELEMENT  on-behalf-of (#PCDATA %on-behalf-of-elements;)*           >
+<!ATTLIST  on-behalf-of
+             %on-behalf-of-atts;                                     >
+
+
+<!--                    PUBLISHER CONTENT MODEL                    -->
+<!--                    The content model for the <publisher>
+                        element                                    -->
+<!ENTITY % publisher-model
+                        "((publisher-name, publisher-loc?)+)"        >
+
+
+<!--                    PUBLISHER                                  -->
+<!--                    Who published the work
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=publisher
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=publisher
+                                                                   -->
+<!ELEMENT  publisher    %publisher-model;                            >
+<!ATTLIST  publisher
+             %publisher-atts;                                        >
+
+
+<!--                    PUBLISHER'S NAME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <publisher-name>
+                        Design Note: All inline mixes begin with an
+                        OR bar; since %just-rendition; is an
+                        inline mix, the OR bar is already there    -->
+<!ENTITY % publisher-name-elements
+                        "%just-rendition;| %institution-wrap.class;" >
+
+
+<!--                    PUBLISHER'S NAME                           -->
+<!--                    Name of the publisher of the work
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=publisher-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=publisher-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=publisher-name
+                                                                   -->
+<!ELEMENT  publisher-name
+                        (#PCDATA %publisher-name-elements;)*         >
+<!ATTLIST  publisher-name
+             %publisher-name-atts;                                   >
+
+
+<!--                    PUBLISHER'S LOCATION ELEMENTS              -->
+<!--                    Elements for use in the Publisher Location
+                        <publisher-loc> element                    -->
+<!ENTITY % publisher-loc-elements
+                        "| %address.class; | %address-link.class; |
+                         %emphasis.class; | %subsup.class;"          >
+
+
+<!--                    PUBLISHER'S LOCATION                       -->
+<!--                    Place of publication, usually a city such
+                        as New York or London
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=publisher-loc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=publisher-loc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=publisher-loc
+                                                                   -->
+<!ELEMENT  publisher-loc
+                        (#PCDATA %publisher-loc-elements;)*          >
+<!ATTLIST  publisher-loc
+             %publisher-loc-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON METADATA ELEMENTS CONTINUED         -->
+<!--                    PAGE NUMBERING (SIZE) ELEMENTS             -->
+<!-- ============================================================= -->
+
+
+<!--                    FIRST PAGE                                 -->
+<!--                    The page number on which the article starts,
+                        for print journals that have page numbers
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fpage
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fpage
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fpage
+                                                                   -->
+<!ELEMENT  fpage        (#PCDATA)                                    >
+<!ATTLIST  fpage
+             %fpage-atts;                                            >
+
+
+<!--                    LAST PAGE                                  -->
+<!--                    The page number on which the article ends,
+                        for print journals that have page numbers
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=lpage
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=lpage
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=lpage
+                                                                   -->
+<!ELEMENT  lpage        (#PCDATA)                                    >
+<!ATTLIST  lpage
+             %lpage-atts;                                            >
+
+
+<!--                    PAGE RANGES                                -->
+<!--                    A container element for additional page
+                        information (TO BE USED TO SUPPLEMENT AND
+                        NOT TO REPLACE <fpage> and <lpage>) to record
+                        discontinuous pages ranges such as
+                            "8-11, 14-19, 40"
+                        meaning that the article begins on page
+                        8, runs 8 through 11, skips to pages 14
+                        through 19, and concludes on page 40.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=page-range
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=page-range
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=page-range
+                                                                   -->
+<!ELEMENT  page-range   (#PCDATA)                                    >
+<!ATTLIST  page-range
+             %page-range-atts;                                       >
+
+
+<!--                    SIZE ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the size element.                          -->
+<!ENTITY % size-elements
+                        ""                                           >
+
+
+<!--                    SIZE                                       -->
+<!--                    The size (such as running time, page count,
+                        or physical measurements) of the object being
+                        described, usually by a <product> element.
+                        The "units" attribute must be used to name
+                        the unit of measure (pages, minutes, hours,
+                        linear feet, etc.).
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=size
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=size
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=size
+                                                                   -->
+<!ELEMENT  size         (#PCDATA %size-elements;)*                   >
+<!ATTLIST  size
+             %size-atts;                                             >
+
+
+<!--                    ELECTRONIC LOCATION IDENTIFIER             -->
+<!--                    Used to identify an article that
+                        does not have traditional page numbers.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=elocation-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=elocation-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=elocation-id
+                                                                   -->
+<!ELEMENT  elocation-id (#PCDATA)                                    >
+<!ATTLIST  elocation-id
+             %elocation-id-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    CITATIONS (BIBLIOGRAPHIC REFERENCE)        -->
+<!-- ============================================================= -->
+
+
+<!--                    CITATION ALTERNATIVES MODEL                -->
+<!--                    Model for the <citation-alternatives>
+                        element.                                   -->
+<!ENTITY % citation-alternatives-model
+                        "(%citation-minus-alt.class;)+"              >
+
+
+<!--                    CITATION ALTERNATIVES                      -->
+<!--                    This element will hold alternative versions of 
+                        one citation, for example, a single citation 
+                        in multiple languages or a single citation 
+                        tagged as both a <mixed-citation> complete 
+                        with punctuation and spacing and as an
+                        <element-citation> with punctuation and 
+                        spacing removed.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=citation-alternativesv
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=citation-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=citation-alternatives
+                                                                   -->
+<!ELEMENT  citation-alternatives
+                        %citation-alternatives-model;                >
+<!ATTLIST  citation-alternatives
+             %citation-alternatives-atts;                            >
+
+
+<!--                    CITATION ELEMENTS                          -->
+<!--                    Content for both types of citation. These
+                        elements may be mixed with #PCDATA in the
+                        <mixed-citation> element (in which all
+                        punctuation and spacing are left intact), and
+                        they also constitute the choices that can be
+                        used to form the all-element-content of the
+                        <element-citation> element (in which
+                        punctuation and spacing are removed).
+                        Design Note: All inline mixes begin with an
+                        OR bar.                                    -->
+<!ENTITY % citation-elements
+                        "%emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %phrase.class; | %references.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    MIXED CITATION                             -->
+<!--                    A citation is a description of a work, such
+                        as a journal article, book, or personal
+                        communication, that is cited in the text of
+                        the article. This citation element is
+                        completely loose, with text, punctuation,
+                        spacing, and any of the citation elements
+                        in any order.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=mixed-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=mixed-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=mixed-citation
+                                                                   -->
+<!ELEMENT  mixed-citation
+                        (#PCDATA | %citation-elements;)*             >
+<!ATTLIST  mixed-citation
+             %mixed-citation-atts;                                   >
+
+
+<!--                    ELEMENT CITATION                           -->
+<!--                    A citation is a description of a work, such
+                        as a journal article, book, or personal
+                        communication, that is cited in the text of
+                        the article. This citation model contains
+                        element-only content, with elements in
+                        any order as many times as needed. This
+                        citation is intended for use in capturing
+                        a publisher's specific element order.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=element-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=element-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=element-citation
+                                                                   -->
+<!ELEMENT  element-citation
+                        (%citation-elements;)+                       >
+<!ATTLIST  element-citation
+             %element-citation-atts;                                 >
+
+
+<!-- ============================================================= -->
+<!--                    ADDRESS ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS MODEL                              -->
+<!--                    Content model for the <address> element    -->
+<!ENTITY % address-model
+                        "(%address.class; | %address-link.class;)*"  >
+
+
+<!--                    ADDRESS/CONTACT INFORMATION                -->
+<!--                    Wrapper element for contact information such
+                        as address, phone, fax, email, url, country,
+                        etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=address
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=address
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=address
+                                                                   -->
+<!ELEMENT  address      %address-model;                              >
+<!ATTLIST  address
+             %address-atts;                                          >
+
+
+<!--                    ADDRESS LINE ELEMENTS                      -->
+<!--                    Elements for use in the <addr-line> element-->
+<!ENTITY % addr-line-elements
+                        "%simple-text; | %address-line.class;"       >
+
+
+<!--                    ADDRESS LINE                               -->
+<!--                    One line in an address                     -->
+<!--                    Conversion Note: If the address is
+                        undifferentiated data characters, the entire
+                        address may be inside one of these elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=addr-line
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=addr-line
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=addr-line
+                                                                   -->
+<!ELEMENT  addr-line    (#PCDATA %addr-line-elements;)*              >
+<!ATTLIST  addr-line
+             %addr-line-atts;                                        >
+
+
+<!--                    CITY ELEMENTS                              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the city element.                          -->
+<!ENTITY % city-elements
+                        ""                                           >
+
+
+<!--                    CITY: IN AN ADDRESS                        -->
+<!--                    The name of a city.                   
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=city
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=city
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=city
+                                                                   -->
+<!ELEMENT  city         (#PCDATA %city-elements;)*                   >
+<!ATTLIST  city
+             %city-atts;                                             >
+
+
+<!--                    COUNTRY ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the country element.                       -->
+<!ENTITY % country-elements
+                        ""                                           >
+
+
+<!--                    COUNTRY: IN AN ADDRESS                     -->
+<!--                    The name of a country.                    
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=country
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=country
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=country
+                                                                   -->
+<!ELEMENT  country      (#PCDATA %country-elements;)*                >
+<!ATTLIST  country
+             %country-atts;                                          >
+
+
+<!--                    EMAIL ADDRESS ELEMENTS                     -->
+<!--                    Elements to be mixed with #PCDATA inside the
+                        <email> element                            -->
+<!ENTITY % email-elements
+                        ""                                           >
+
+
+<!--                    EMAIL ADDRESS                              -->
+<!--                    The email address of a person or institution.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=email
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=email
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=email
+                                                                   -->
+<!ELEMENT  email        (#PCDATA %email-elements;)*                  >
+<!ATTLIST  email
+             %email-atts;                                            >
+
+
+<!--                    FAX NUMBER ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <fax>                                    -->
+<!ENTITY % fax-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    FAX NUMBER: IN AN ADDRESS                  -->
+<!--                    The number used to send faxes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fax
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fax
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fax
+                                                                   -->
+<!ELEMENT  fax          (#PCDATA %fax-elements;)*                    >
+<!ATTLIST  fax
+             %fax-atts;                                              >
+
+
+<!--                    INSTITUTION NAME ELEMENTS                  -->
+<!--                    Elements for use in the <institution>
+                        element                                    -->
+<!ENTITY % institution-elements
+                        "| %break.class; | %emphasis.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    INSTITUTION NAME: IN AN ADDRESS            -->
+<!--                    Name of a institution or organization such as
+                        a university or corporation used in an
+                        address or within a citation (such as a
+                        <mixed-citation> or an <element-citation>)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=institution
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=institution
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=institution
+                                                                   -->
+<!ELEMENT  institution  (#PCDATA %institution-elements;)*            >
+<!ATTLIST  institution
+             %institution-atts;                                      >
+
+
+<!--                    INSTITUTION IDENTIFIER MODEL               -->
+<!--                    Content model for the <institution-id>
+                        element                                    -->
+<!ENTITY % institution-id-model
+                        "(#PCDATA)"                                  >
+
+
+<!--                    INSTITUTION IDENTIFIER                     -->
+<!--                    Contains an institutional identifier,
+                        whether publisher-specific (for example,  
+                        "AIP") or from an established identifying
+                        authority (for example,"Ringgold" or "ISNI").
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=institution-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=institution-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=institution-id
+                                                                   -->
+<!ELEMENT  institution-id  
+                        %institution-id-model;                       >
+<!ATTLIST  institution-id
+             %institution-id-atts;                                   >
+
+
+<!--                    INSTITUTION WRAPPER MODEL                  -->
+<!--                    Content model for the <institution-wrap>
+                        element                                    -->
+<!ENTITY % institution-wrap-model
+                        "(%institution.class;)*"                     >
+
+
+<!--                    INSTITUTION WRAPPER                        -->
+<!--                    A container element to hold the name of an
+                        institution <institution> and any formal
+                        identifiers for that institution 
+                        <institution-id>), for example, a INSI or
+                        Ringgold ID.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=institution-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=institution-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=institution-wrap
+                                                                   -->
+<!ELEMENT  institution-wrap  
+                        %institution-wrap-model;                     >
+<!ATTLIST  institution-wrap
+             %institution-wrap-atts;                                 >
+
+
+<!--                    PHONE NUMBER ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <phone number>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %just-rendition; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % phone-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PHONE NUMBER: IN AN ADDRESS                -->
+<!--                    A callable phone number in some telephone or
+                        wireless system somewhere in the world.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=phone
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=phone
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=phone
+                                                                   -->
+<!ELEMENT  phone        (#PCDATA %phone-elements;)*                  >
+<!ATTLIST  phone
+             %phone-atts;                                            >
+
+
+<!--                    POSTAL CODE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the postal-code element.                   -->
+<!ENTITY % postal-code-elements
+                        ""                                           >
+
+
+<!--                    POSTAL CODE: IN AN ADDRESS                 -->
+<!--                    A postal number such as a zip-code or postal
+                        code used to address physical mail.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=postal-code
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=postal-code
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=postal-code
+                                                                   -->
+<!ELEMENT  postal-code  (#PCDATA %postal-code-elements;)*            >
+<!ATTLIST  postal-code
+             %postal-code-atts;                                      >
+
+
+<!--                    STATE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the state element.                         -->
+<!ENTITY % state-elements
+                        ""                                           >
+
+
+<!--                    STATE or PROVINCE: IN AN ADDRESS           -->
+<!--                    The name of a state, province, territory or
+                        other political unit used in an address. This
+                        is a lower level subdivision than a country,
+                        but higher than a city, county, or parish. 
+                        The names for such a unit vary geopolitically.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=state
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=state
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=state
+                                                                   -->
+<!ELEMENT  state        (#PCDATA %state-elements;)*                  >
+<!ATTLIST  state
+             %state-atts;                                            >
+
+
+<!--                    URI ELEMENTS                               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <uri>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % uri-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    URI                                        -->
+<!--                    URI such as a URL that may be used as a
+                        live link, typically naming a web site, such
+                        as:
+                           <url>http://www.mulberrytech.com</url>
+                        Alternatively the element content may name
+                        the URL, e.g., "Mulberry's Website" and the
+                        "xlink:href" attribute may hold the real
+                        URL.
+                           <url xlink:href="http://www.mulberrytech.
+                           com">Mulberry's Website</url>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=uri
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=uri
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=uri
+                                                                   -->
+<!ELEMENT  uri          (#PCDATA %uri-elements;)*                    >
+<!ATTLIST  uri
+             %uri-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    SUPPLEMENT ELEMENTS                        -->
+<!-- ============================================================= -->
+
+
+<!--                    SUPPLEMENT ELEMENTS                        -->
+<!--                    Elements for use in the <supplement> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % supplement-elements
+                        "%simple-text; | %contrib-group.class; |
+                         %title.class;"                              >
+
+
+<!--                    SUPPLEMENT                                 -->
+<!--                    For a journal published as a supplement, this
+                        is a container element for all the provided
+                        supplement information, such as additional
+                        identification numbers, titles, authors, and
+                        supplement series information.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=supplement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=supplement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=supplement
+                                                                   -->
+<!ELEMENT  supplement   (#PCDATA %supplement-elements;)*             >
+<!ATTLIST  supplement
+            %supplement-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    DATE ELEMENTS (PUBLICATION HISTORY)        -->
+<!-- ============================================================= -->
+
+
+<!--                    DATE                                       -->
+<!--                    The elements <day>, <month>, and <year> should
+                        ALWAYS be numeric values. The date may be
+                        represented as a string in <string-date>, but
+                        the numeric values should be present whenever
+                        possible.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=date
+                                                                   -->
+<!ELEMENT  date         %date-model;                                 >
+<!ATTLIST  date
+              %date-atts;                                            >
+
+
+<!--                    DAY                                        -->
+<!--                    The numeric value of a day of the month, used
+                        in both article metadata and inside a citation,
+                        in two digits as it would be stated in the "DD"
+                        in an international date format YYYY-MM-DD, for
+                        example "03", "25".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=day
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=day
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=day
+                                                                   -->
+<!ELEMENT  day          (#PCDATA)                                    >
+<!ATTLIST  day
+             %day-atts;                                              >
+
+
+<!--                    MONTH                                      -->
+<!--                    Names one of the months of the year. Used in
+                        both article metadata and inside a citation,
+                        this element may contain a full month
+                        "December", an abbreviation "Dec", or,
+                        preferably, a numeric month such as "12".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=month
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=month
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=month
+                                                                   -->
+<!ELEMENT  month        (#PCDATA)                                    >
+<!ATTLIST  month
+             %month-atts;                                            >
+
+
+<!--                    SEASON                                     -->
+<!--                    Season of publication, such as "Spring".
+                        Used in both article metadata and inside a
+                        citation (such as a <mixed-citation> or an
+                        <element-citation>)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=season
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=season
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=season
+                                                                   -->
+<!ELEMENT  season       (#PCDATA)                                    >
+<!ATTLIST  season
+             %season-atts;                                           >
+
+
+<!--                    ERA                                        -->
+<!--                    Era of publication. Used in certain Japanese
+                        and Korean dates.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=era
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=era
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=era
+                                                                   -->
+<!ELEMENT  era         (#PCDATA)                                     >
+<!ATTLIST  era
+             %era-atts;                                              >
+
+
+<!--                    YEAR                                       -->
+<!--                    Year of publication, which should be expressed
+                        as a 4-digit number: "1776" or "1924"
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=year
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=year
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=year
+                                                                   -->
+<!ELEMENT  year         (#PCDATA)                                    >
+<!ATTLIST  year
+             %year-atts;                                             >
+
+
+<!--                    STRING DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-date> element                  -->
+<!ENTITY % string-date-elements
+                        " | %date-parts.class;"                      >
+
+
+<!--                    DATE AS A STRING                           -->
+<!--                    This is a representation of the date as a
+                        string; usually used for dates for which
+                        months and years are not given, but may be
+                        used for any date as a string (i.e., "January,
+                        2001" "Fall 2001" "March 11, 2001").
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=string-date
+                                                                   -->
+<!ELEMENT  string-date  (#PCDATA %string-date-elements;)*            >
+<!ATTLIST  string-date
+             %string-date-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    GROUP OR CORPORATE AUTHOR ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    COLLABORATION ALTERNATIVES ELEMENTS        -->
+<!--                    Content model for the <collab-alternatives>
+                        element.                                   -->
+<!ENTITY % collab-alternatives-model
+                        "(%collab.class;)+"                          >
+
+
+<!--                    COLLABORATION ALTERNATIVES                 -->
+<!--                    Wrapper element for more than one version of
+                        a collaboration, for example, the name of a
+                        laboratory in more than one language such as
+                        the lab name in Japanese kana characters and 
+                        a transliterated form of the lab name in Latin 
+                        alphabet.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=collab-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=collab-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=collab-alternatives
+                                                                   -->
+<!ELEMENT  collab-alternatives
+                        %collab-alternatives-model;                  >
+<!ATTLIST  collab-alternatives
+             %collab-alternatives-atts;                              >
+
+
+<!--                    COLLABORATIVE (GROUP) AUTHOR ELEMENTS      -->
+<!--                    Elements for use in the <collab> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % collab-elements
+                        "%simple-text; | %address.class; |
+                         %contrib-group.class; |
+                         %contrib-info.class; | %fn-link.class;"     >
+
+
+<!--                    COLLABORATIVE (GROUP) AUTHOR               -->
+<!--                    Used for groups of authors credited under
+                        one name, either as a collaboration in the
+                        strictest sense, or when an organization,
+                        institution, or corporation is the group.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=collab
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=collab
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=collab
+                                                                   -->
+<!ELEMENT  collab       (#PCDATA %collab-elements;)*                 >
+<!ATTLIST  collab
+             %collab-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    PERSON'S NAME ELEMENTS (BIBLIOGRAPHIC)     -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR IDENTIFIER MODEL               -->
+<!--                    Content model for the <contrib-id> element -->
+<!ENTITY % contrib-id-model
+                        "(#PCDATA)"                                  >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER                     -->
+<!--                    One identifier for a person such as a
+                        contributor or principal investigator. This
+                        element will hold an ORCID, a trusted
+                        publishers's identifier, or a JST or NII 
+                        identifier.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=contrib-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=contrib-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=contrib-id
+                                                                   -->
+<!ELEMENT  contrib-id   %contrib-id-model;                           >
+<!ATTLIST  contrib-id 
+             %contrib-id-atts;                                       >
+
+
+<!--                    NAME ALTERNATIVES MODEL                    -->
+<!--                    Content model for the <name-alternatives>
+                        element                                    -->
+<!ENTITY % name-alternatives-model
+                        "((%name-alternatives.class;)+)"             >
+
+
+<!--                    NAME ALTERNATIVES                          -->
+<!--                    Wrapper element for more than one version of
+                        a personal name, for example, the name in
+                        Japanese kana characters and a transliterated
+                        form of the name in Latin alphabet.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=name-alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=name-alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=name-alternatives
+                                                                   -->
+<!ELEMENT  name-alternatives
+                        %name-alternatives-model;                    >
+<!ATTLIST  name-alternatives
+             %name-alternatives-atts;                                >
+
+
+
+<!--                    NAME OF PERSON (STRUCTURED)                -->
+<!--                    Wrapper element for personal names.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=name
+                                                                   -->
+<!ELEMENT  name         ( ( (surname, given-names?) | given-names),
+                          prefix?, suffix?)                          >
+<!ATTLIST  name
+             %name-atts;                                             >
+
+
+<!--                    STRING NAME ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <string-name> element                  -->
+<!ENTITY % string-name-elements
+                        " | %person-name.class;"                     >
+
+
+<!--                    NAME OF PERSON (UNSTRUCTURED)              -->
+<!--                    Wrapper element for personal names where the
+                        stricter format of the <name> element cannot
+                        be followed. This is a very loose element,
+                        allowing data characters, generated text,
+                        and any or all of the naming elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=string-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=string-name
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=string-name
+                                                                   -->
+<!ELEMENT  string-name  (#PCDATA %string-name-elements;)*            >
+<!ATTLIST  string-name
+             %string-name-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    PARTS OF A PERSON'S NAME ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    DEGREE(S) ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <degrees>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % degrees-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    DEGREE(S)                                  -->
+<!--                    Academic degrees or professional
+                        certifications
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=degrees
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=degrees
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=degrees
+                                                                   -->
+<!ELEMENT  degrees      (#PCDATA %degrees-elements;)*                >
+<!ATTLIST  degrees
+             %degrees-atts;                                          >
+
+
+<!--                    GIVEN (FIRST) NAMES ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <given-names>                            -->
+<!ENTITY % given-names-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    GIVEN (FIRST) NAMES                        -->
+<!--                    Includes all given names for a person, such
+                        as the first name, middle names, maiden
+                        name if used as part of the married name,
+                        etc.)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=given-names
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=given-names
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=given-names
+                                                                   -->
+<!ELEMENT  given-names  (#PCDATA %given-names-elements;)*            >
+<!ATTLIST  given-names
+             %given-names-atts;                                      >
+
+
+<!--                    SURNAME ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <surname>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % surname-elements
+                        "%just-rendition; "                          >
+
+
+<!--                    SURNAME                                    -->
+<!--                    The surname (family name) of an individual.
+                        or the single name if there is only one
+                        name, for example, "Cher" or "Pele".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=surname
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=surname
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=surname
+                                                                   -->
+<!ELEMENT  surname      (#PCDATA %surname-elements;)*                >
+<!ATTLIST  surname
+             %surname-atts;                                          >
+
+
+<!--                    PREFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <prefix>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % prefix-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PREFIX                                     -->
+<!--                    Honorifics or other qualifiers that usually
+                        precede the surname, for example,  Professor,
+                        Rev., President, Senator, Dr., Sir, The
+                        Honorable, et al.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=prefix
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=prefix
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=prefix
+                                                                   -->
+<!ELEMENT  prefix       (#PCDATA %prefix-elements;)*                 >
+<!ATTLIST  prefix
+             %prefix-atts;                                           >
+
+
+
+<!--                    SUFFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <suffix>
+                        Design Note: This PE begins with an OR bar,
+                        it is inside %just-rendition;              -->
+<!ENTITY % suffix-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    SUFFIX                                     -->
+<!--                    Text used as a suffix to a person's name, for
+                        example: Sr., Jr., III, 3rd
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=suffix
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=suffix
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=suffix
+                                                                   -->
+<!ELEMENT  suffix       (#PCDATA %suffix-elements;)*                 >
+<!ATTLIST  suffix
+             %suffix-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    EXTERNAL LINK ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    EXTERNAL LINK ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <ext-link>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % ext-link-elements
+                        "%link-elements;"                            >
+
+
+<!--                    EXTERNAL LINK                              -->
+<!--                    Link to an external file, such as Medline,
+                        Genbank, etc.  Linking may be accomplished
+                        using the XLink linking attributes.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ext-link
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ext-link
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ext-link
+                                                                   -->
+<!ELEMENT  ext-link     (#PCDATA %ext-link-elements;)*               >
+<!ATTLIST  ext-link
+             %ext-link-atts;                                         >
+
+
+<!-- ============================================================= -->
+<!--                    SHARED STRUCTURAL ELEMENTS                 -->
+<!-- ============================================================= -->
+
+
+<!--                    ATTRIBUTION ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an attribution
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % attrib-elements
+                        "%emphasized-text;"                          >
+
+
+<!--                    ATTRIBUTION                                -->
+<!--                    Source, author, formal thanks, or other
+                        information (other than copyright material)
+                        concerning the origins of an extract, a poem
+                        <verse-group> or similar element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=attrib
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=attrib
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=attrib
+                                                                   -->
+<!ELEMENT  attrib       (#PCDATA %attrib-elements;)*                 >
+<!ATTLIST  attrib
+             %attrib-atts;                                           >
+
+
+<!--                    DEFINITION LIST: DEFINITION MODEL          -->
+<!--                    Content model for the <def> element, which
+                        is used in contexts outside of <def-list>s -->
+<!ENTITY % def-model    "((%just-para.class;)+ )"                    >
+
+
+<!--                    DEFINITION LIST: DEFINITION                -->
+<!--                    Used in two senses:
+                        1) The definition, description, or other
+                        explanation of the word, phrase, or picture
+                        of a 2-part or definition list
+                        2) The definition or expansion of an
+                        abbreviation or acronym <abbrev>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=def
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=def
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=def
+                                                                   -->
+<!ELEMENT  def          %def-model;                                  >
+<!ATTLIST  def
+             %def-atts;                                              >
+
+
+<!--                    LABEL ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <label> element                        -->
+<!ENTITY % label-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %subsup.class;"       >
+
+
+<!--                    LABEL OF A FIGURE, REFERENCE, ETC.         -->
+<!--                    The number and any prefix word that comes
+                        before, for example, the caption of a Figure,
+                        such as "Figure 3." or "Exhibit 2.".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=label
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=label
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=label
+                                                                   -->
+<!ELEMENT  label        (#PCDATA %label-elements;)*                  >
+<!ATTLIST  label
+             %label-atts;                                            >
+
+
+<!--                    PRICE ELEMENTS                             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <price> element                        -->
+<!ENTITY % price-elements
+                        "| %emphasis.class;"                         >
+
+
+<!--                    PRICE                                      -->
+<!--                    Sale price of a work, typically a book or
+                        software package that is being reviewed
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=price
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=price
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=price
+                                                                   -->
+<!ELEMENT  price        (#PCDATA %price-elements;)*                  >
+<!ATTLIST  price
+             %price-atts;                                            >
+
+
+<!--                    STRUCTURAL TITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <title> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % struct-title-elements
+                        "%simple-phrase; | %break.class; |
+                         %citation.class;"                           >
+
+
+<!--                    TITLE                                      -->
+<!--                    Heading or title for a structural element
+                        such as a Section, Figure, Boxed Text, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=title
+                                                                   -->
+<!ELEMENT  title        (#PCDATA %struct-title-elements;)*           >
+<!ATTLIST  title
+             %title-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED ARTICLE ELEMENTS                   -->
+<!--                    (METADATA AND STRUCTURAL)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED ARTICLE ELEMENTS                   -->
+<!--                    Elements allowed inside <related-article>  -->
+<!ENTITY % related-article-elements
+                        "| %emphasis.class; | %journal-id.class; |
+                         %phrase-content.class; |
+                         %references.class; |  %subsup.class;"       >
+
+
+<!--                    RELATED ARTICLE INFORMATION                -->
+<!--                    Wrapper element, used as a container for
+                        text links to a related article, possibly
+                        accompanied by a very brief description
+                        such as "errata (correction)".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=related-article
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=related-article
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=related-article
+                                                                   -->
+<!ELEMENT  related-article
+                        (#PCDATA %related-article-elements;)*        >
+<!ATTLIST  related-article
+             %related-article-atts;                                  >
+
+
+<!-- ============================================================= -->
+<!--                    SIGNATURE BLOCK ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    SIGNATURE BLOCK ELEMENTS                   -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig-block> element.                       -->
+<!ENTITY % sig-block-elements
+                         "| %break.class; | %emphasis.class; |
+                          %just-base-display.class; |
+                          %inline-display-noalt.class; |
+                          %phrase-content.class; |
+                          %sig.class; | %subsup.class;"              >
+
+
+<!--                    SIGNATURE BLOCK                            -->
+<!--                    An area of text and graphic material placed
+                        at the end of an article or section to hold
+                        the graphical signature or other description
+                        of the person responsible for or attesting
+                        to the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sig-block
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sig-block
+                                                                   -->
+<!ELEMENT  sig-block    (#PCDATA %sig-block-elements;)*              >
+<!ATTLIST  sig-block
+             %sig-block-atts;                                        >
+
+
+<!--                    SIGNATURE ELEMENTS                         -->
+<!--                    Elements to be mixed with data characters
+                        inside the content model for the
+                        <sig> element.                             -->
+<!ENTITY % sig-elements "%rendition-plus; | %break.class; |
+                         %inline-display-noalt.class; |
+                         %just-base-display-noalt.class;"            >
+
+
+<!--                    SIGNATURE                                  -->
+<!--                    One contributor signature and associated
+                        material (such as a text restatement of the
+                        affiliation) inside a signature block.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sig
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sig
+                                                                   -->
+<!ELEMENT  sig          (#PCDATA %sig-elements;)*                    >
+<!ATTLIST  sig
+             %sig-atts;                                              >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER/BACK MATTER ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    ACKNOWLEDGMENTS MODEL                      -->
+<!--                    Content model for the <ack> element        -->
+<!ENTITY % ack-model    "%sec-opt-title-model;"                      >
+
+
+<!--                    ACKNOWLEDGMENTS                            -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ack
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ack
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ack
+                                                                   -->
+
+<!ELEMENT  ack          %ack-model;                                  >
+<!ATTLIST  ack
+             %ack-atts;                                              >
+
+
+<!--                    BIOGRAPHY MODEL                            -->
+<!--                    Content model for the <bio> element        -->
+<!ENTITY % bio-model    "%sec-opt-title-model;"                      >
+
+
+<!--                    BIOGRAPHY                                  -->
+<!--                    Short biography of a person, usually the
+                        author
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=bio
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=bio
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=bio
+                                                                   -->
+<!ELEMENT  bio          %bio-model;                                  >
+<!ATTLIST  bio
+             %bio-atts;                                              >
+
+
+<!--                    NOTES MODEL                                -->
+<!--                    Content model for the <notes> element      -->
+<!ENTITY % notes-model  "%sec-opt-title-model;"                      >
+
+
+<!--                    NOTES                                      -->
+<!--                    A container element for the notes that may
+                        appear at the end of an Article or at the
+                        end of a Table, for example, a typical
+                        end-of-article note is a "Note in Proof".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=notes
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=notes
+                                                                   -->
+<!ELEMENT  notes        %notes-model;                                >
+<!ATTLIST  notes
+             %notes-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    ACCESSIBILITY ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    ALTERNATE TITLE TEXT FOR A FIGURE, ETC.    -->
+<!--                    Short phrase used to display or pronounce
+                        as an alternative to providing the full
+                        graphic for accessibility display or
+                        graphic-limited web sites or devices. For
+                        example, <alt-text> may be used to display
+                        "behind" a figure or graphic.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=alt-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=alt-text
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=alt-text
+                                                                   -->
+<!ELEMENT  alt-text     (#PCDATA)                                    >
+<!ATTLIST  alt-text
+             %alt-text-atts;                                         >
+
+
+<!--                    LONG DESCRIPTION ELEMENTS                  -->
+<!--                    Elements to be mixed with data characters
+                        inside the <long-desc> element             -->
+<!ENTITY % long-desc-elements
+                        ""                                           >
+
+
+<!--                    LONG DESCRIPTION                           -->
+<!--                    Description or summary of the content of a
+                        graphical object, table, or textual object
+                        such as a text box, used by some systems to
+                        make the object accessible, even to people
+                        or systems that cannot read/see/display the
+                        object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=long-desc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=long-desc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=long-desc
+                                                                   -->
+<!ELEMENT  long-desc    (#PCDATA %long-desc-elements;)*              >
+<!ATTLIST  long-desc
+             %long-desc-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOM METADATA ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    CUSTOM METADATA GROUP MODEL                -->
+<!--                    Content model for the <custom-meta-group>
+                        element                                    -->
+<!ENTITY % custom-meta-group-model
+                        "(custom-meta+)"                             >
+
+
+<!--                    CUSTOM METADATA GROUP                      -->
+<!--                    Some DTDs and schemas allow for metadata
+                        above and beyond that which can be specified
+                        by this DTD. This element is a grouping
+                        element used to contain all these additional
+                        metadata elements.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=custom-meta-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=custom-meta-group
+                                                                   -->
+<!ELEMENT  custom-meta-group
+                        %custom-meta-group-model;                    >
+<!ATTLIST  custom-meta-group
+             %custom-meta-group-atts;                                >
+
+
+<!--                    CUSTOM METADATA MODEL                      -->
+<!--                    Content model for the <custom-meta> element-->
+<!ENTITY % custom-meta-model
+                        "(meta-name, meta-value)"                    >
+
+
+<!--                    CUSTOM METADATA                            -->
+<!--                    Some DTDs and schemas allow for metadata
+                        above and beyond that which can be specified
+                        by this DTD. This element is used to capture
+                        metadata elements that have not been defined
+                        explicitly in the models for this DTD, so
+                        that the intellectual content will not be lost.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=custom-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=custom-meta
+                                                                   -->
+<!ELEMENT  custom-meta  %custom-meta-model;                          >
+<!ATTLIST  custom-meta
+             %custom-meta-atts;                                      >
+
+
+<!--                    METADATA DATA NAME ELEMENTS                -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the <meta-name> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % meta-name-elements
+                        ""                                           >
+
+
+<!--                    METADATA DATA NAME FOR CUSTOM METADATA     -->
+<!--                    The <custom-meta> element
+                        allows for an infinite number of name/value
+                        pairs, with few constraints on the length or
+                        content of the value. This element contains
+                        the name of the metadata field.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=meta-name
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=meta-name
+                                                                   -->
+<!ELEMENT  meta-name    (#PCDATA %meta-name-elements;)*              >
+<!ATTLIST  meta-name
+             %meta-name-atts;                                        >
+
+
+<!--                    METADATA DATA VALUE ELEMENTS               -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the <meta-value> element
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % meta-value-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    METADATA DATA VALUE FOR CUSTOM METADATA    -->
+<!--                    The <custom-meta> element
+                        allows for an infinite number of name/value
+                        pairs, with few constraints on the length or
+                        content of the value. This element contains
+                        the value of the metadata field that is named
+                        by the <meta-name> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=meta-value
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=meta-value
+                                                                   -->
+<!ELEMENT  meta-value   (#PCDATA %meta-value-elements;)*             >
+<!ATTLIST  meta-value
+             %meta-value-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    PROCESSING ALTERNATIVES ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    ALTERNATIVES MODEL                         -->
+<!--                    Model for the <alternatives> processing
+                        alternatives element                       -->
+<!ENTITY % alternatives-model
+                        "(%alternatives-display.class; |
+                          %math.class;)+"                            >
+
+
+<!--                    ALTERNATIVES FOR PROCESSING                -->
+<!--                    Container element used to hold a group of
+                        processing alternatives, for example, a
+                        single logical <graphic> that ships in
+                        different formats (tif, gif, jpeg) or
+                        different resolutions. This element is a
+                        physical grouping to contain multiple
+                        logically equivalent (substitutable) versions
+                        of the same information object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=alternatives
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=alternatives
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=alternatives
+                                                                   -->
+<!ELEMENT  alternatives %alternatives-model;                         >
+<!ATTLIST  alternatives
+             %alternatives-atts;                                     >
+
+
+<!--                    TEXTUAL FORM ELEMENTS                      -->
+<!--                    Model for the <textual-form> element       -->
+<!ENTITY % textual-form-elements
+                        "| %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    TEXTUAL FORM                               -->
+<!--                    Container element (for use only inside
+                        <alternatives>) that will hold text and
+                        mixed content objects that act as alternatives
+                        to, for example, graphics.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=textual-form
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=textual-form
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=textual-form
+                                                                   -->
+<!ELEMENT  textual-form (#PCDATA %textual-form-elements;)*           >
+<!ATTLIST  textual-form
+             %textual-form-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    GENERATED TEXT OR PUNCTUATION              -->
+<!-- ============================================================= -->
+
+
+<!--                    X TEXT ATTRIBUTES                          -->
+<!--                    Attributes for the element <x>             -->
+<!ENTITY % x-atts
+            "%jats-common-atts;                                        
+             content-type
+                        CDATA                             #IMPLIED
+             xml:space ( default | preserve)       #FIXED 'preserve'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    X ELEMENTS                                 -->
+<!--                    Elements for use inside the <x> element    -->
+<!ENTITY % x-elements   ""                                           >
+
+
+<!--                    X - GENERATED TEXT AND PUNCTUATION         -->
+<!--                    A container element to hold punctuation or
+                        other generated text, typically when 1) an
+                        archive decides not to have any text
+                        generated and thus to pre-generate such
+                        things as commas or semicolons between
+                        keywords or 2) when an archive receives text
+                        with <x> tags embedded and wishes to retain
+                        them.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=x
+                                                                   -->
+<!ELEMENT  x            (#PCDATA %x-elements;)*                      >
+<!ATTLIST  x
+             %x-atts;                                                >
+
+
+<!-- ================== End NISO JATS Common (Shared) Elements === -->
+

--- a/publishing/1.1/JATS-default-classes1.ent
+++ b/publishing/1.1/JATS-default-classes1.ent
@@ -1,0 +1,1277 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Default Element Classes Module                    -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.1 20151215//EN"
+Delivered as file "JATS-default-classes1.ent"                      -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             define the default element classes. Classes are   -->
+<!--             OR-groups of elements that are defined together   -->
+<!--             to be used in mixes and in Element Declarations.  -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before all   -->
+<!--             content modules that declare elements, and after  -->
+<!--             the class customization module (if any).          -->
+<!--                                                               -->
+<!-- CONTAINS:   PEs that define the element classes to be used    -->
+<!--             in the JATS DTD Suite modules.                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 32. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 32. ALI (NISO Access and License Indicators)
+     - Added <ali:license_ref> to license-p.class, as 
+       alternatives inside <license>
+     - Created a new class: license.class to hold the new ALI
+       element <ali:free_to_read>, as an alternative to
+       <license> inside <permissions>. 
+
+ 31. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 30. ADDED TO REFERENCES - Added the following elements to 
+     %references.class so that it would be allowed inside all 
+     citation types, product, et al.
+      - conf-acronym
+      - data-title (for citing datasets and parts of datasets)
+      - version (for data and software, similar to edition)
+
+ 29. STATEMENT - Added new statement.class, so that statements
+     can be recursive.
+
+ 28. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+ 27. ADDRESS ELEMENTS IN NEW CLASSES
+      - Added 3 new elements: <city>, <state>, <postal-code>
+          - address.class
+          - address-line.class
+        which adds then to: address, addr-line, add, collab, 
+        conf-loc, corresp, publisher-loc      
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 26. NEW <era> ELEMENT
+     Added <era> to date-parts.class
+
+ 25. NEW CLASSES
+     - def-item.class
+     - def-list.class
+     - list-item.class
+     - ref.class for use in <ref-list>
+     - unstructured-kwd-group.class for use in Green
+
+ 24. NEW CODE ELEMENT- Added <code> to
+      - alternatives-display.class
+      - block-display.class
+      - block-display-noalt.class
+      - floats-display.class
+      - inside-chem-struct-wrap.class      
+      - simple-display.class
+      - simple-display-noalt.class
+      - simple-intable-display.class
+
+ 23. INSTITUTION-WRAP ADDED
+     Added the element <institution-wrap> to the following classes:
+      - address.class
+      - address-line.class
+      - recipient-name.class
+      - references.class
+
+ 18. RUBY
+     - Added <ruby> to emphasis class
+     - Added a face-markup class (all the emphasis class except 
+         <ruby>) for use inside <ruby>
+
+ 17. ADDED NEW CLASSES (for new locations for the elements)
+     - abstract.class
+     - kwd-group.class
+     - institution.class
+     - institution-wrap.class
+     
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 16. CITATION ALTERNATIVES - Added a new element 
+     <citation-alternatives> to the citation.class. The element
+     will hold, for example, a single citation in multiple
+     languages or a single citation tagged as a <mixed-citation>
+     complete with punctuation and spacing and also as an
+     <element-citation> with all punctuation and spacing removed.
+
+ 15. CONTRIBUTOR ID CLASS - Created a new class "contrib-id.class"
+     to hold identifiers for people such as contributors such
+     as <contrib> and <principal-investigator>s. This will hold
+     publishers-specific IDs, ORCIDs, and JST and NII identifiers.
+
+ 14. NESTED KEYWORD CLASS - Created a new class "nested-kwd.class"
+     to hold the kinds of keywords that can be used inside
+     a nested keyword structure.
+     
+ 13. COLLAB CLASS - Created a new class "collab.class" to hold 
+     only the element <collab>, for use in the element
+     <collab-alternatives>.
+
+ 12. COLLABORATION ALTERNATIVES - Added <collab-alternatives> to
+     the name.class and -references.class to allow the
+     <collab-alternatives> element to occur anywhere <collab> 
+     was already used.
+   
+ 11. STANDARDS CLASS - Created a new class "std.class" to hold all
+     the elements inside the <std> element within citations.
+   
+ 10. REFERENCES CLASS - Added <issn-l> to the class.
+   
+  9. NOTHING BUT PARA CLASS - Added a new %nothing-but-para.class;
+     to get rid of PE clashes when the entity %just-para.class; needed
+     to be expanded to include other elements. The nothing-but
+     parameter entity contains <p> and only <p> and should never
+     be changed in a customization. The infelicitously-named PE
+     %just-para.class; can be modified for a customization to include
+     other elements as well.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  8. Updated the DTD-version attribute to "0.4" 
+   
+  7. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  6. NEW CLASS FOR just <alt-text> %small-access.class;
+     Since not everything needs a <long-desc>
+
+  5. ALTERNATIVES - Added <private-char> so that the alternatives
+     wrapper may be used to hold alternative characters, some as
+     <private-char>, some as <textual-form>, some as <graphic>,
+     etc.
+
+  4. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to hold multiple <aff>s that are representations of a single
+     affiliation, for example, the name of an institution in two
+     languages or two scripts.
+      -  contrib-info.class
+      -  person-group-info.class
+      -  Made a new class %aff-alternatives.class to hold just
+         <aff> and <aff-alternatives> NEW PE
+
+  3. NAME ALTERNATIVES - Added a new container element to hold
+     alternate versions of a person's name, for example:
+       -  a Roman alphabet transliteration, the Japanese characters,
+          and the Japanese with Ruby annotations or
+       -  the full peerage title of a person as well as a name
+          that is just surname and given names
+       -  a name and a sort version of the name that transliterates
+          the diacritics (such as cedillas and umlauts) to the same
+          character with no diacritic.
+     a. This structure was added to %name.class;
+     b. This structure was added to %investigator-name.class;
+     c. This structure was added to %recipient-name.class;
+     d. This structure was added to %references.class;
+
+  2. ROLE - Added <role> to %person-group-info.class; thereby
+     adding it to: <person-group> and <sig-block>
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    CLASSES FOR COMMON ELEMENTS (%common.ent;) -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS CLASS ELEMENTS                     -->
+<!--                    Potential element components of an address;
+                        not a proper class                         -->
+<!ENTITY % address.class
+                        "addr-line | city | country | fax |
+                         institution | institution-wrap | phone |
+                         postal-code | state"                        >
+
+
+<!--                    ADDRESS LINE CLASS ELEMENTS                -->
+<!--                    Potential element components of an address;
+                        line not a proper class                    -->
+<!ENTITY % address-line.class
+                        "city | country | fax | institution | 
+                         institution-wrap | phone |
+                         postal-code | state"                        >
+
+
+<!--                    CITATION CLASS ELEMENTS                    -->
+<!--                    Reference to an external document, as used
+                        within, for example, the text of a
+                        paragraph                                  -->
+<!ENTITY % citation.class
+                        "citation-alternatives | element-citation | 
+                         mixed-citation"                             >
+
+
+<!--                    CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+<!--                    All the citation elements except the
+                        <citation-alternatives> element.           -->
+<!ENTITY % citation-minus-alt.class
+                        "element-citation | mixed-citation | 
+                         nlm-citation"                               >
+
+
+<!--                    DEFINITION CLASS ELEMENTS                  -->
+<!--                    Definitions and other elements to match
+                        with terms and abbreviations               -->
+<!ENTITY % def.class    "def"                                        >
+
+
+<!--                    DEGREE CLASS                               -->
+<!--                    The academic or professional degrees that
+                        accompany a person's name                  -->
+<!ENTITY % degree.class "degrees"                                    >
+
+
+<!--                    IDENTIFIER CLASS ELEMENTS                  -->
+<!--                    DOIs and other identifiers are used by
+                        publishers at many levels, for example for
+                        an <abstract> or a <fig>.                  -->
+<!ENTITY % id.class     "object-id"                                  >
+
+
+<!--                    LABEL CLASS                                -->
+<!--                    The label element, used to hold the number
+                        or character of a labeled object such as a
+                        table or footnote                          -->
+<!ENTITY % label.class  "label"                                      >
+
+
+<!--                    NOTE CLASS ELEMENTS                        -->
+<!--                    A note may appear at the end of an Article
+                        or at the end of a Table.  For example, a
+                        typical end-of-article note is a
+                        "Note in Proof".                           -->
+<!ENTITY % note.class   "note"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    PERSON NAMING ELEMENTS (%common.ent;)      -->
+<!-- ============================================================= -->
+
+
+<!--                    COLLAB CLASS                               -->
+<!--                    A class to hold the <collab> element, so that
+                        more than on collaboration can be named 
+                        inside <collab-alternatives>.              -->
+<!ENTITY % collab.class "collab"                                     >
+
+
+<!--                    INVESTIGATOR NAMES CLASS                   -->
+<!--                    The elements used to name the personal names
+                        for principal investigators.               -->
+<!ENTITY % investigator-name.class
+                        "name | name-alternatives | string-name"     >
+
+
+<!--                    NAMES ALTERNATIVES CLASS                   -->
+<!--                    Elements that may contain the name of a
+                        person. These elements act as alternatives
+                        inside the <name-alternatives> wrapper, to
+                        allow multiple versions of one person's name
+                        to be included. These variants are
+                        differentiated by attributes: @xml:lang for
+                        language, region, language variant, etc. and
+                        @specific-use for indexing names,
+                        search names, etc.                         -->
+<!ENTITY % name-alternatives.class
+                        "name | string-name"                         >
+
+
+<!--                    NAMES CLASS                                -->
+<!--                    The elements used to name the personal names
+                        for individuals and the collaboration names
+                        for groups.                                -->
+<!ENTITY % name.class   "anonymous | collab | collab-alternatives |
+                         name | name-alternatives | string-name"     >
+                         
+
+
+<!--                    PERSONAL NAMES CLASS                       -->
+<!--                    The element components of a person's name,
+                        for the name of a contributor              -->
+<!ENTITY % person-name.class
+                        "degrees | given-names | prefix | surname |
+                         suffix"                                     >
+
+
+<!--                    STRING NAME CLASS                          -->
+<!--                    The element <string-name> is most useful
+                        inside citations, but some tag sets restrict
+                        its use in metadata. A one-element class.  -->
+<!ENTITY % string-name.class
+                        "string-name"                                >
+
+
+<!--                    RECIPIENT NAMES CLASS                      -->
+<!--                    The elements used to name the personal names
+                        or corporate names (such as Labs) for
+                        funded award recipients                    -->
+<!ENTITY % recipient-name.class
+                        "name | name-alternatives | institution |
+                         institution-wrap | string-name"             >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA CONTRIBUTOR CLASSES;      -->
+<!-- ============================================================= -->
+
+
+<!--                    CONTRIBUTOR CLASS                          -->
+<!--                    Sometimes only the <contrib> element needs to
+                        be added to a model. Used mostly in the
+                        model for <contrib-group>.                 -->
+<!ENTITY % contrib.class
+                        "contrib"                                    >
+
+
+<!--                    CONTRIBUTOR GROUP CLASS                    -->
+<!--                    Sometimes only the <contrib-group> element
+                        needs to be added to a model.              -->
+<!ENTITY % contrib-group.class
+                        "contrib-group"                              >
+
+
+<!--                    CONTRIBUTOR IDENTIFIER CLASS               -->
+<!--                    Names the class to hold unique
+                        person identifiers, such as an ORCID or
+                        a trusted publisher identifier.            -->
+<!ENTITY % contrib-id.class
+                        "contrib-id"                                 >
+
+
+<!--                    CONTRIBUTOR INFORMATION CLASS              -->
+<!--                    Metadata about a contributor               -->
+<!ENTITY % contrib-info.class
+                        "address | aff | aff-alternatives |
+                         author-comment | bio | email |  etal |
+                         ext-link | on-behalf-of | role | uri | xref">
+
+
+<!--                    CONTRIBUTOR INFORMATION FOR REFERENCES     -->
+<!--                    The additions and alternatives to a person's
+                        name that may be used inside the element
+                        <person-group>                             -->
+<!ENTITY % person-group-info.class
+                        "aff | aff-alternatives | etal | role"       >
+
+
+<!-- ============================================================= -->
+<!--                    ARTICLE METADATA CLASSES %articlemeta.ent; -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT CLASS ELEMENTS                    -->
+<!--                    Potential element components of an address;
+                        not a proper class                         -->
+<!ENTITY % abstract.class
+                        "abstract"                                   >
+
+
+<!--                    AFFILIATIONS ALTERNATIVES CLASS            -->
+<!--                    The <aff> and <aff-alternatives> elements only
+                                                                   -->
+<!ENTITY % aff-alternatives.class
+                        "aff | aff-alternatives"                     >
+
+
+<!--                    CONFERENCE CLASS                           -->
+<!--                    The element components of the description
+                        of a conference; not a proper class        -->
+<!ENTITY % conference.class
+                        "conf-date | conf-name | conf-num |
+                         conf-loc | conf-sponsor | conf-theme |
+                         conf-acronym | string-conf"                 >
+
+
+<!--                    CORRESPONDING AUTHOR CLASS                 -->
+<!--                    Elements associated with the corresponding
+                        author                                     -->
+<!ENTITY % corresp.class
+                        "corresp"                                    >
+
+
+<!--                    DATE CLASS ELEMENTS                        -->
+<!--                    Dates and other matters of history         -->
+<!ENTITY % date.class   "date | string-date"                         >
+
+
+<!--                    DATE PARTS CLASS ELEMENTS                  -->
+<!--                    Components of date-style elements          -->
+<!ENTITY % date-parts.class
+                        "day | era | month | season | year"          >
+
+
+<!--                    INSTITUTION CLASS ELEMENTS                 -->
+<!--                    To hold an <institution> and its
+                        identifiers, so you always can use both
+                        together.                                  -->
+<!ENTITY % institution.class
+                        "institution | institution-id"               >
+
+
+<!--                    INSTITUTION CLASS ELEMENTS                 -->
+<!--                    To allow both of the institution elements to 
+                        be used anywhere one of them might be needed.
+                                                                   -->
+<!ENTITY % institution-wrap.class
+                        "institution | institution-wrap"             >
+
+
+<!--                    JOURNAL IDENTIFIER CLASS ELEMENTS          -->
+<!--                    The <journal-id> element and any synonyms.
+                        Created for use inside <related-article>.  -->
+<!ENTITY % journal-id.class
+                        "journal-id"                                 >
+
+
+<!--                    KEYWORD CLASS ELEMENTS                     -->
+<!--                    Keywords and any keyword-synonyms          -->
+<!ENTITY % kwd.class    "kwd | compound-kwd | nested-kwd"            >
+
+
+<!--                    KEYWORD GROUP CLASS ELEMENTS               -->
+<!--                    The element <kwd-group> for use in models. -->
+<!ENTITY % kwd-group.class    
+                        "kwd-group"                                  >
+
+
+<!--                    LICENSE CLASS ELEMENTS                     -->
+<!--                    The alternatives to <license> that may live
+                        inside <permissions>.                      -->
+<!ENTITY % license.class    
+                        "ali:free_to_read | license"                 >
+
+
+<!--                    LICENSE PARAGRAPH CLASS ELEMENTS           -->
+<!--                    To hold the paragraphs and license
+                        references that may be inside the element
+                        <license>.                                 -->
+<!ENTITY % license-p.class
+                        "ali:license_ref | license-p"                >
+
+
+<!--                    NESTED KEYWORD CLASS ELEMENTS              -->
+<!--                    The kinds of keywords that can be used inside
+                        a nested keyword structure.                -->
+<!ENTITY % nested-kwd.class    
+                        "kwd | compound-kwd"                         >
+
+
+<!--                    TITLE CLASS                                -->
+<!--                    Title metadata element that can be used
+                        to provide article-like metadata about
+                        other objects, for example a <supplement>  -->
+<!ENTITY % title.class  "title"                                      >
+
+
+<!--                    UNSTRUCTURED KEYWORD GROUP CLASS           -->
+<!--                    The <unstructured-kwd-group> element for use 
+                        by itself.                                 -->
+<!ENTITY % unstructured-kwd-group.class  
+                        "unstructured-kwd-group"                     >
+
+
+<!--                    STRING DATE CLASS                          -->
+<!--                    The <string-date> element for use by itself.
+                                                                   -->
+<!ENTITY % string-date.class  
+                        "string-date"                                >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER CLASSES (%backmatter.ent;)     -->
+<!-- ============================================================= -->
+
+
+<!--                    JUST APPENDIX CLASS                        -->
+<!--                    The appendix and only the appendix         -->
+<!ENTITY % app.class    "app"                                        >
+
+
+<!--                    BACK MATTER CLASS                          -->
+<!--                    Ancillary elements, typically used in the
+                        back matter of an article, section, etc.   -->
+<!ENTITY % back.class   "ack | app-group | bio | fn-group |
+                         glossary |  ref-list"                       >
+
+
+<!--                    FRONT MATTER CLASS                         -->
+<!--                    Ancillary elements, typically used in the
+                        front matter of an article, book, etc.  .  -->
+<!ENTITY % front.class  "ack | bio | fn-group | glossary"            >
+
+
+<!--                    FRONT AND BACK CLASS                       -->
+<!--                    Ancillary elements, typically used in the
+                        front or back matter of an article         -->
+<!ENTITY % front-back.class
+                        "notes"                                      >
+
+
+<!--                    SECTION BACK MATTER CLASS                  -->
+<!--                    Ancillary elements, typically used in the
+                        back matter of a section, etc.             -->
+<!ENTITY % sec-back.class
+                        "fn-group | glossary |  ref-list"            >
+
+
+<!--                    JUST SIGNATURE CLASS                       -->
+<!--                    The signature and only the signature <sig>
+                        for use inside <sig-block>s                -->
+<!ENTITY % sig.class    "sig"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    CLASSES USED IN DISPLAY ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESSIBILITY CLASS ELEMENTS               -->
+<!--                    Elements added to make it easier to process
+                        journal articles in ways that are more
+                        accessible to people and devices with special
+                        needs, for example the visually handicapped.
+                          <alt-text> is a short phrase description of
+                        an objects, <long-desc> is a more complete
+                        description of the content or intent of an
+                        object.                                    -->
+<!ENTITY % access.class "alt-text | long-desc"                       >
+
+
+<!--                    SMALL ACCESSIBILITY CLASS ELEMENTS         -->
+<!--                    Elements added to make it easier to process
+                        journal articles in ways that are more
+                        accessible to people and devices with special
+                        needs, for example the visually handicapped.
+                          <alt-text> is a short phrase description of
+                        an objects. This class is for use when
+                        <long-desc> is just too much.              -->
+<!ENTITY % small-access.class
+                        "alt-text"                                   >
+
+
+<!--                    CAPTION DISPLAY ELEMENTS                   -->
+<!--                    Basic figure display elements              -->
+<!ENTITY % caption.class
+                        "caption"                                    >
+
+
+<!--                    DISPLAY ELEMENT BACK MATTER ELEMENTS       -->
+<!--                    Miscellaneous stuff (such as photo credits or
+                        copyright statement) at the end of a display
+                        element such as a figure or a boxed text
+                        element such as a sidebar.                 -->
+<!ENTITY % display-back-matter.class
+                        "attrib | permissions"                       >
+
+
+<!-- ============================================================= -->
+<!--                    DISPLAY ELEMENTS CLASSES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY CLASS ELEMENTS                     -->
+<!--                    Graphical or other image-related elements.
+                        The display elements may occur within
+                        the text of a table cell or paragraph
+                        although they are typically at the same
+                        hierarchical level as a paragraph.         -->
+<!ENTITY % block-display.class
+                        "address | alternatives | array |
+                         boxed-text | chem-struct-wrap | code | 
+                         fig | fig-group | graphic | media |
+                         preformat | supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!ENTITY % block-display-noalt.class
+                        "address | array |
+                         boxed-text | chem-struct-wrap | code | 
+                         fig | fig-group | graphic | media |
+                         preformat | supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!--                    FLOATING DISPLAY CLASS ELEMENTS            -->
+<!--                    Block display elements that can take the
+                        position attribute, and thus may be floating
+                        as opposed to fixed in narrative position in
+                        an article. Created for use as the content
+                        of <floats-group>.                         -->
+<!ENTITY % floats-display.class
+                        "alternatives | boxed-text |
+                         chem-struct-wrap | code | fig | fig-group |
+                         graphic | media | preformat |
+                         supplementary-material |
+                         table-wrap | table-wrap-group"              >
+
+
+<!--                    FIGURE DISPLAY ELEMENTS                    -->
+<!--                    Basic figure display elements              -->
+<!ENTITY % fig-display.class
+                        "fig"                                        >
+
+
+<!--                    INLINE DISPLAY CLASS ELEMENTS              -->
+<!--                    Non-block display elements that set or
+                        display inline with the text               -->
+<!ENTITY % inline-display.class
+                        "alternatives | inline-graphic |
+                         private-char"                               >
+
+
+<!ENTITY % inline-display-noalt.class
+                        "inline-graphic | private-char"              >
+
+
+<!--                    MOST BASIC DISPLAY ELEMENTS                -->
+<!--                    Just the few display elements that are
+                        simple display objects: a picture, a movie,
+                        a sound file.                              -->
+<!ENTITY % just-base-display.class
+                        "alternatives | graphic | media"             >
+
+
+<!ENTITY % just-base-display-noalt.class
+                        "graphic | media"                            >
+
+
+<!--                    SIMPLE DISPLAY ELEMENTS                    -->
+<!--                    The simplest and most basic of the Display
+                        Class elements, which may be allowed in many
+                        places, for example, inside other Display
+                        Class elements or inside the cell of a
+                        Table                                      -->
+<!ENTITY % simple-display.class
+                        "alternatives | array | code | graphic | 
+                         media | preformat"                          >
+
+
+<!ENTITY % simple-display-noalt.class
+                        "array | code | graphic | media | preformat" >
+
+<!--                    SIMPLE TABLE DISPLAY ELEMENTS              -->
+<!--                    Very similar to the simple-display.class, but
+                        Table Wrappers <table-wrap> should contain
+                        <table>s, <oasis:table>s, etc., not
+                        arrays.                                    -->
+<!ENTITY % simple-intable-display.class
+                        "alternatives | chem-struct-wrap | code |
+                         graphic | media | preformat"                >
+
+
+<!--                    INSIDE CHEMICAL STRUCTURE ELEMENTS         -->
+<!--                    Very similar to the simple-display.class, but
+                        for use inside <chem-struct-wrap>, so it
+                        can contain both <chem-struct> and
+                        <textual-form>                             -->
+<!ENTITY % inside-chem-struct-wrap.class
+                        "alternatives | chem-struct | code | graphic |
+                         media | preformat | textual-form"           >
+
+
+<!--                    ALTERNATIVES DISPLAY CLASS ELEMENTS        -->
+<!--                    Display elements that can be alternatives to
+                        each  other inside an alternatives element.
+                                                                   -->
+<!ENTITY % alternatives-display.class
+                        "array | chem-struct | code | graphic |
+                         inline-graphic |
+                         inline-supplementary-material |
+                         media | preformat |private-char |
+                         supplementary-material | table |
+                         textual-form"                               >
+
+
+<!-- ============================================================= -->
+<!--                    MATH CLASSES (%math.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHEMATICAL EXPRESSIONS AND FORMULAE
+                        CLASS ELEMENTS                             -->
+<!ENTITY % block-math.class
+                        "disp-formula | disp-formula-group"          >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER CLASS           -->
+<!ENTITY % chem-struct-wrap.class
+                        "chem-struct-wrap"                           >
+
+
+<!--                    INLINE MATHEMATICAL EXPRESSIONS MIX CLASS
+                        ELEMENTS                                   -->
+<!ENTITY % inline-math.class
+                        "chem-struct | inline-formula"               >
+
+
+<!--                    MATHEMATICAL EXPRESSIONS CLASS ELEMENTS    -->
+<!ENTITY % math.class   "tex-math | mml:math"                        >
+
+
+<!--                    SIMPLE MATHML CLASS                        -->
+<!ENTITY % simple-math.class
+                        "mml:math"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    FORMAT CLASSES (%format.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    APPEARANCE CLASS ELEMENTS                  -->
+<!--                    Names those elements (inherited from the
+                        XHTML table DTD that are only concerned with
+                        appearance, not with structure or content.
+                        Use of these elements is to be discouraged.-->
+<!ENTITY % appearance.class
+                        "hr"                                         >
+
+
+<!--                    FORCED BREAK FORMATTING CLASS ELEMENTS     -->
+<!--                    Element to force a formatting break such as
+                        a line break                               -->
+<!ENTITY % break.class  "break"                                      >
+
+
+<!--                    EMPHASIS/RENDITION ELEMENTS                -->
+<!--                    Elements concerning with marking the location
+                        of typographical emphasis (highlighting)
+                        DTD Design Note: There are no emphasis
+                        elements for <fractur>, <openface> (black
+                        board), <script>, etc. because this DTD
+                        recommends the use of the STIX extensions
+                        to accomplish this, as soon as they are
+                        available.                                 -->
+<!ENTITY % emphasis.class
+                        "bold | fixed-case | italic | monospace |
+                         overline | overline-start | overline-end |
+                         roman | sans-serif | sc | strike |
+                         underline | underline-start | 
+                         underline-end |
+                         ruby"                                       >
+
+
+<!--                    FACE MARKUP ELEMENTS                       -->
+<!--                    All of the emphasis/rendition elements
+                        except <ruby>, for use (initially) inside
+                        <ruby> itself.                             -->
+<!ENTITY % face-markup.class
+                        "bold | fixed-case | italic | monospace |
+                         overline | overline-start | overline-end |
+                         roman | sans-serif | sc | strike |
+                         underline | underline-start | 
+                         underline-end"                              >
+
+
+<!--                    UP/DOWN RENDITION ELEMENTS                 -->
+<!ENTITY % subsup.class "sub | sup"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    LINK CLASSES (%link.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    ADDRESS LINK CLASS ELEMENTS                -->
+<!--                    Link elements that can be used inside
+                        addresses. This is essentially the three
+                        generic external links.
+                        (Note: in earlier releases, this Parameter
+                        Entity was named %address-elements;,
+                        although it functioned as a class.)        -->
+<!ENTITY % address-link.class
+                        "email | ext-link | uri"                     >
+
+
+
+<!--                    SIMPLE LINKS/CROSS-REFERENCES CLASS        -->
+<!--                    The smaller and simpler linking elements
+                        that might be inside, for example, a
+                        Keyword <kwd>                              -->
+<!ENTITY % simple-link.class
+                        "fn | target | xref"                         >
+
+
+<!--                    CROSS-REFERENCES CLASS                     -->
+<!--                    A class just to hold <xref>.               -->
+<!ENTITY % xref.class   "xref"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    FOOTNOTE CLASSES (%link.ent;)              -->
+<!-- ============================================================= -->
+
+<!--                    FOOTNOTE LINKS CLASS                       -->
+<!--                    Only the most basic, internal links        -->
+<!ENTITY % fn-link.class
+                        "fn"                                         >
+
+
+<!--                    FOOTNOTE GROUP CLASS                       -->
+<!--                    Collections of footnotes                   -->
+<!ENTITY % fn-group.class
+                        "fn-group"                                   >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED-OBJECT CLASSES                     -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL ARTICLE LINK CLASS ELEMENTS        -->
+<!--                    Links used inside journal articles, to point
+                        to related material                        -->
+<!ENTITY % article-link.class
+                        "inline-supplementary-material |
+                         related-article | related-object"           >
+
+
+<!--                    RELATED ARTICLE LINKS CLASS                -->
+<!--                    For using <related-article> at the paragraph
+                        level                                      -->
+<!ENTITY % related-article.class
+                        "related-article  | related-object"          >
+
+
+<!-- ============================================================= -->
+<!--                    LIST CLASSES (%list.ent;)                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST CLASS ELEMENT              -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % def-list.class   
+                        "def-list"                                   >
+
+
+<!--                    DEFINITION LIST ITEM CLASS ELEMENT         -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % def-item.class   
+                        "def-item"                                   >
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+<!--                    All the types of lists that may occur
+                        as part of the text, therefore excluding
+                        Bibliographic Reference Lists <ref-list>   -->
+<!ENTITY % list.class   "def-list | list"                            >
+
+
+<!--                    LIST ITEM CLASS ELEMENT                    -->
+<!--                    Class for the <list-item>, so it may be used
+                        in OR groups.                              -->
+<!ENTITY % list-item.class   
+                        "list-item"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH CLASSES (%para.ent;)             -->
+<!-- ============================================================= -->
+
+
+<!--                    REST OF PARAGRAPH CLASS                    -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Paragraph.
+                        Contains all paragraph-level objects that are
+                        not also used inside tables and excepting
+                        also the paragraph element itself          -->
+<!ENTITY % rest-of-para.class
+                        "ack | disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!--                    IN TABLE PARAGRAPH CLASS                   -->
+<!--                    The simpler of the paragraph-level elements
+                        that might be found inside a table cell    -->
+<!ENTITY % intable-para.class
+                        "disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!--                    JUST PARAGRAPH CLASS                       -->
+<!--                    Set by default to hold the just the Paragraph 
+                        element, alone. This parameter entity may
+                        be redefined by a customization to name any
+                        element(s) that the Tag Set wishes to be
+                        able to use anywhere within textual elements
+                        that a paragraph may occur. Such elements
+                        would also need to be added to the PE
+                        %block-display.class; and to some individual
+                        element PEs.                               -->
+<!ENTITY % just-para.class
+                        "p"                                          >
+
+
+<!--                    NOTHING BUT PARAGRAPH CLASS                -->
+<!--                    To hold the paragraph element <p>, alone.
+                        This parameter entity should be left
+                        untouched by any customization             -->
+<!ENTITY % nothing-but-para.class
+                        "p"                                          >
+
+
+<!--                    STATEMENT CLASS                            -->
+<!--                    To hold the paragraph element <statement>, 
+                        alone.                                     -->
+<!ENTITY % statement.class
+                        "statement"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    PHRASE CLASSES (%phrase.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    FUNDING CLASS ELEMENTS                     -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text to identify pieces of
+                        funding metadata. where such material is not
+                        pulled out separately but just mixed into
+                        text as phrases or sentences within a
+                        paragraph. These elements may be used to mark,
+                        for example, the <award-id> (such as a grant
+                        number or contract number) or the
+                        <funding-source> such as the sponsoring
+                        organization or trust that awarded the grant.
+                                                                   -->
+<!ENTITY % funding.class
+                        "award-id | funding-source | open-access"    >
+
+
+<!--                    PHRASE CLASS ELEMENTS                      -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text because the subject
+                        (content) should be identified as something
+                        special or different                       -->
+<!ENTITY % phrase.class "abbrev | milestone-end | milestone-start |
+                         named-content | styled-content"             >
+
+
+<!--                    STYLED CONTENT CLASS ELEMENTS              -->
+<!--                    The <styled-content> element alone, so it
+                        can be used in places where emphasis is used.
+                                                                   -->
+<!ENTITY % styled-content.class
+                        "styled-content"                             >
+
+
+<!--                    PHRASE CONTENT CLASS ELEMENTS              -->
+<!--                    Small inline elements, that surround a word
+                        or phrase in the text because the subject
+                        (content) should be identified as something
+                        special or different. This class in is
+                        intended to be a subset of the  Phrase Class,
+                        for use in restricted situations, such as
+                        within metadata paragraphs, to record
+                        publisher-identified semantic or usage
+                        material.                                  -->
+<!ENTITY % phrase-content.class
+                        "named-content | styled-content"             >
+
+
+<!--                    PRICE CLASS ELEMENTS                       -->
+<!--                    Created to hold the <price> element so that
+                        it can be selectively added to elements,
+                        initially to <product>.                    -->
+<!ENTITY % price.class  "price"                                      >
+
+
+<!--                    PRODUCT ELEMENTS                           -->
+<!--                    Created to hold the <product> element so that
+                        it can be selectively added to elements,
+                        initially to <note>.                       -->
+<!ENTITY % product.class
+                        "product"                                    >
+
+
+<!-- ============================================================= -->
+<!--                    REFERENCES CLASSES (references.ent)        -->
+<!-- ============================================================= -->
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION) CLASS   -->
+<!--                    The elements that may be included inside a
+                        citation (bibliographic reference), either
+                        in an all-element-content (<element-citation>)
+                        or in a mixed-content citation
+                        (<mixed-citation>).                        -->
+<!ENTITY % references.class
+                        "annotation | article-title | chapter-title |
+                         collab | collab-alternatives |comment | 
+                         conf-acronym | conf-date | conf-loc | 
+                         conf-name | conf-sponsor | 
+                         data-title | date | date-in-citation | 
+                         day | edition |  email | elocation-id |  
+                         etal | ext-link | fpage |
+                         gov | institution | institution-wrap |
+                         isbn | issn | issn-l | 
+                         issue | issue-id | issue-part | issue-title |
+                         lpage | month | name | name-alternatives |
+                         object-id | page-range | part-title |
+                         patent | person-group | pub-id |
+                         publisher-loc | publisher-name | role |
+                         season | series | size | source | std |
+                         string-name | supplement |
+                         trans-source | trans-title | uri | version |
+                         volume | volume-id | volume-series | year"  >
+
+
+<!--                    JUST REFERENCE-LIST CLASS                  -->
+<!--                    The reference list and only the reference
+                        list                                       -->
+<!ENTITY % ref-list.class
+                        "ref-list"                                   >
+
+
+<!--                    STANDARDS CLASS                            -->
+<!--                    The elements that can be used in the mixed
+                        content model of a <std>, which is a
+                        cited standard inside a citation:
+                          source contains the name of the standard
+                          pub-id contains the standard designator
+                          date elements name the official date
+                          std-organization names the standards body
+                          named-content takes anything else a 
+                            publisher/archive needs (come in 
+                            from %rendition-plus.                  -->
+<!ENTITY % std.class    "day | month | pub-id | source | 
+                         std-organization | year"                    >
+
+
+<!--                    JUST REFERENCE CLASS                       -->
+<!--                    The element <ref> for use in models.       -->
+<!ENTITY % ref.class    "ref"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    SECTION CLASS (%section.ent;)              -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION CLASS ELEMENTS                     -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Section, which is
+                        a headed structure full of smaller elements
+                        such as paragraphs.                        -->
+<!ENTITY % sec.class    "sec"                                        >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE MODEL CLASSES                        -->
+<!-- ============================================================= -->
+
+
+<!--                    JUST TABLE CLASS                           -->
+<!--                    To include just a table <table-wrap>
+                        element                                    -->
+<!ENTITY % just-table.class
+                        "table-wrap"                                 >
+
+
+<!--                    TABLE CLASS ELEMENTS                       -->
+<!--                    Elements that will be used to contain the
+                        rows and columns inside the Table Wrapper
+                        element <table-wrap>.  The following elements
+                        can be set up for inclusion:
+                          XHTML Table Model    table               -->
+<!ENTITY % table.class  "table"                                      >
+
+
+<!--                    TABLE FOOT CLASS                           -->
+<!--                    Elements to include at the end of a table
+                        in the table.                              -->
+<!ENTITY % table-foot.class
+                        "table-wrap-foot"                            >
+
+
+<!--                    TABLE BODY CLASS                           -->
+<!--                    To include just a table <table-wrap>
+                        element                                    -->
+<!ENTITY % tbody.class  "tbody"                                      >
+
+
+<!-- ================== End Journal Suite Default Classes  ======= -->

--- a/publishing/1.1/JATS-default-mixes1.ent
+++ b/publishing/1.1/JATS-default-mixes1.ent
@@ -1,0 +1,455 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Default Element Mixes Module                      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.1 20151215//EN"
+Delivered as file "JATS-default-mixes1.ent"                        -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Declares default values for all the element mixes -->
+<!--             used in the content models of the DTD Suite       -->
+<!--                                                               -->
+<!--             Mixes are Or-groups of classes, used in many      -->
+<!--             different content models. Mixes should not use    -->
+<!--             element names directly, only through classes.     -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called after the    -->
+<!--             customize mixes module (if any).                  -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             August 2004                                       -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+    
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. PARAGRAPH IN TABLE CELL - Added <p> to the contents of
+     table cells, through %inside-cell; (using
+     %nothing-but-para.class;).
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. PARA-LEVEL PARAMETER ENTITY CONFLICT - Changed the parameter
+     entity %para-level; to use the PE %nothing-but-para.class;,
+     removing the similar PE "just-para.class;". It is possible to 
+     add element(s) to %just-para.class;, so that the added element(s)
+     may be used everywhere <p> is used. Such elements would also be
+     named in %block-display.class;. This would lead to a conflict
+     in %para-level; if both %just-para.class; and
+     %block-display.class; named <p>. So %just-para.class; is replaced
+     here in %para-level;. This is backward compatible for all XML
+     documents. If a JATS customization has modified %just-para.class;
+     they may need to change their customization to accommodate.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ELEMENT MIXES FOR USE IN CONTENT MODELS    -->
+<!--                    (MIXES ARE COMPOSED USING CLASSES)         -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION-LEVEL ELEMENTS                     -->
+<!--                    Elements that may be used at the same
+                        structural level as a Section for example
+                        inside the Body <body>                     -->
+<!ENTITY % sec-level    "%sec.class;"                                >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENT MIXES(%backmatter.ent;)-->
+<!-- ============================================================= -->
+
+
+<!--                    DOCUMENT BACK MATTER ELEMENTS              -->
+<!--                    Back Matter Elements used by a full document
+                        such as a journal article. This is an element
+                        grouping rather than a class. These
+                        elements may also appear in the content models
+                        of structural elements, such as back matter.
+                        (Note: Technically this should have used
+                        %sec.class;, but %sec-level; was used in an
+                        earlier release and backwards compatibility
+                        must be maintained.                        -->
+<!ENTITY % doc-back-matter-mix
+                        "%back.class; | %front-back.class; |
+                         %sec.class;"                                >
+
+
+<!--                    SECTION BACK MATTER ELEMENTS               -->
+<!--                    Back matter elements used inside smaller
+                        structures, such as sections and sidebars  -->
+<!ENTITY % sec-back-matter-mix
+                        "%front-back.class; | %sec-back.class;"      >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH-LEVEL ELEMENT MIXES              -->
+<!-- ============================================================= -->
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!--                    Elements that may be used at the same
+                        structural level as a paragraph, for
+                        example inside a Section
+                        Note: There a major overlap between this
+                        parameter entity and that for the elements
+                        that are at the same level as a paragraph.
+                        Inline elements appear only inside a
+                        paragraph, but block elements such as quotes
+                        and lists may appear either within a
+                        paragraph or at the same level as a
+                        paragraph. This serves a requirement in a
+                        repository DTD, since some incoming material
+                        will have restricted such elements to only
+                        inside a paragraph,  some incoming material
+                        will have restricted them to only outside a
+                        paragraph and some may allow them in both
+                        places. Thus the DTD must allow for them to
+                        be in either or both.                      -->
+<!ENTITY % para-level   "%block-display.class; | %block-math.class; |
+                         %list.class; | %math.class; | 
+                         %nothing-but-para.class; | 
+                         %related-article.class; |
+                         %rest-of-para.class;"                       >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ELEMENT MIXES                        -->
+<!-- ============================================================= -->
+
+
+<!--                    INSIDE TABLE CELL ELEMENTS                 -->
+<!--                    Mixed with #PCDATA inside a table cell, such
+                        as a <td> or <th> element in the XHTML table
+                        model, the <entry> element in the OASIS CALS
+                        table model, etc.  This PE will be used as the
+                        value of %Flow.mix;, %paracon;, etc.
+                        ### Usage Alert ###
+                        Design Note: Inside cell is an exception, an
+                        inline mix that does not start with an OR
+                        bar. This is because is used within the
+                        PE -%Flow.mix;, which is an inline mix
+                        defined in the course of the XHTML Table DTD,
+                        a DTD not under control of this DTD Suite. -->
+<!ENTITY % inside-cell  "%address-link.class; |  %appearance.class; |
+                         %article-link.class; |
+                         %block-math.class; | %break.class; |
+                         %citation.class; | %emphasis.class; |
+                         %inline-math.class; |
+                         %list.class; | %math.class; |
+                         %nothing-but-para.class; |
+                         %phrase.class; | %simple-display.class; |
+                         %inline-display-noalt.class; |
+                         %simple-link.class; | %subsup.class;"       >
+
+
+<!--                    INSIDE TABLE WRAPPER ELEMENTS              -->
+<!--                    Usually a Table Wrapper contains a table,
+                        properly tagged with rows and columns, but
+                        sometimes, a structure that is labeled as
+                        a "table" is actually a list, or two
+                        paragraphs.  This Parameter Entity names
+                        all the alternatives to table that may
+                        occur inside a table wrapper.              -->
+<!ENTITY % inside-table-wrap
+                        "%intable-para.class; | %list.class; |
+                         %simple-intable-display.class;  |
+                         %table.class;"                              >
+
+
+<!-- ============================================================= -->
+<!--                    INLINE ELEMENT MIXES                       -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS MIX ELEMENTS                      -->
+<!--                    Elements that may be used inside most of the
+                        emphasis class elements
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % emphasized-text
+                        "| %address-link.class; |
+                         %article-link.class; | %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    JUST RENDITION                             -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be stripped down to only
+                        subscript and superscript by some, more
+                        restrictive DTDs.
+                        MAINTENANCE NOTE: This Parameter Entity
+                        and the related PE "rendition-plus" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to change similar models individually .
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % just-rendition
+                        "| %emphasis.class;  | %subsup.class; |
+                         %phrase-content.class;"                     >
+
+
+<!--                    RENDITION MARKUP PLUS                      -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be enhanced slightly in some
+                        more permissive DTDs, and should always
+                        contain at least typographic emphasis,
+                        subscript, and superscript.
+                        MAINTENANCE NOTE:: This Parameter Entity
+                        and the related PE "just-rendition" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to individually change similar models.
+                        modify entire groups of elements, but not
+                        to change similar models individually .
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % rendition-plus
+                        "| %emphasis.class;  | %subsup.class; |
+                         %phrase-content.class;"                     >
+
+
+<!--                    SIMPLE PHRASE-LEVEL TEXTUAL ELEMENTS       -->
+<!--                    Elements that may be used almost anywhere
+                        text is used, for example, inside a title.
+                        Simple text plus inline display and math
+                        elements. In practice, This is the next step
+                        up from "simple-text", adding the links.
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % simple-phrase
+                        "| %address-link.class; |
+                         %article-link.class; | %emphasis.class; |
+                         %inline-display.class; |
+                         %inline-math.class; | %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    SIMPLE TEXTUAL CONTENT                     -->
+<!--                    Elements that may be used inside elements
+                        that are really expected to be #PCDATA and
+                        not to contain any of these things.
+                        Note that there is only inline math and no 
+                        links.
+                        Simpler even than %simple-phrase;
+                        Design Note: Inline mixes begin with an
+                        OR bar                                     -->
+<!ENTITY % simple-text  "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %phrase.class; |
+                         %subsup.class; "                            >
+
+
+<!-- ================== End Archiving DTD Mixes Customization ==== -->

--- a/publishing/1.1/JATS-display1.ent
+++ b/publishing/1.1/JATS-display1.ent
@@ -1,0 +1,1000 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Display Class Elements                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-display1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                     -->
+<!--                                                               -->
+<!-- PURPOSE:    Describes display-related elements such as        -->
+<!--             Figures, Graphics, Math, Chemical Structures,     -->
+<!--             Graphics, etc.                                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 16. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 15. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  14. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 13. CAPTION ATTRIBUTE - Changed the mechanism by which the @style
+      attribute is associated with the element <caption>. 
+      Previously, the <caption> element's base attributes were 
+      declared in this module and additional attributes (@style) 
+      for it were declared in the XHTML Table Module. The @style 
+      attribute is now declared in this module, and the caption 
+      attributes in the XHTML table model have been set to IGNORE. 
+      This was done to make sure that the attributes available on 
+      the JATS <caption> element did not change based on which table
+      model a JATS user was using.
+
+ 12. CODE - Added the new element <code> (using code-atts and
+     code-elements). Resembles <preformat>, but different
+     semantics.
+
+ 11. CAPTION ATTRIBUTES - Added the new PE %jats-common-atts; to
+     the caption attributes, even though doing so while making
+     no other changes would mean multiple definitions
+     of the @id and @content-type attributes. This would produce a
+     warning, which should be ignored, so see item #13 above.
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  9. ABSTRACT AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - chem-struct-wrap (through %chem-struct-wrap-model;)
+        - fig (through %fig-model;)
+        - fig-group (through %fig-group-model;)
+        - graphic (through %graphic-model;)
+        - media (through %media-model;)
+        - table-wrap (through %table-wrap-model;)
+        - table-wrap-group (through %table-wrap-group-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  8. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  7. Updated the DTD-version attribute to "0.4" 
+   
+  6. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  5. INLINE GRAPHIC - Uses new class %small-access.class; (no
+     model change)
+
+  4. POSITION ATTRIBUTE - Added the value "background"
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to %display-atts;. If these attribute were
+     already part of the list, deleted them. These attributes were
+     added to:
+      - array       (already there)
+      - boxed-text  (already there)
+      - caption     (already there)
+      - chem-struct (added @xml:lang, @specific-use already)
+      - chem-struct-wrap (added @xml:lang, @specific-use already)
+      - fig (already there)
+      - fig-group (added @xml:lang, @specific-use already there)
+      - graphic (added @xml:lang, @specific-use already there)
+      - inline-graphic (both)
+      - media (added @xml:lang, @specific -use already there)
+      - preformat (already there)
+      - supplementary-material (already there)
+      - table-wrap (already there)
+      - table-wrap-group (added @xml:lang, @specific -use
+          already there)
+
+  2. GRAPHIC MODEL - Removed the dependency which had both
+     <graphic> and <media> modeled with the same parameter
+     entity %graphic-model;. Created new PE for %media-model;
+     but set it (as the default) to %graphic-model; so that no
+     customization would break. NEW PE
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ATTRIBUTES FOR MULTIPLE ELEMENTS           -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY ATTRIBUTES                         -->
+<!--                    Attributes used for several of the block
+                        display elements                           -->
+<!ENTITY % display-atts
+            "position   (anchor | background | float | margin)
+                                                          'float'
+             orientation
+                        (portrait | landscape)            'portrait'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    SPECIFIC ATTRIBUTE LISTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARRAY ATTRIBUTES                           -->
+<!--                    Attributes for the <array> element         -->
+<!ENTITY % array-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             orientation
+                        (portrait | landscape)            'portrait'
+             xml:lang   NMTOKEN                           #IMPLIED" >
+
+
+<!--                    BOXED TEXT ATTRIBUTES                      -->
+<!--                    Attributes for the <boxed-text> element    -->
+<!ENTITY % boxed-text-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    CAPTION ATTRIBUTES                         -->
+<!--                    Attributes for <caption> element           -->
+<!--                    The attribute @style was added to make all
+                        JATS captions the same as XHTML table
+                        captions.                                  -->
+<!ENTITY % caption-atts
+            "%jats-common-atts;
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED 
+             style      CDATA                             #IMPLIED"  >
+
+<!--                    CHEMICAL STRUCTURE ATTRIBUTES              -->
+<!--                    Attributes for <chem-struct>, a wrapper
+                        around one (typically inline) chemical
+                        structure, or one of several structures in
+                        a <chem-struct-wrap>                       -->
+<!ENTITY % chem-struct-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER ATTRIBUTES      -->
+<!--                    Attributes for the <chem-struct-wrap>
+                        element, the outer wrapper around one or more
+                        block-level chemical structures            -->
+<!ENTITY % chem-struct-wrap-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                   CODE ATTRIBUTES                             -->
+<!--                   Attributes for the <code> element           -->
+<!ENTITY % code-atts
+            "%jats-common-atts;                                       
+             code-type          CDATA                     #IMPLIED
+             code-version       CDATA                     #IMPLIED
+             executable         (yes | no)                #IMPLIED
+             language           CDATA                     #IMPLIED
+             language-version   CDATA                     #IMPLIED
+             platforms          CDATA                     #IMPLIED
+             %display-atts;
+             xml:space (default | preserve)       #FIXED 'preserve'" >
+
+
+<!--                    FIGURE ATTRIBUTES                          -->
+<!--                    Attributes for Figures <fig>               -->
+<!ENTITY % fig-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              fig-type  CDATA                             #IMPLIED"  >
+
+
+<!--                    FIGURE GROUP ATTRIBUTES                    -->
+<!--                    Attributes for Figure Groups <fig-group>   -->
+<!ENTITY % fig-group-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED "  >
+
+
+<!--                    GRAPHIC ATTRIBUTES                         -->
+<!--                    Attributes for the <graphic> element       -->
+<!ENTITY % graphic-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              %link-atts;"                                           >
+
+
+<!--                    INLINE GRAPHIC ATTRIBUTES                  -->
+<!--                    Attributes for the <inline-graphic> element-->
+<!ENTITY % inline-graphic-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             baseline-shift
+                        CDATA                             #IMPLIED
+             mimetype   CDATA                             #IMPLIED
+             mime-subtype
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %link-atts;"                                            >
+
+
+<!--                    MEDIA ATTRIBUTES                           -->
+<!--                    Attributes for the <media> element         -->
+<!ENTITY % media-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              %link-atts;"                                           >
+
+
+<!--                   PREFORMATTED TEXT ATTRIBUTES                -->
+<!--                   Attributes for the <preformat> element      -->
+<!ENTITY % preformat-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              preformat-type
+                        CDATA                             #IMPLIED
+              xml:space (default | preserve)     #FIXED 'preserve'"  >
+
+
+<!--                    SUPPLEMENTARY INFORMATION ATTRIBUTES       -->
+<!--                    Attributes for Supplementary Material
+                        <supplementary-material>                   -->
+<!ENTITY % supplementary-material-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              mimetype  CDATA                             #IMPLIED
+              mime-subtype
+                        CDATA                             #IMPLIED
+              %might-link-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ATTRIBUTES                           -->
+<!-- ============================================================= -->
+
+
+<!--                    TABLE WRAPPER ATTRIBUTES                   -->
+<!--                    Attributes to be added to the regular NLM
+                        table attributes, for example, when the
+                        Elsevier or OASIS Exchange table models are
+                        used.                                      -->
+<!ENTITY % other-table-wrap-atts
+            ""                                                       >                                       
+
+
+<!--                    TABLE GROUP ATTRIBUTES                     -->
+<!--                    Attributes for groups of <table-wrap>
+                        elements <table-wrap-group>                -->
+<!ENTITY % table-wrap-group-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              %other-table-wrap-atts;"                               >
+
+
+<!--                    TABLE WRAPPER ATTRIBUTES                   -->
+<!--                    Attributes for the <table-wrap> element,
+                        the container for <table>s                 -->
+<!ENTITY % table-wrap-atts
+            "%jats-common-atts;                                       
+              %display-atts;
+              content-type
+                        CDATA                             #IMPLIED
+              %other-table-wrap-atts;"                               >
+
+
+<!--                    TABLE WRAP FOOR ATTRIBUTES                 -->
+<!--                    Attributes for the <table-wrap-foot> element
+                                                                   -->
+<!ENTITY % table-wrap-foot-atts
+            "%jats-common-atts;"                                     >                                       
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CONTENT MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    FIGURE-LIKE CONTENT MODEL                  -->
+<!--                    Content model for the Figure element and any
+                        similarly structured elements              -->
+<!ENTITY % fig-model    "((%id.class;)*, label?, (%caption.class;)*,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%block-math.class; |
+                           %chem-struct-wrap.class; |
+                           %intable-para.class; |
+                           %just-table.class; | %just-para.class; |
+                           %list.class; | %simple-display.class;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!-- ============================================================= -->
+<!--                    ARRAY ELEMENTS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    ARRAY CONTENT MODEL                        -->
+<!--                    Content model for the <array> element      -->
+<!ENTITY % array-model  "(label?,
+                          (%access.class; | %address-link.class;)*,
+                          ( (%just-base-display.class;)* |
+                            %tbody.class; ),
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    ARRAY (SIMPLE TABULAR ARRAY)               -->
+<!--                    Used to define in-text table-like (columnar)
+                        material.  Uses the XHTML table body element
+                        or a graphic to express the rows and columns.
+                        These have neither labels nor captions,
+                        arrays with labels and captions are table
+                        wrappers.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=array
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=array
+                                                                   -->
+<!ELEMENT  array        %array-model;                                >
+<!ATTLIST  array
+             %array-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BOXED TEXT ELEMENTS                        -->
+<!-- ============================================================= -->
+
+
+<!--                    BOXED TEXT MODEL                           -->
+<!--                    Complete content model for the boxed text
+                        element <boxed-text>                       -->
+<!ENTITY % boxed-text-model
+                        "((%id.class;)*, sec-meta?, label?, caption?,
+                          (%para-level;)*, (%sec-level;)*,
+                          (%sec-back-matter-mix;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    BOXED TEXT                                 -->
+<!--                    Textual material that is outside the flow
+                        of the narrative text, for example, a
+                        sidebar, marginalia, text insert, caution or
+                        note box, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=boxed-text
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=boxed-text
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=boxed-text
+                                                                   -->
+<!ELEMENT  boxed-text   %boxed-text-model;                           >
+<!ATTLIST  boxed-text
+             %boxed-text-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    CHEMICAL STRUCTURE ELEMENTS                -->
+<!-- ============================================================= -->
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER MODEL           -->
+<!--                    Content model for the Chemical Structure
+                        Wrapper <chem-struct-wrap> element         -->
+<!ENTITY % chem-struct-wrap-model
+                        "((%id.class;)*, label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%inside-chem-struct-wrap.class;)+,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    CHEMICAL STRUCTURE WRAPPER                 -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text.
+                        These may be numbered.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=chem-struct-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=chem-struct-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=chem-struct-wrap
+                                                                   -->
+<!ELEMENT  chem-struct-wrap
+                        %chem-struct-wrap-model;                     >
+<!ATTLIST  chem-struct-wrap
+             %chem-struct-wrap-atts;                                 >
+
+
+<!--                    CHEMICAL STRUCTURE ELEMENTS                -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Chemical Structure
+                        <chem-struct>                              -->
+<!ENTITY % chem-struct-elements
+                        "| %access.class; | %address-link.class; |
+                         %break.class; |
+                         %emphasis.class; | %label.class; |
+                         %list.class; | %math.class; |
+                         %phrase-content.class; |
+                         %simple-display.class; |
+                         %simple-link.class; | %subsup.class; "      >
+
+
+<!--                    CHEMICAL STRUCTURE MODEL                   -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text
+                                                                   -->
+<!ENTITY % chem-struct-model
+                        "(#PCDATA %chem-struct-elements;)* "         >
+
+
+<!--                    CHEMICAL STRUCTURE (DISPLAY)               -->
+<!--                    A chemical expression, reaction, equation,
+                        etc. that is set apart within the text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=chem-struct
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=chem-struct
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=chem-struct
+                                                                   -->
+<!ELEMENT  chem-struct  %chem-struct-model;                          >
+<!ATTLIST  chem-struct
+             %chem-struct-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    FIGURE ELEMENTS                            -->
+<!-- ============================================================= -->
+
+
+<!--                    FIGURE GROUP MODEL                         -->
+<!--                    Content model for a Figure Group element   -->
+<!ENTITY % fig-group-model
+                        "(label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%fig-display.class; |
+                           %just-base-display.class;)* )"            >
+
+
+<!--                    FIGURE GROUP                               -->
+<!--                    Used for a group of figures that must be
+                        displayed together
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fig-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fig-group
+                                                                   -->
+<!ELEMENT  fig-group    %fig-group-model;                            >
+<!ATTLIST  fig-group
+             %fig-group-atts;                                        >
+
+
+<!--                    FIGURE                                     -->
+<!--                    A block of graphic or textual material that
+                        is identified as a "Figure", usually with
+                        a caption and a label such as "Figure" or
+                        "Figure 3.".The content of a Figure need not
+                        be graphical in nature,.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fig
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fig
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fig
+                                                                   -->
+<!ELEMENT  fig          %fig-model;                                  >
+<!ATTLIST  fig
+             %fig-atts;                                              >
+
+
+<!--                    CAPTION BODY PARTS                         -->
+<!--                    Elements that may be included in the body of
+                        the <caption> element                      -->
+<!ENTITY % caption-body-parts
+                        "(%just-para.class;)*"                       >
+
+
+<!--                    CAPTION MODEL                              -->
+<!--                    Content model for the <caption> element    -->
+<!ENTITY % caption-model
+                        "(title?, %caption-body-parts;)"             >
+
+
+<!--                    CAPTION OF A FIGURE, TABLE, ETC.           -->
+<!--                    Wrapper element for the textual description
+                        associated with a figure, table, etc. In
+                        some source document captions, the first
+                        sentence is set off from the rest as a title.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=caption
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=caption
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=caption
+                                                                   -->
+<!ELEMENT  caption      %caption-model;                              >
+<!ATTLIST  caption
+             %caption-atts;                                          >
+
+
+<!--ELEM  title        Defined in %common.ent;                     -->
+<!--ELEM  p            Defined in %common.ent;                     -->
+
+
+<!-- ============================================================= -->
+<!--                    THE GRAPHIC AND MEDIA OBJECT ELEMENTS      -->
+<!-- ============================================================= -->
+
+
+<!--                    GRAPHIC MODEL                              -->
+<!--                    Content model for the <graphic> element    -->
+<!ENTITY % graphic-model
+                        "(%access.class; | %abstract.class; | 
+                          %address-link.class; | %caption.class; |
+                          %id.class; | %kwd-group.class; | 
+                          %label.class; |
+                          %display-back-matter.class;)* "            >
+
+
+<!--                    GRAPHIC                                    -->
+<!--                    An external file that holds a picture,
+                        illustration, etc., usually as some form of
+                        binary object. The "content" of the <graphic>
+                        element is not the object, but merely
+                        information about the object. The "href"
+                        attribute points to the file containing
+                        the object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=graphic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=graphic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=graphic
+                                                                   -->
+<!ELEMENT  graphic      %graphic-model;                              >
+<!ATTLIST  graphic
+             %graphic-atts;                                          >
+
+
+<!--                    MEDIA MODEL                                -->
+<!--                    Content model for the <media> element      -->
+<!ENTITY % media-model  "(%access.class; | %abstract.class; | 
+                          %address-link.class; |
+                          %caption.class; | %id.class; | 
+                          %kwd-group.class; | %label.class; | 
+                          %display-back-matter.class;)* "            >
+
+
+<!--                    MEDIA OBJECT                               -->
+<!--                    An external file that holds a media object,
+                        such as an animation or a movie. The
+                        "content" of the <media> element is not the
+                        object, but merely information about the
+                        object. The "href" attribute points to the
+                        file containing the object.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=media
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=media
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=media
+                                                                   -->
+<!ELEMENT  media        %media-model;                                >
+<!ATTLIST  media
+             %media-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    INLINE GRAPHIC                             -->
+<!-- ============================================================= -->
+
+
+<!--                    INLINE GRAPHIC MODEL                       -->
+<!--                    Content model for the <inline-graphic>
+                        element                                    -->
+<!ENTITY % inline-graphic-model
+                        "((%small-access.class;)?)"                  >
+
+
+<!--                    INLINE GRAPHIC                             -->
+<!--                    A small graphic such as an icon or a small
+                        picture symbol that is displayed or set
+                        in the same line as the text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=inline-graphic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=inline-graphic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=inline-graphic
+                                                                   -->
+<!ELEMENT  inline-graphic
+                        %inline-graphic-model;                       >
+<!ATTLIST  inline-graphic
+             %inline-graphic-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    PRESERVE THE WHITESPACE TEXT               -->
+<!-- ============================================================= -->
+
+
+<!--                    PREFORMATTED TEXT ELEMENTS                 -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <preformat> element                        -->
+<!ENTITY % preformat-elements
+                        "| %access.class; | %address-link.class; |
+                         %display-back-matter.class; |
+                         %emphasis.class; | %id.class; |
+                         %phrase.class; | %subsup.class;"            >
+
+
+<!--                    PREFORMAT MODEL                            -->
+<!--                    Content model for the <preformat> element  -->
+<!ENTITY % preformat-model
+                        "(#PCDATA %preformat-elements;)*"            >
+
+
+<!--                    PREFORMATTED TEXT                          -->
+<!--                    Used for preformatted text such as
+                        computer code in which whitespace, such as
+                        tabs, line feeds, and spaces, should be
+                        preserved.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=preformat
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=preformat
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=preformat
+                                                                   -->
+<!ELEMENT  preformat    %preformat-model;                            >
+<!ATTLIST  preformat
+             %preformat-atts;                                        >
+
+
+<!--                    CODE ELEMENTS                              -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <code> element                             -->
+<!ENTITY % code-elements
+                        "| %address-link.class; | 
+                         %emphasis.class; | %phrase.class; | 
+                         %simple-link.class; | %subsup.class;"      >
+
+
+<!--                    CODE TEXT                                  -->
+<!--                    A container element for technical content
+                        such as programming language code, 
+                        pseudo-code, schemas, or a markup fragment.
+                          This material may be preformatted text, with
+                        or without emphasis, or it may be an external
+                        link to a binary executable file.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=code
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=code
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=code
+                                                                   -->
+<!ELEMENT  code         (#PCDATA %code-elements;)*                   >
+<!ATTLIST  code
+             %code-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUPPLEMENTARY MATERIAL                     -->
+<!-- ============================================================= -->
+
+
+<!--                    SUPPLEMENTARY MATERIAL MODEL               -->
+<!--                    Content model for the
+                        <supplementary-material> element           -->
+<!ENTITY % supplementary-material-model
+                        "%fig-model;"                                >
+
+
+<!--                    SUPPLEMENTARY MATERIAL                     -->
+<!--                    Additional data files that contain
+                        information directly supportive of the item,
+                        for example, an audio clip, movie, database,
+                        spreadsheet, applet, or other external file.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=supplementary-material
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=supplementary-material
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=supplementary-material
+                                                                   -->
+<!ELEMENT  supplementary-material
+                        %supplementary-material-model;               >
+<!ATTLIST  supplementary-material
+             %supplementary-material-atts;                           >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE ELEMENTS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    TABLE WRAPPER GROUP MODEL                  -->
+<!--                    Content model for the <table-wrap-group>
+                        element                                    -->
+<!ENTITY % table-wrap-group-model
+                        "(label?, caption?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%just-table.class;)+ )"                   >
+
+
+<!--                    TABLE WRAPPER GROUP                        -->
+<!--                    Used as a wrapper tag to contain a group of
+                        tables that must be displayed together
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=table-wrap-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=table-wrap-group
+                                                                   -->
+<!ELEMENT  table-wrap-group
+                        %table-wrap-group-model;                     >
+<!ATTLIST  table-wrap-group
+             %table-wrap-group-atts;                                 >
+
+
+<!--                    TABLE WRAPPER CONTENT MODEL                -->
+<!--                    Content model for the container element that
+                        surrounds the standard table models for row
+                        and columns.                               -->
+<!ENTITY % table-wrap-model
+                        "((%id.class;)*, label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%inside-table-wrap;)*,
+                          (%table-foot.class; |
+                           %display-back-matter.class;)* )"          >
+
+
+<!--                    TABLE WRAPPER                              -->
+<!--                    Used to hold a complete table, that is, not
+                        only the rows and columns that make up a
+                        table, but also the table captions, list
+                        of table footnotes, alternative descriptions
+                        for accessibility, etc.  Within the Table
+                        Wrapper element, the row and column tags that
+                        describe the table cells are defined by one
+                        of the popular "standard" table models, for
+                        example the XHTML table model, OASIS Exchange
+                        (CALS) table model, of the Elsevier Science
+                        Full Length Article table body <tblbody>
+                        model, et al.)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=table-wrap
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=table-wrap
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=table-wrap
+                                                                   -->
+<!ELEMENT  table-wrap   %table-wrap-model;                           >
+<!ATTLIST  table-wrap
+             %table-wrap-atts;                                       >
+
+
+<!--                    TABLE WRAP FOOTER MODEL                    -->
+<!--                    Content model for the <table-wrap-foot>
+                        element                                    -->
+<!ENTITY % table-wrap-foot-model
+                        "(title?,
+                          (%just-para.class; |  %fn-group.class; |
+                           %fn-link.class; |
+                           %display-back-matter.class;)+ )"          >
+
+
+<!--                    TABLE WRAP FOOTER                          -->
+<!--                    Wrapper element to hold a group of footnotes
+                        or other notes or general paragraphs at the
+                        end of a table.  Not the same as the
+                        Table Foot <tfoot>, which contains rows
+                        and columns like the rest of the table.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=table-wrap-foot
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=table-wrap-foot
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=table-wrap-foot
+                                                                   -->
+<!ELEMENT  table-wrap-foot
+                        %table-wrap-foot-model;                      >
+<!ATTLIST  table-wrap-foot
+             %table-wrap-foot-atts;                                  >
+
+
+<!-- ================== End Display Class Module ================= -->

--- a/publishing/1.1/JATS-format1.ent
+++ b/publishing/1.1/JATS-format1.ent
@@ -1,0 +1,858 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Formatting Element Classes                        -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+ "-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.1 20151215//EN"
+  Delivered as file "JATS-format1.ent"                             -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Elements concerned with rendition of output, for  -->
+<!--             example printing on a page or display on a screen -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  12. RUBY MODEL CHANGED TO MATCH HTML5
+      - changed the Ruby content model to allow only a single
+        Ruby annotation on a single Ruby base:
+            (rb, rt+)
+        The Ruby textual annotation may NOT take a pair of
+        Ruby parentheses. This is a simplification of the
+        HTML5 model:
+           (rb, (rt | (rp, rt, rp)) )
+        The simplification does not allow Ruby parenthesis.
+        Archiving and BITS both use the full model above.
+
+  11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. RUBY ANNOTATIONS - Added new elements for:
+      - <ruby> The Ruby wrapper element, which contains the base
+          text and the annotation.
+      - <rb> Ruby Base text, acts in the same manner as face markup,
+        surrounding some text in the narrative.
+      - <rt> Ruby Text, the annotation that modifies a piece of
+         the narrative text, frequently typeset above the text.
+
+  9. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - break 
+      - hr      
+      - rp               
+
+  8. ADDED NEW ELEMENT <fixed-case> 
+     - defined as meaning that the case of the content is not to
+       change, even if the content around it is styled to all
+       upper case or all lower. For example "PhD".
+
+  7. ADDED NEW ATTRIBUTE - @toggle added to:
+     - bold, italic (default="yes"), monospace, overline, 
+       roman (default="no"), sans-serif, sc, strike, and underline.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  5. Updated the DTD-version attribute to "0.4" 
+   
+  4. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  3. @SPECIAL-USE - Added the attribute @special-use to the
+     all 14 formatting (emphasis) elements. This includes all the
+     ones listed in 2. below as well as:
+       - sub             sub-atts  
+       - sup             sup-atts
+       - overline        overline-atts
+       - overline-start  overline-start-atts
+       - overline-end    overline-start-atts
+       - underline       underline-atts
+       - underline-start underline-start-atts
+       - underline-end   underline-end-atts
+
+  2. PEs FOR ATTLISTS - Added parameter entity redefinitions for the
+     attribute lists of the following elements: (no attributes or
+     values were changed)
+       - bold            bold-atts       NEW PE
+       - italic          italic-atts     NEW PE
+       - monospace       monospace-atts  NEW PE
+       - roman           roman-atts      NEW PE
+       - sans-serif      sans-serif-atts NEW PE
+       - sc              sc-atts         NEW PE
+       - strike          strike-atts     NEW PE
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    BOLD ATTRIBUTES                            -->
+<!--                    Attributes for the <bold> element          -->
+<!ENTITY % bold-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    BREAK ATTRIBUTES                           -->
+<!--                    Attributes for the <break> element         -->
+<!ENTITY % break-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FIXED CASE ATTRIBUTES                      -->
+<!--                    Attributes for the <fixed-case> element    -->
+<!ENTITY % fixed-case-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    HORIZONTAL RULE ATTRIBUTES                 -->
+<!--                    Attributes for the <hr> element            -->
+<!ENTITY % hr-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    ITALIC ATTRIBUTES                          -->
+<!--                    Attributes for the <italic> element        -->
+<!ENTITY % italic-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        'yes'
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    MONOSPACE ATTRIBUTES                       -->
+<!--                    Attributes for the <bold> element          -->
+<!ENTITY % monospace-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE START ATTRIBUTES                  -->
+<!--                    Attributes for the <overline> element      -->
+<!ENTITY % overline-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE START ATTRIBUTES                  -->
+<!--                    Attributes for the <overline-start> element-->
+<!ENTITY % overline-start-atts
+            "%jats-common-atts-id-required;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    OVERLINE END ATTRIBUTES                    -->
+<!--                    Attributes for the <overline-end> element  -->
+<!ENTITY % overline-end-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ROMAN ATTRIBUTES                           -->
+<!--                    Attributes for the <roman> element         -->
+<!ENTITY % roman-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        'no'
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    RUBY BASE ATTRIBUTES                       -->
+<!--                    Attributes for the <rb> element            -->
+<!ENTITY % rb-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RUBY PARENTHESIS ATTRIBUTES                -->
+<!--                    Attributes for the <rp> element            -->
+<!ENTITY % rp-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION ATTRIBUTES         -->
+<!--                    Attributes for the <rt> element            -->
+<!ENTITY % rt-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RUBY ATTRIBUTES                            -->
+<!--                    Attributes for the <ruby> element          -->
+<!ENTITY % ruby-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SANS SERIF ATTRIBUTES                      -->
+<!--                    Attributes for the <sans-serif> element    -->
+<!ENTITY % sans-serif-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SMALL CAPS ATTRIBUTES                      -->
+<!--                    Attributes for the <sc> element            -->
+<!ENTITY % sc-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    STRIKE THROUGH ATTRIBUTES                  -->
+<!--                    Attributes for the <strike> element        -->
+<!ENTITY % strike-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUBSCRIPT ATTRIBUTES                       -->
+<!--                    Attributes for the subscript <sub> element -->
+<!ENTITY % sub-atts
+            "%jats-common-atts;                                       
+             arrange    (stack | stagger)                 #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    SUPERSCRIPT ATTRIBUTES                     -->
+<!--                    Attributes for the superscript <sup>
+                        element                                    -->
+<!ENTITY % sup-atts
+            "%jats-common-atts;                                       
+             arrange    (stack | stagger)                 #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE ATTRIBUTES                       -->
+<!--                    Attributes for the <underline> element     -->
+<!ENTITY % underline-atts
+            "%jats-common-atts;                                       
+             toggle     (yes | no)                        #IMPLIED
+             underline-style
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE START ATTRIBUTES                 -->
+<!--                    Attributes for the <underline-start>
+                        element                                    -->
+<!ENTITY % underline-start-atts
+            "%jats-common-atts-id-required;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    UNDERLINE END ATTRIBUTES                   -->
+<!--                    Attributes for the <underline-end> element -->
+<!ENTITY % underline-end-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    APPEARANCE CLASS ELEMENTS                  -->
+<!-- ============================================================= -->
+
+
+<!--                    HORIZONTAL RULE                            -->
+<!--                    Defined to allow the user to specify an
+                        explicit (non machine-generated) rule.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=hr
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=hr
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=hr
+                                                                   -->
+<!ELEMENT  hr           EMPTY                                        >
+<!ATTLIST  hr 
+             %hr-atts;                                               >
+
+
+<!-- ============================================================= -->
+<!--                    BREAK CLASS ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    LINE BREAK                                 -->
+<!--                    Defined to allow the user to specify an
+                        explicit (non machine-generated) line break.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=break
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=break
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=break
+                                                                   -->
+<!ELEMENT  break        EMPTY                                        >
+<!ATTLIST  break
+             %break-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    EMPHASIS/RENDITION CLASS ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    BOLD                                       -->
+<!--                    Used to mark text that should appear in bold
+                        face type for print or display
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=bold
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=bold
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=bold
+                                                                   -->
+<!ELEMENT  bold         (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  bold
+             %bold-atts;                                             >
+
+
+<!--                    FIXED CASE                 -->
+<!--                    Used to mark text in which the case of the 
+                        content should not be changed, even if the 
+                        content around it is styled to all
+                        upper case or all lower. For example "PhD".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fixed-case
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fixed-case
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fixed-case
+                                                                   -->
+<!ELEMENT  fixed-case   (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  fixed-case
+             %fixed-case-atts;                                       >
+
+
+<!--                    ITALIC                                     -->
+<!--                    Used to mark text that should appear in
+                        italic type on output.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=italic
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=italic
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=italic
+                                                                   -->
+<!ELEMENT  italic       (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  italic
+             %italic-atts;                                           >
+
+
+<!--                    MONOSPACE TEXT (TYPEWRITER TEXT)           -->
+<!--                    Used to mark text that should appear in
+                        a non-proportional font, such as courier
+                        for display or print.  This is common for
+                        computer code examples, man-machine
+                        dialogues, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=monospace
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=monospace
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=monospace
+                                                                   -->
+<!ELEMENT  monospace    (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  monospace
+             %monospace-atts;                                        >
+
+
+<!--                    ROMAN                                      -->
+<!--                    Used to mark text that should remain in
+                        roman script no matter what style the
+                        surrounding text takes on.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=roman
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=roman
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=roman
+                                                                   -->
+<!ELEMENT  roman        (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  roman
+             %roman-atts;                                            >
+
+
+
+<!--                    SANS SERIF                                 -->
+<!--                    Used to mark text that should appear in a
+                        special sans-serif font, typically used in
+                        math or chemistry
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sans-serif
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sans-serif
+                                                                   -->
+<!ELEMENT  sans-serif   (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sans-serif
+             %sans-serif-atts;                                       >
+
+
+<!--                    SMALL CAPS                                 -->
+<!--                    Used to mark text that should appear in a
+                        font which creates smaller capital letters
+                        on output.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sc
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sc
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=sc
+                                                                   -->
+<!ELEMENT  sc           (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sc
+             %sc-atts;                                               >
+
+
+<!--                    OVERLINE                                   -->
+<!--                    Used to mark text that should appear with a
+                        horizontal line above each character in
+                        display or print. There is no PE for
+                        override because this was added to handle
+                        a specific publisher tag set and should not
+                        grow beyond what they need.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=overline
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=overline
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=overline
+                                                                   -->
+<!ELEMENT  overline     (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  overline
+             %overline-atts;                                         >
+
+
+<!--                    STRIKE THROUGH                             -->
+<!--                    Used to mark text that should appear with
+                        a line through it so as to appear "struck out"
+                        on display or print
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=strike
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=strike
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=strike
+                                                                   -->
+<!ELEMENT  strike       (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  strike
+             %strike-atts;                                           >
+
+
+<!--                    SUBSCRIPT                                  -->
+<!--                    A number or expression that is set lower
+                        than the baseline and slightly smaller,
+                        to act as an inferior or subscript
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sub
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sub
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=sub
+                                                                   -->
+<!ELEMENT  sub          (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sub
+             %sub-atts;                                              >
+
+
+<!--                    SUPERSCRIPT                                -->
+<!--                    A number or expression that is set higher
+                        than the baseline and slightly smaller,
+                        to act as a superior or superscript
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sup
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sup
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=sup
+                                                                   -->
+<!ELEMENT  sup          (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  sup
+             %sup-atts;                                              >
+
+
+<!--                    UNDERLINE                                  -->
+<!--                    Used to mark text that should appear with a
+                        horizontal line below each character in
+                        display or print.
+                        Details at:
+                         http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=underline
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=underline
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=underline
+                                                                   -->
+<!ELEMENT  underline    (#PCDATA %emphasized-text;)*                 >
+<!ATTLIST  underline
+             %underline-atts;                                        >
+
+
+<!-- ============================================================= -->
+<!--                    ADVANCED UNDERLINE AND OVERLINE ELEMENTS
+                        (From the Elsevier DTD, used mostly within
+                        mathematics, when ordinary MathML underline
+                        and overline functions are inadequate. The
+                        elements act as milestone tags marking the
+                        start and end of over or underlining that
+                        may extend across element boundaries.)     -->
+<!-- ============================================================= -->
+
+
+<!--                    OVERLINE START                             -->
+<!--                    The start of a milestone-created overline, the
+                        end of ornament will be marked by an
+                        Overline End element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=overline-start
+                                                                   -->
+<!ELEMENT  overline-start
+                        EMPTY                                        >
+<!ATTLIST  overline-start
+             %overline-start-atts;                                   >
+
+
+<!--                    OVERLINE END                               -->
+<!--                    The end of a milestone-created overline, the
+                        start of ornament will be marked by an
+                        Overline Start element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=overline-end
+                                                                   -->
+<!ELEMENT  overline-end EMPTY                                        >
+<!ATTLIST  overline-end
+             %overline-end-atts;                                     >
+
+
+<!--                    UNDERLINE START                            -->
+<!--                    The start of a milestone-created underline,
+                        the end of ornament will be marked by an
+                        Underline End element
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=underline-start
+                                                                   -->
+<!ELEMENT  underline-start
+                        EMPTY                                        >
+<!ATTLIST  underline-start
+             %underline-start-atts;                                  >
+
+
+<!--                    UNDERLINE END                              -->
+<!--                    The end of a milestone-created underline, the
+                        start of ornament will be marked by an
+                        Underline Start element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=underline-end
+                                                                   -->
+<!ELEMENT  underline-end
+                        EMPTY                                        >
+<!ATTLIST  underline-end
+             %underline-end-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    RUBY MARKUP                                -->
+<!-- ============================================================= -->
+
+
+<!--                    RUBY WRAPPER Model                         -->
+<!--                    Content model for the <ruby> element       -->
+<!ENTITY % ruby-model   "(rb, rt)"                                   >
+
+
+<!--                    RUBY WRAPPER                               -->
+<!--                    A Ruby textual annotation is an annotation,
+                        typically short, applied to a letter, word,
+                        phrase, or name that appears in the narrative
+                        text. Ruby annotations can indicate,
+                        for example, pronunciation advice, notes for 
+                        translation, semantic annotations, et al.
+                          The <ruby> element is an inline wrapper  
+                        element that contains some of the document 
+                        narrative text (inside a Ruby Base <rb> 
+                        element) and one or more Ruby textual 
+                        annotations (inside <rt> elements) that are
+                        associated with the base text.
+                          In display or print, the characters of the
+                        Ruby annotation are frequently placed above 
+                        the characters they modify, in parenthesis 
+                        after the characters they modify, or to the
+                        right of vertically set text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ruby
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ruby
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ruby
+                                                                   -->
+<!ELEMENT  ruby         %ruby-model;                                 >
+<!ATTLIST  ruby
+             %ruby-atts;                                             >
+
+
+<!--                    RUBY BASE ELEMENTS                         -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Ruby Base <rb>.        -->
+<!ENTITY % rb-elements  "| %face-markup.class;"                      >
+
+
+<!--                    RUBY BASE                                  -->
+<!--                    The <rb> element is one half of a Ruby 
+                        Annotation <ruby>, and it contains the 
+                        narrative text to which a Ruby textual 
+                        annotation <rt> should be applied.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=rb
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=rb
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=rb
+                                                                   -->
+<!ELEMENT  rb           (#PCDATA %rb-elements;)*                     >
+<!ATTLIST  rb
+             %rb-atts;                                               >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION ELEMENTS           -->
+<!--                    Those elements that may mix with the data
+                        characters inside a Ruby Textual Annotation
+                        <rt>.                                      -->
+<!ENTITY % rt-elements  ""                                           >
+
+
+<!--                    RUBY TEXTUAL ANNOTATION                    -->
+<!--                    The <rt> element is one half of a Ruby 
+                        Annotation <ruby>, and it contains the 
+                        Ruby textual annotation that is applied to
+                        the Ruby Base text <rb>.
+                        Details at:
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=rt
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=rt
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=rt
+                                                                   -->
+<!ELEMENT  rt           (#PCDATA %rt-elements;)*                     >
+<!ATTLIST  rt
+             %rt-atts;                                               >
+
+
+
+<!--                    RUBY PARENTHESIS                           -->
+<!--                    The <rp> element is an optional element used
+                        to provide spacing and a parenthesis to 
+                        surround Ruby Text <rt>, for older systems 
+                        that do not handle Ruby properly.
+                        Remarks. This optional element never holds
+                        any text except a space, an open 
+                        parenthesis, or a close parenthesis:
+                          <ruby><rb>text</rb>
+                          <rp> (</rp><rt>annotation</rt><rp>) </rp>
+                          </ruby>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=rp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=rp
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=rp
+                                                                   -->
+<!ELEMENT  rp           (#PCDATA)                                    >
+<!ATTLIST  rp
+             %rp-atts;                                               >
+
+
+<!-- ================== End Format Class Module ================== -->

--- a/publishing/1.1/JATS-funding1.ent
+++ b/publishing/1.1/JATS-funding1.ent
@@ -1,0 +1,547 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Funding Elements                                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.1 20151215//EN"
+     Delivered as file "JATS-funding1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the elements which describe funding for   -->
+<!--             the research reported in a work or the open       -->
+<!--             access funding for the work                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2008                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+      =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 11. INSTITUTION WRAP ADDED
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - funding-source
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  9. PRINCIPAL-AWARD-RECIPIENT MODEL - Added "contrib-id.class" to 
+     the <principal-award-recipient> through 
+     principal-award-recipient-elements, to hold identifiers for 
+     people, such as publishers-specific IDs, ORCIDs, etc..
+
+  8. PRINCIPAL INVESTIGATOR MODEL - Added "contrib-id.class" to 
+     the <principal-investigator> through 
+     principal-investigator-elements, to hold identifiers for 
+     people, such as publishers-specific IDs, ORCIDs, etc..
+   
+  7. Updated the public identifier to "v1.0 20120330//EN", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "1".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+  4. FUNDING GROUP- Allowed <open-access> to repeat within
+     <funding-group>
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - award-group through award-group-atts (both)
+      - award-id through award-id-atts (both)
+      - funding-group through funding-group-atts (both) NEW PE
+      - funding-source through funding-source-atts (both)
+      - funding-statement through funding-statement-atts (both)
+      - open-access through open-access-atts (both) NEW PE
+      - principal-award-recipient through
+          principal-award-recipient-atts (both) NEW PE
+      - principal-investigator through principal-investigator-atts
+          (both) NEW PE
+
+  2. OPEN ACCESS MODEL - Changed the model from
+         "(p+)"
+     to
+          "(%just-para.class;+)"
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    AWARD GROUP ATTRIBUTES                     -->
+<!--                    Attributes for the <award-group> element   -->
+<!ENTITY % award-group-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             award-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    AWARD IDENTIFIER ATTRIBUTES                -->
+<!--                    Attributes for the <award-id> element      -->
+<!ENTITY % award-id-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FUNDING GROUP ATTRIBUTES                   -->
+<!--                    Attributes for the <funding-group>
+                        element                                    -->
+<!ENTITY % funding-group-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    FUNDING SOURCE ATTRIBUTES                  -->
+<!--                    Attributes for the <funding-source> element-->
+<!ENTITY % funding-source-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             source-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    FUNDING STATEMENT ATTRIBUTES               -->
+<!--                    Attributes for the <funding-statement>
+                        element                                    -->
+<!ENTITY % funding-statement-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    OPEN ACCESS ATTRIBUTES                     -->
+<!--                    Attributes for the <open-access>
+                        element                                    -->
+<!ENTITY % open-access-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT ATTRIBUTES       -->
+<!--                    Attributes for the <principal-award-recipient>
+                        element                                    -->
+<!ENTITY % principal-award-recipient-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PRINCIPAL INVESTIGATOR ATTRIBUTES          -->
+<!--                    Attributes for the <principal-investigator>
+                        element                                    -->
+<!ENTITY % principal-investigator-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    FUNDING ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    FUNDING GROUP MODEL                        -->
+<!--                    Model for the <funding-group> element      -->
+<!ENTITY % funding-group-model
+                        "(award-group*, funding-statement*,
+                         open-access*)"                              >
+
+
+<!--                    FUNDING GROUP                              -->
+<!--                    Container element for information concerning
+                        grants, contracts, sponsors, or other
+                        funding for the research reported in the
+                        work (typically an article), as well as for
+                        material on the open access funding for the
+                        work, for example, which model of open access
+                        funding was used or who paid the open access
+                        charges.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=funding-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=funding-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=funding-group
+                                                                   -->
+<!ELEMENT  funding-group
+                        %funding-group-model;                        >
+<!ATTLIST  funding-group
+             %funding-group-atts;                                    >
+
+
+<!--                    FUNDING STATEMENT ELEMENTS                 -->
+<!--                    Model for the <funding-statement> element  -->
+<!ENTITY % funding-statement-elements
+                        "| %address-link.class; | %emphasis.class; |
+                         %phrase-content.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    FUNDING STATEMENT                          -->
+<!--                    A displayable prose statement that describes
+                        the funding for the research on which a work
+                        was based. Such a statement is required, for
+                        example, by research funded in whole or part
+                        by the Wellcome Trust. The statement may
+                        mention (and therefore repeat) the funding
+                        source, PI, or other funding information.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=funding-statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=funding-statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=funding-statement
+                                                                   -->
+<!ELEMENT  funding-statement
+                        (#PCDATA %funding-statement-elements;)*      >
+<!ATTLIST  funding-statement
+             %funding-statement-atts;                                >
+
+
+<!--                    OPEN ACCESS MODEL                          -->
+<!--                    Model for the <open-access> element        -->
+<!ENTITY % open-access-model
+                        "((%just-para.class;)+)"                     >
+
+
+<!--                    OPEN ACCESS                                -->
+<!--                    A container element to hold metadata
+                        concerning the open access provisions that
+                        apply to a work, for example which model
+                        of charging was used or who paid the open
+                        access charges for a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=open-access
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=open-access
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=open-access
+                                                                   -->
+<!ELEMENT  open-access  %open-access-model;                          >
+<!ATTLIST  open-access
+             %open-access-atts;                                      >
+
+
+<!-- ============================================================= -->
+<!--                    AWARD GROUP ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    AWARD GROUP MODEL                          -->
+<!--                    Model for the <award-group> element        -->
+<!ENTITY % award-group-model
+                        "(funding-source*, award-id*,
+                          principal-award-recipient*,
+                          principal-investigator*)"                  >
+
+
+<!--                    AWARD GROUP                                -->
+<!--                    Container element for information concerning
+                        one award that sponsored a work or the
+                        research on which the work was based. There
+                        may be more than source of funding, a grant
+                        or contract number, PI, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=award-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=award-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=award-group
+                                                                   -->
+<!ELEMENT  award-group  %award-group-model;                          >
+<!ATTLIST  award-group
+             %award-group-atts;                                      >
+
+
+<!--                    FUNDING SOURCE ELEMENTS                    -->
+<!--                    Model for the <funding-source> element     -->
+<!ENTITY % funding-source-elements
+                        "%simple-text; | %institution-wrap.class;"   >
+
+
+<!--                    FUNDING SOURCE                             -->
+<!--                    Agency or organization (such as a foundation,
+                        corporation, or an educational institution)
+                        that funded the research on which a work was
+                        based, for example, the Wellcome Trust, NIH,
+                        HHS, Princeton University, or Alcoa
+                        sponsoring the research for a journal
+                        article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=funding-source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=funding-source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=funding-source
+                                                                   -->
+<!ELEMENT  funding-source
+                        (#PCDATA %funding-source-elements;)*         >
+<!ATTLIST  funding-source
+             %funding-source-atts;                                   >
+
+
+<!--                    AWARD IDENTIFIER ELEMENTS                  -->
+<!--                    Model for the <award-id> element           -->
+<!ENTITY % award-id-elements
+                        "%simple-text;"                              >
+
+
+<!--                    AWARD IDENTIFIER                           -->
+<!--                    An identifier that has been assigned to the
+                        award, for example, a grant number, a grant
+                        reference number, or a contract number.
+                        [Note, this is a real-world identifier not
+                        an XML ID.]
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=award-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=award-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=award-id
+                                                                   -->
+<!ELEMENT  award-id     (#PCDATA %award-id-elements;)*               >
+<!ATTLIST  award-id
+             %award-id-atts;                                         >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT ELEMENTS         -->
+<!--                    Model for the <principal-award-recipient>
+                        element                                    -->
+<!ENTITY % principal-award-recipient-elements
+                        " | %contrib-id.class; | 
+                         %recipient-name.class;"                     >
+
+
+<!--                    PRINCIPAL AWARD RECIPIENT                  -->
+<!--                    The institution or individuals to whom the
+                        award was given, for example the principal
+                        grant holder
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=principal-award-recipient
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=principal-award-recipient
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=principal-award-recipient
+                                                                   -->
+<!ELEMENT  principal-award-recipient
+                        (#PCDATA
+                         %principal-award-recipient-elements;)*      >
+<!ATTLIST  principal-award-recipient
+             %principal-award-recipient-atts;                        >
+
+
+<!--                    PRINCIPAL INVESTIGATOR ELEMENTS            -->
+<!--                    Model for the <principal-investigator>
+                        element                                    -->
+<!ENTITY % principal-investigator-elements
+                        " | %contrib-id.class; | 
+                         %investigator-name.class;"                  >
+
+
+<!--                    PRINCIPAL INVESTIGATOR RECIPIENT           -->
+<!--                    Individual responsible for the intellectual
+                        content of the work reported in the article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=principal-investigator
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=principal-investigator
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=principal-investigator
+                                                                   -->
+<!ELEMENT  principal-investigator
+                        (#PCDATA
+                         %principal-investigator-elements;)*         >
+<!ATTLIST  principal-investigator
+             %principal-investigator-atts;                           >
+
+
+<!-- ================== End Funding Module ======================= -->

--- a/publishing/1.1/JATS-journalmeta1.ent
+++ b/publishing/1.1/JATS-journalmeta1.ent
@@ -1,0 +1,454 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Metadata Elements                         -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.1 20151215//EN"
+     Delivered as file "JATS-journalmeta1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements used to describe the journal   -->
+<!--             in which the journal article is published.        -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 13. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - journal-meta
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  9. JOURNAL METADATA MODEL
+     - Added <issn-l> as an optional element to <journal-meta>
+     - Added contributors and affiliations to journal metadata through
+       contrib-group.class (which resolves to <contrib-group>) and 
+       aff-alternatives.class (which resolves to <aff> or
+       <aff-alternatives>), using the journal-meta-model.
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  8. Updated the DTD-version attribute to "0.4" 
+   
+  7. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  6. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <abbrev-journal-title> through %abbrev-journal-title-atts;
+      - <journal-title> through %journal-title-atts;
+      - <journal-subtitle> through %journal-subtitle-atts;
+
+  5. JOURNAL METADATA- Added <notes> to repeat within <journal-meta>
+     (through %journal-meta-model; and added @xml:lang and
+     @specific-use to the attributes of <notes> through %notes-atts;
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - abbrev-journal-title through abbrev-journal-title-atts
+          (@specific-use-only; @xml:lang already)
+      - journal-title through journal-title-atts
+          (@specific-use-only;
+      - journal-subtitle through journal-subtitle-atts
+          (@specific-use-only)
+
+  3. JOURNAL TITLE ELEMENTS - Removed the dependency which had both
+     <journal-title> and <journal-subtitle> modeled with the same
+     parameter entity %journal-title-elements;. Created new PE for
+     %journal-subtitle-elements; but set it (as the default) to
+     %journal-title-elements; so that no customization would break.
+
+  2. SELF URI - Added <self-uri> to <journal-meta> (directly
+     following <notes>) so that an XML document can point to the
+     journal home page.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+<!--                    ABBREVIATED JOURNAL TITLE ATTRIBUTES       -->
+<!--                    Attribute list for Abbreviated Journal Title
+                        <abbrev-journal-title> element             -->
+<!ENTITY % abbrev-journal-title-atts
+            "%jats-common-atts;                                       
+             abbrev-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <journal-meta>
+                        element                                    -->
+<!ENTITY % journal-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    JOURNAL TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <journal-title>
+                        element                                    -->
+<!ENTITY % journal-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    JOURNAL TITLE GROUP ATTRIBUTES             -->
+<!--                    Attributes for the <journal-title-group>
+                        element                                    -->
+<!ENTITY % journal-title-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                              #IMPLIED" >
+
+
+<!--                    JOURNAL SUBTITLE GROUP ATTRIBUTES          -->
+<!--                    Attributes for the <journal-subtitle>
+                        element                                    -->
+<!ENTITY % journal-subtitle-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang  NMTOKEN                            #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL METADATA                           -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL METADATA MODEL                     -->
+<!--                    Content model for the journal metadata
+                        element <journal-meta>                     -->
+<!ENTITY % journal-meta-model
+                        "(journal-id*, journal-title-group*,
+                          (%contrib-group.class; |
+                          %aff-alternatives.class;)*,
+                          issn*, issn-l?, isbn*, 
+                          publisher?, notes*, self-uri*,
+                          custom-meta-group?)"                       >
+
+
+<!--ELEM   journal-id   Defined in %common.ent;                    -->
+<!--ELEM   issn         Defined in %common.ent;                    -->
+<!--ELEM   issn-l       Defined in %common.ent;                    -->
+<!--ELEM   publisher    Defined in %common.ent;                    -->
+<!--ELEM   notes        Defined in %common.ent;                    -->
+<!--ELEM   custom-meta-group
+                        Defined in %common.ent;                    -->
+
+
+<!--                    JOURNAL METADATA                           -->
+<!--                    Metadata that identifies the journal in which
+                        the article was published
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=journal-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=journal-meta
+                                                                   -->
+<!ELEMENT  journal-meta %journal-meta-model;                         >
+<!ATTLIST  journal-meta
+             %journal-meta-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL TITLE ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    JOURNAL TITLE GROUP MODEL                  -->
+<!--                    Content model for the element
+                        <journal-title-group>                      -->
+<!ENTITY % journal-title-group-model
+                        "(journal-title*, journal-subtitle*,
+                          trans-title-group*, abbrev-journal-title*)">
+
+
+<!--ELEM   trans-title-group
+                        Defined in %common.ent;                    -->
+
+
+<!--                    JOURNAL TITLE GROUP                        -->
+<!--                    A container element to hold the title and
+                        its subtitle (if any) for the journal in which
+                        the article was published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=journal-title-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=journal-title-group
+                                                                   -->
+<!ELEMENT  journal-title-group
+                        %journal-title-group-model;                  >
+<!ATTLIST  journal-title-group
+             %journal-title-group-atts;                              >
+
+
+<!--                    JOURNAL TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <journal-title>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % journal-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    JOURNAL TITLE (FULL)                       -->
+<!--                    The title of the journal in which the
+                        article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=journal-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=journal-title
+                                                                   -->
+<!ELEMENT  journal-title
+                        (#PCDATA %journal-title-elements;)*          >
+<!ATTLIST  journal-title
+             %journal-title-atts;                                    >
+
+
+<!--                    JOURNAL SUBTITLE ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <journal-subtitle>                       -->
+<!ENTITY % journal-subtitle-elements
+                        "%journal-title-elements;"                   >
+
+
+<!--                    JOURNAL SUBTITLE                           -->
+<!--                    The subtitle of the journal in which the
+                        article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=journal-subtitle
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=journal-subtitle
+                                                                   -->
+<!ELEMENT  journal-subtitle
+                        (#PCDATA %journal-subtitle-elements;)*       >
+<!ATTLIST  journal-subtitle
+             %journal-subtitle-atts;                                 >
+
+
+<!--                    ABBREVIATED JOURNAL TITLE ELEMENTS         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <abbrev-journal-title>
+                        Design Note: This PE begins with an OR
+                        bar because %just-rendition; begins with an
+                        OR bar.                                    -->
+<!ENTITY % abbrev-journal-title-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    ABBREVIATED JOURNAL TITLE                  -->
+<!--                    A short form of the title of the journal
+                        in which the article is published.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=abbrev-journal-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=abbrev-journal-title
+                                                                   -->
+<!ELEMENT  abbrev-journal-title
+                        (#PCDATA %abbrev-journal-title-elements;)*   >
+<!ATTLIST  abbrev-journal-title
+             %abbrev-journal-title-atts;                             >
+
+
+<!-- ================== End Journal Metadata Elements  =========== -->

--- a/publishing/1.1/JATS-journalpub-oasis-custom-classes1.ent
+++ b/publishing/1.1/JATS-journalpub-oasis-custom-classes1.ent
@@ -1,0 +1,378 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD with OASIS Tables          -->
+<!--             Customize Classes                                 -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.1 20151215//EN"
+Delivered as file "JATS-journalpub-oasis-custom-classes1.ent"      -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD with OASIS Tables          -->
+<!--             of the JATS DTD Suite                             -->
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the JATS DTD Suite default named        -->
+<!--             element classes.                                  -->
+<!--                                                               -->
+<!--             This DTD (in contrast to the Journal Archiving    -->
+<!--             and Interchange DTD) has more prescriptive content-->
+<!--             models. There are fewer choices in the models     -->
+<!--             within this DTD, and some XML structures that     -->
+<!--             were made part of the NISO JATS simply to         -->
+<!--             facilitate conversion of existing journal         -->
+<!--             material from other DTDs into this format have not-->
+<!--             been included in this DTD.                        -->
+<!--                                                               -->
+<!--             Similarly, this is also a tighter DTD. Some of the-->
+<!--             attributes that have type CDATA values in the     -->
+<!--             Archiving DTD, and can thus accept any value,     -->
+<!--             have been given explicit value lists in this DTD. -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             content modules that declare elements, and before -->
+<!--             the default classes module.                       -->
+<!--                                                               -->
+<!-- CONTAINS:   1) PEs for changing the contents of the default   -->
+<!--                element classes                                -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 12. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  10. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  9. NEW CODE ELEMENT- Added <code> to
+      - alternatives-display.class
+
+ 10. RUBY - Added <ruby> to emphasis.class. Added new 
+     face-markup.class to handle all emphasis except <ruby>.
+     <ruby> will not in this round be recursive.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. CITATION ALTERNATIVES - Added a new element 
+     <citation-alternatives> to the citation.class. The element
+     will hold, for example, a single citation in multiple
+     languages or a single citation tagged as a <mixed-citation>
+     complete with punctuation and spacing and also as an
+     <element-citation> with all punctuation and spacing removed.
+   
+   
+  6. COLLABORATION ALTERNATIVES - Added <collab-alternatives> to
+     the name.class, to allow a <collab-alternatives> elements to
+     be anywhere <collab> already was.
+   
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  5. Created May 2010 as part of adding Publishing OASIS model
+     that uses the OASIS CALS Exchange Table Model rather than the
+     XHTML model. Updated the public identifier to 
+     "v0.4 20110131", modified the formal public identifier to 
+     include "JATS (Z39.96)", and the filename as delivered to 
+     include "JATS" and the new version number "0".
+
+  4. TABLE ELEMENTS- Added the OASIS CALS Table model to the
+     table classes.
+
+  3. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to contrib-info.class to hold multiple <aff>s that are
+     representations of a single affiliation, for example, the name
+     of an institution in two languages or two scripts.
+
+  2. NAME ALTERNATIVES - Added <name-alternatives> to
+     %name.class;, to therefore be used wherever name is allowed.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CLASS OVER-RIDES    -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE FORMATTING CLASS (format.ent)    -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS RENDITION ELEMENTS                -->
+<!--                    All the face markup plus <ruby>            -->
+<!ENTITY % emphasis.class
+                        "bold | fixed-case | italic | monospace | 
+                         overline | roman |  sans-serif | sc | 
+                         strike | underline |
+                         ruby"                                       >
+
+
+<!--                    FACE MARKUP CLASS ELEMENTS                 -->
+<!--                    All the face markup without <ruby>         -->
+<!ENTITY % face-markup.class
+                        "bold | fixed-case |italic | monospace | 
+                         overline | roman | sans-serif | sc | strike |
+                         underline"                                  >
+
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE INLINE CLASSES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    CITATION CLASS ELEMENTS                    -->
+<!--                    Reference to an external document, as used
+                        within, for example, the text of a
+                        paragraph                                  -->
+<!ENTITY % citation.class
+                        "citation-alternatives | element-citation | 
+                         mixed-citation | nlm-citation"              >
+
+
+<!--                    CITATION ADDITIONS CLASS ELEMENTS          -->
+<!--                    Elements that are not part of the broader
+                        -references.class, but that need to be part
+                        of the model for citations.                -->
+<!ENTITY % citation-additions.class
+                        "string-date"                                >
+
+
+<!--                    CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+<!--                    All the citation elements except the
+                        <citation-alternatives> element.           -->
+<!ENTITY % citation-minus-alt.class
+                        "element-citation | mixed-citation | 
+                         nlm-citation"                               >
+
+
+<!--                    CONTRIBUTOR INFORMATION                    -->
+<!--                    Metadata about a contributor               -->
+<!ENTITY % contrib-info.class
+                        "address | aff | aff-alternatives |
+                         author-comment | bio | email | ext-link |
+                         on-behalf-of | role | uri | xref"           >
+
+
+<!--                    DATE CLASS ELEMENTS                        -->
+<!--                    Dates and other matters of history         -->
+<!ENTITY % date.class   "date"                                       >
+
+
+<!--                    NAMES CLASS                                -->
+<!--                    The elements used to name the personal names
+                        for individuals and the collaboration names
+                        for groups
+                        Removed <string-name>                      -->
+<!ENTITY % name.class   "anonymous | collab | collab-alternatives |
+                         name | name-alternatives"                   >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE PARAGRAPH-LIKE ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    REST OF PARAGRAPH CLASS (MINUS PARAGRAPH)  -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Paragraph.
+                        Contains all paragraph-level objects that are
+                        not also used inside tables and excepting
+                        also the paragraph element itself.         -->
+<!ENTITY % rest-of-para.class
+                        "disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!-- ============================================================= -->
+<!--                    TABLE CLASSES                              -->
+<!-- ============================================================= -->
+
+
+<!--                    ALTERNATIVES DISPLAY CLASS ELEMENTS        -->
+<!--                    Display elements that can be alternatives to
+                        each  other inside an alternatives element.
+                          XHTML Table Model    table
+                          OASIS CALS Table     oasis:table         -->
+<!ENTITY % alternatives-display.class
+                        "array | chem-struct | code | graphic |
+                         inline-graphic |
+                         inline-supplementary-material |
+                         media | preformat |private-char |
+                         supplementary-material | 
+                         table | %otable.qname; |
+                         textual-form"                               >
+
+
+<!--                    TABLE CLASS ELEMENTS                       -->
+<!--                    Elements that will be used to contain the
+                        rows and columns inside the Table Wrapper
+                        element <table-wrap>.  The following 
+                        elements can be set up for inclusion:
+                          XHTML Table Model    table
+                          OASIS CALS Table     oasis:table         -->
+<!ENTITY % table.class  "table | %otable.qname;"                     >
+
+
+<!--                    TABLE BODY CLASS                           -->
+<!--                    To include just a table body <tbody> 
+                        element. Both XHTML and OASIS table types. -->
+<!ENTITY % tbody.class  "tbody | %otbody.qname;"                     >
+
+
+<!-- ================== End Publishing Classes Customization ===== -->

--- a/publishing/1.1/JATS-journalpub-oasis-custom-modules1.ent
+++ b/publishing/1.1/JATS-journalpub-oasis-custom-modules1.ent
@@ -1,0 +1,270 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD with OASIS Tables          -->
+<!--             DTD-Specific Modules                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+     Delivered as file "JATS-journalpub-oasis-custom-modules1.ent" -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD with OASIS Tables          -->
+<!--             of the JATS DTD Suite                             -->
+<!--                                                               -->
+<!-- PURPOSE:    To name any modules created explicitly for this   -->
+<!--             DTD, that is, not present in the JATS DTD Suite   -->
+<!--                                                               -->
+<!-- CONTAINS:   Full external Parameter Entity declarations       -->
+<!--             for all Journal Publishing OASIS DTD-Specific     -->
+<!--             modules used by this DTD. (Note: the modules are  -->
+<!--             DECLARED in this module, but referenced [invoked] -->
+<!--             in the Journal Publishing DTD with OASIS Tables   -->
+<!--             DTD module.)                                      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    SET UP OASIS NAMESPACE AND PREFIX          -->
+<!-- ============================================================= -->
+
+
+<!--                    OASIS-TABLE-SPECIFIC NAMESPACE AND PREFIX  -->
+<!--                    Set up the Parameter Entities used to control
+                        the namespace URI and prefix for the OASIS
+                        CALS Exchange table Model (JATS version).  -->
+<!ENTITY % JATS-oasis-namespace.ent
+                        PUBLIC
+"-//NLM//DTD JATS OASIS Table Namespace Module v1.1 20151215//EN"
+"JATS-oasis-namespace1.ent"                                          > 
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES DECLARED             -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element classes in the
+                        DTD Suite. Used for namespaced OASIS 
+                        tables when used alone.                    -->
+<!ENTITY % journalpub-oasis-custom-classes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.1 20151215//EN"
+"JATS-journalpub-oasis-custom-classes1.ent"                          >
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        mix definitions that will be used to
+                        over-ride some element mixes in the DTD
+                        Suite.                                     -->
+<!ENTITY % journalpubcustom-mixes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.1 20151215//EN"
+"JATS-journalpubcustom-mixes1.ent"                                   >
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Set up the Parameter Entities for element-
+                        specific element groups, complete content
+                        models, and attribute list and value over-
+                        rides. These PEs will over-ride selected
+                        content models and attribute lists for the
+                        Journal Archiving and Interchange DTD.     -->
+<!ENTITY % journalpubcustom-models.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.1 20151215//EN"
+"JATS-journalpubcustom-models1.ent"                                  >
+
+
+<!--                    NLM CITATION MODULE                        -->
+<!--                    The only new element created for the
+                        Publishing DTD, the highly structured NLM
+                        citation, to enforce a slightly loose version
+                        of an NLM-structured bibliographic reference.
+                        Sequence is enforced and interior punctuation
+                        is expected to be generated.               -->
+<!ENTITY % nlmcitation.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+"JATS-nlmcitation1.ent"                                              >
+
+
+<!-- =================== End Publishing DTD Module of Modules ==== -->

--- a/publishing/1.1/JATS-journalpubcustom-classes1.ent
+++ b/publishing/1.1/JATS-journalpubcustom-classes1.ent
@@ -1,0 +1,337 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD Customize Classes Module   -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.1 20151215//EN"
+Delivered as file "JATS-journalpubcustom-classes1.ent"             -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the                     -->
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the JATS DTD Suite default named        -->
+<!--             element classes.                                  -->
+<!--                                                               -->
+<!--             This DTD (in contrast to the Journal Archiving    -->
+<!--             and Interchange DTD) has more prescriptive content-->
+<!--             models. There are fewer choices in the models     -->
+<!--             within this DTD, and some XML structures that     -->
+<!--             were made part of the NISO JATS simply to         -->
+<!--             facilitate conversion of existing journal         -->
+<!--             material from other DTDs into this format have not-->
+<!--             been included in this DTD.                        -->
+<!--                                                               -->
+<!--             Similarly, this is also a tighter DTD. Some of the-->
+<!--             attributes that have type CDATA values in the     -->
+<!--             Archiving DTD, and can thus accept any value,     -->
+<!--             have been given explicit value lists in this DTD. -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             content modules that declare elements, and before -->
+<!--             the default classes module.                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 12. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+  
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  9. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  8. CITATION ALTERNATIVES - Added a new element 
+     <citation-alternatives> to the citation.class. The element
+     will hold, for example, a single citation in multiple
+     languages or a single citation tagged as a <mixed-citation>
+     complete with punctuation and spacing and also as an
+     <element-citation> with all punctuation and spacing removed.
+   
+  7. COLLABORATION ALTERNATIVES - Added <collab-alternatives> to
+     the name.class, to allow a <collab-alternatives> elements to
+     be anywhere <collab> already was.
+    
+  6. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to contrib-info.class to hold multiple <aff>s that are
+     representations of a single affiliation, for example, the name
+     of an institution in two languages or two scripts.
+
+  4. NAME ALTERNATIVES - Added <name-alternatives> to
+     %name.class;, to therefore be used wherever name is allowed.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CLASS OVER-RIDES    -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE FORMATTING CLASS (format.ent)    -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS RENDITION ELEMENTS                -->
+<!--                    All the face markup plus <ruby>            -->
+<!ENTITY % emphasis.class
+                        "bold | fixed-case | italic | monospace | 
+                         overline | roman |  sans-serif | sc | 
+                         strike | underline |
+                         ruby"                                       >
+
+
+<!--                    FACE MARKUP CLASS ELEMENTS                 -->
+<!--                    All the face markup without <ruby>         -->
+<!ENTITY % face-markup.class
+                        "bold | fixed-case |italic | monospace | 
+                         overline | roman | sans-serif | sc | strike |
+                         underline"                                  >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE INLINE CLASSES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    CITATION CLASS ELEMENTS                    -->
+<!--                    Reference to an external document, as used
+                        within, for example, the text of a
+                        paragraph                                  -->
+<!ENTITY % citation.class
+                        "citation-alternatives | element-citation | 
+                         mixed-citation | nlm-citation"              >
+
+
+<!--                    CITATION ADDITIONS CLASS ELEMENTS          -->
+<!--                    Elements that are not part of the broader
+                        -references.class, but that need to be part
+                        of the model for citations.                -->
+<!ENTITY % citation-additions.class
+                        "string-date"                                >
+
+
+<!--                    CITATION MINUS ALTERNATIVES CLASS ELEMENTS -->
+<!--                    All the citation elements except the
+                        <citation-alternatives> element.           -->
+<!ENTITY % citation-minus-alt.class
+                        "element-citation | mixed-citation | 
+                         nlm-citation"                               >
+
+
+<!--                    CONTRIBUTOR INFORMATION                    -->
+<!--                    Metadata about a contributor               -->
+<!ENTITY % contrib-info.class
+                        "address | aff | aff-alternatives |
+                         author-comment | bio | email | ext-link |
+                         on-behalf-of | role | uri | xref"           >
+
+
+<!--                    DATE CLASS ELEMENTS                        -->
+<!--                    Dates and other matters of history         -->
+<!ENTITY % date.class   "date"                                       >
+
+
+<!--                    NAMES CLASS                                -->
+<!--                    The elements used to name the personal names
+                        for individuals and the collaboration names
+                        for groups
+                        Removed <string-name>                      -->
+<!ENTITY % name.class   "anonymous | collab | collab-alternatives |
+                         name | name-alternatives"                   >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDE PARAGRAPH-LIKE ELEMENTS          -->
+<!-- ============================================================= -->
+
+
+<!--                    REST OF PARAGRAPH CLASS (MINUS PARAGRAPH)  -->
+<!--                    Information for the reader that is at the
+                        same structural level as a Paragraph.
+                        Contains all paragraph-level objects that are
+                        not also used inside tables and excepting
+                        also the paragraph element itself.         -->
+<!ENTITY % rest-of-para.class
+                        "disp-quote | speech | statement |
+                         verse-group"                                >
+
+
+<!-- ================== End Publishing Classes Customization ===== -->

--- a/publishing/1.1/JATS-journalpubcustom-mixes1.ent
+++ b/publishing/1.1/JATS-journalpubcustom-mixes1.ent
@@ -1,0 +1,258 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD Customize Mixes Module     -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.1 20151215//EN"
+Delivered as file "JATS-journalpubcustom-mixes1.ent"               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the                     -->
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the JATS DTD Suite default named,       -->
+<!--             general purpose mixes. (Mixes for particular      -->
+<!--             elements are declared in the Publishing Custom    -->
+<!--             Models module.)                                   -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             default mixes modules (%default-mixes;)           -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    INLINE MIXES FOR USE IN CONTENT MODELS     -->
+<!--                    (MIXES ARE COMPOSED USING CLASSES)         -->
+<!-- ============================================================= -->
+
+
+<!--                    EMPHASIS MIX ELEMENTS                      -->
+<!--                    Elements that may be used inside most of the
+                        emphasis class elements                    -->
+<!ENTITY % emphasized-text
+                        "| %address-link.class; |
+                         %article-link.class; | %emphasis.class;  |
+                         %inline-display.class; |
+                         %inline-math.class; |  %math.class; |
+                         %phrase.class; | %simple-link.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    JUST RENDITION                             -->
+<!--                    Only the simplest of the typographic
+                        emphasis elements, as well as subscript and
+                        superscript.  Usually used in a model that
+                        allows #PCDATA and this restricted mixture.
+                        This mix may be stripped down to only
+                        subscript and superscript by some, more
+                        restrictive DTDs.
+                        MAINTENANCE NOTE: This Parameter Entity
+                        and the related PE "rendition-plus" have
+                        been put in place to restrict the amount of
+                        variability that a person modifying the DTD
+                        through PE redefinition can achieve. Some
+                        elements have been set #PCDATA plus one PE
+                        and some have been set to #PCDATA plus the
+                        other in an effort to allow designers to
+                        modify entire groups of elements, but not
+                        to change similar models individually .    -->
+<!ENTITY % just-rendition
+                        ""                                           >
+
+
+<!--                    SECTION BACK MATTER ELEMENTS               -->
+<!--                    Back matter elements used inside smaller
+                        structures, such as sections and sidebars  -->
+<!ENTITY % sec-back-matter-mix
+                        "%sec-back.class;"                           >
+
+
+<!-- ================== End Publishing DTD Mixes Customization === -->

--- a/publishing/1.1/JATS-journalpubcustom-models1.ent
+++ b/publishing/1.1/JATS-journalpubcustom-models1.ent
@@ -1,0 +1,979 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD Customize Content and      -->
+<!--             Attributes Module                                 -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.1 20151215//EN"
+Delivered as file "JATS-journalpubcustom-models1.ent"              -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the JATS DTD Suite      -->
+<!--                                                               -->
+<!-- PURPOSE:    To declare the Parameter Entities (PEs) used to   -->
+<!--             over-ride the content models, parts of content    -->
+<!--             models, or attribute lists of the JATS DTD Suite  -->
+<!--                                                               -->
+<!--             Or-groups within models should use mixes or       -->
+<!--             classes rather than name elements directly.       -->
+<!--                                                               -->
+<!--             Note: Since PEs must be declared before they      -->
+<!--             are used, this module must be called before the   -->
+<!--             content modules that declare elements.            -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 25. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 24. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 23. <VOLUME> INSIDE <ARTICLE-META>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+ 
+ 32. VERSION ELEMENTS
+     The new element <version> uses the PE %-just-rendition,
+     but Authoring has set that PE to null, so the <version>
+     element added <sup> and <sub> to be like the content
+     of <edition>.
+ 
+ 31. VALUE LIST FOR PERSON-GROUP-TYPE
+     Added "curator" to the list of preson-group role values.
+
+ 30. EDITION ELEMENTS - Added <sub> and <sup> to the model of
+     edition. These were needed now that the "Edition" element
+     has been renamed and repurposed as "Edition Statement".
+
+ 29. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+ 28. CONFERENCE LOCATION ELEMENTS AND PUBLISHER LOCATION ELEMENTS
+      - Added 3 new OPTIONAL elements: <city>, <state>, 
+        and <postal-code> by adding address.class
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 27. ON-BEHALF-OF NEW CONTENT
+     Added <xref>, <fn>, and <target> (the simple links) to 
+     <on-behalf-of>.
+
+ 26. ADDED <string-date> to <mixed-citation> and <element-citation>
+     through citation-elements.
+
+ 25. NEW ELEMENT <era>
+     Added to the model of <date>, optional following year,
+     through date-model.
+
+ 24. XML Base
+     Added the attribute @xml:base to the Global (common)
+     attributes used on all elements.
+
+ 23. INSTITUTION-WRAP ADDED
+     Added the element <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <conf-sponsor>
+      - <publisher-name>
+      - <std-organization>
+
+ 22.  GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     All attribute lists in this module changed.
+
+ 21. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - ack (through %ack-model;)
+        - fig (through %fig-model;)
+        - fig-group (through %fig-group-model;)
+
+     - Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - article-meta (through %article-meta-model;)
+
+ 20. ACKNOWLEDGEMENT MODEL
+     - Added optional, repeatable <kwd-group> to the beginning of 
+       <ack> (through %ack-model;).
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 19. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <article-meta> using article-meta-model.
+
+ 18. CONTRIBUTOR MODEL - Added "contrib-id.class" to the beginning
+     at the <contrib> model, to hold identifiers for people,
+     such as publishers-specific IDs and ORCIDs.
+      
+ 17. STANDARDS ORGANIZATION - Added std-organization-elements
+     to reduce what was allowed in the names of standards bodies.
+   
+ 16. JOURNAL METADATA MODEL
+     - Added <issn-l> as an optional element to <journal-meta>
+     - Added contributors and affiliations to journal metadata through
+       contrib-group.class (which resolves to <contrib-group>) and 
+       aff-alternatives.class (which resolves to <aff> or
+       <aff-alternatives>), using the journal-meta-model.
+   
+ 15. JOURNAL METADATA MODEL
+      
+ 14. PARAGRAPH PARAMETER ENTITY SYNTAX CHANGE (no models changed)
+     Fixed content models that were stated as "p*" and "sec*"
+     to use the %just-para.class;, %sec.class, and %ref-list.class; 
+     classes. Element models that were changed include:
+      - abstract
+      - ack
+      - trans-abstract
+   
+ 13. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 12. Updated the DTD-version attribute to "0.4" 
+   
+ 11. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+ 10. POSITION ATTRIBUTE - Added the value "background"
+
+  9. PREFORMAT - Added <alt-text> and <long-desc> to <preformat> by
+     adding %access.class; to %preformat-elements;
+
+  8. INITIALS - Removed the attribute over-ride for <surname> and
+     <given-names> to allow the use of @initials.
+
+  7. JOURNAL METADATA- Added <notes> to repeat within <journal-meta>
+     (through %journal-meta-model; and added @xml:lang and
+     @specific-use to the attributes of <notes> through %notes-atts;
+
+  6. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <article-meta> through %article meta-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  5. PERSON-GROUP - Became a mixed-content model, so the parameter
+     entity %person-group-model: was changed to
+     %person-group-elements;, which will be mixed with #PCDATA
+     as defined in references.ent. The PE person-group-model has
+     been retained in references.ent for compatibility, but has been
+     set to the mixed model using person-group-elements.
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to %display-atts;. Also added these attributes
+     to the following over-rides:
+      - inline-graphic through inline-graphic-atts (both)
+      - fn through fn-atts (added @specific-use, @xml:lang already
+          there)
+      - person-group through person-group-atts (both)
+
+  3. LABEL - Added optional <label> to <fig-group> using
+     %fig-group-model; as the first element in model, before caption
+
+  2. SELF URI - Added <self-uri> to <journal-meta> (directly
+     following <notes>) so that an XML document can point to the
+     journal home page.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    INLINE MIXES TO OVER-RIDE CONTENT MODELS   -->
+<!--                    (ELEMENTS TO BE ADDED TO #PCDATA IN MODELS)-->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATED JOURNAL TITLE ELEMENTS         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <abbrev-journal-title>
+                        Removed the face markup, %just-rendition;  -->
+<!ENTITY % abbrev-journal-title-elements
+                        ""                                           >
+
+
+<!--                    CITATION ELEMENTS                          -->
+<!--                    Content for both types of citation. These
+                        elements may be mixed with #PCDATA in the
+                        <mixed-citation> element (in which all
+                        punctuation and spacing are left intact), and
+                        they also constitute the choices that can be
+                        used to form the all-element-content of the
+                        <element-citation> element (in which
+                        punctuation and spacing are removed).
+                        Design Note: All inline mixes begin with an
+                        OR bar.                                    -->
+<!ENTITY % citation-elements
+                        "%citation-additions.class; |
+                         %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; | %label.class; |
+                         %phrase.class; | %references.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    CONFERENCE ACRONYM ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference acronym.
+                        Removed %simple-text;                      -->
+<!ENTITY % conf-acronym-elements
+                        ""                                           >
+
+
+<!--                    CONFERENCE LOCATION ELEMENTS               -->
+<!--                    Elements for use in the <conf-loc> element
+                        Removed %simple-text;                      -->
+<!ENTITY % conf-loc-elements
+                        "| %address.class;"                          >
+
+
+<!--                    CONFERENCE NAME ELEMENTS                   -->
+<!--                    Elements for use in the <conf-name> element.
+                        Removed %simple-text;                      -->
+<!ENTITY % conf-name-elements
+                        ""                                           >
+
+
+<!--                    CONFERENCE NUMBER ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference number.
+                        Removed %simple-text;                      -->
+<!ENTITY % conf-num-elements
+                        ""                                           >
+
+
+<!--                    CONFERENCE SPONSOR  ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the conference sponsor.
+                        Removed %simple-text;                      -->
+<!ENTITY % conf-sponsor-elements
+                        "| %institution-wrap.class;"                 >
+
+
+<!--                    DEGREE(S) ELEMENTS                         -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <degrees>
+                        Removed %just-rendition;                   -->
+<!ENTITY % degrees-elements
+                        ""                                           >
+
+
+<!--                    EDITION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        Removed %just-rendition;                   -->
+<!ENTITY % edition-elements
+                        "| %subsup.class;"                           >
+
+
+<!--                    FAX NUMBER ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <fax>
+                        Removed %just-rendition;                   -->
+<!ENTITY % fax-elements
+                        ""                                           >
+
+
+<!--                    GIVEN (FIRST) NAMES ELEMENTS               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <given-names>
+                        Removed %just-rendition;                   -->
+<!ENTITY % given-names-elements
+                        ""                                           >
+
+
+<!--                    INSTITUTION NAME ELEMENTS                  -->
+<!--                    Elements for use in the <institution>
+                        element
+                        Removed %break.class; and %emphasis.class; -->
+<!ENTITY % institution-elements
+                        "| %subsup.class;"                           >
+
+
+<!--                    ISSUE TITLE ELEMENTS                       -->
+<!--                    Elements for use with data characters inside
+                        the model for the <issue> element
+                        Removed %just-rendition;                   -->
+<!ENTITY % issue-elements
+                        ""                                           >
+
+
+<!--                    JOURNAL TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <journal-title>
+                        Removed %just-rendition;                   -->
+<!ENTITY % journal-title-elements
+                        ""                                           >
+
+
+<!--                    KEYWORD CONTENT ELEMENTS                   -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a keyword <kwd>.                           -->
+<!ENTITY % kwd-elements
+                        "| %emphasis.class; | %phrase-content.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    PATENT NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <patent>
+                        Removed %just-rendition;                   -->
+<!ENTITY % patent-elements
+                        ""                                           >
+
+
+<!--                    PERSON GROUP MODEL                         -->
+<!--                    Content model for the <person-group> element
+                                                                   -->
+<!ENTITY % person-group-elements
+                        "| %name.class; | %person-group-info.class; |
+                          %string-name.class;"                       >
+
+
+<!--                    PHONE NUMBER ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <phone number>
+                        Removed %just-rendition;                   -->
+<!ENTITY % phone-elements
+                        ""                                           >
+
+
+<!--                    PREFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <prefix>
+                        Removed %just-rendition;                   -->
+<!ENTITY % prefix-elements
+                        ""                                           >
+
+
+<!--                    PREFORMATTED TEXT ELEMENTS                 -->
+<!--                    Elements that may be used, along with data
+                        characters, inside the content model for the
+                        <preformat> element, in which whitespace,
+                        such as tabs, line feeds, and spaces will
+                        be preserved                               -->
+<!ENTITY % preformat-elements
+                        "| %access.class; | %address-link.class; |
+                         %display-back-matter.class; |
+                         %emphasis.class; | %phrase.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    PUBLISHER'S LOCATION ELEMENTS              -->
+<!--                    Elements for use in the Publisher Location
+                        <publisher-loc> element
+                        Removed emphasis.class;, and %subsup.class;-->
+<!ENTITY % publisher-loc-elements
+                        "| %address.class; | %address-link.class;"   >
+
+
+<!--                    PUBLISHER'S NAME ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <publisher-name>
+                        Removed %just-rendition;                   -->
+<!ENTITY % publisher-name-elements
+                        "| %institution-wrap.class;"                 >
+
+
+<!--                    STANDARDS ORGANIZATION ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std-organization>.
+                        Removed emphasis.class.                    -->
+<!ENTITY % std-organization-elements
+                        "| %institution-wrap.class; | %subsup.class;">
+
+
+<!--                    SUFFIX ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <suffix>
+                        Removed %just-rendition;                   -->
+<!ENTITY % suffix-elements
+                        ""                                           >
+
+
+<!--                    SURNAME ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <surname>
+                        Removed %just-rendition;                   -->
+<!ENTITY % surname-elements
+                        ""                                           >
+
+
+<!--                    URI ELEMENTS                               -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <uri>
+                        Removed %just-rendition;                   -->
+<!ENTITY % uri-elements
+                        ""                                           >
+
+
+<!--                    VERSION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <version>                                  -->
+<!ENTITY % version-elements
+                        "| %subsup.class;"                           >
+
+
+<!--                    VOLUME NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <volume>
+                        Removed %just-rendition;                   -->
+<!ENTITY % volume-elements
+                        ""                                           >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES OF CONTENT MODELS (FULL MODELS) -->
+<!-- ============================================================= -->
+
+
+<!--                    ABSTRACT MODEL                             -->
+<!--                    Abstracts may contain one or more paragraphs
+                        (as a typical abstract does) or titled
+                        sections, as is done in many physics
+                        articles.
+                        Unlike the default model in the base DTD
+                        Suite, this <abstract> requires that all
+                        sections in the abstract start with titles.-->
+<!ENTITY % abstract-model
+                        "(label?, title?, (%just-para.class;)*, 
+                          (%sec.class;)*)"                           >
+
+
+<!--                    ACKNOWLEDGMENTS MODEL                      -->
+<!--                    Content model for the <ack> element        -->
+<!ENTITY % ack-model    "(label?, title?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%just-para.class;)*, 
+                          (%sec.class;)*, (%ref-list.class;)* )"     >
+
+
+<!--                    ANONYMOUS MODEL                            -->
+<!--                    Unlike in Green, <anonymous> is empty. When
+                        present, it is used to generate the text
+                        "anonymous" or "anon.", etc.               -->
+<!ENTITY % anonymous-model
+                        "EMPTY"                                      >
+
+
+<!--                    ARRAY CONTENT MODEL                        -->
+<!--                    The element used to contain material in
+                        rows and columns that is just a block insert
+                        into the text flow, not numbered or called a
+                        table, and not titled or captioned         -->
+<!ENTITY % array-model  "((%access.class; | %address-link.class;)*,
+                          ( (%just-base-display.class;)* |
+                            %tbody.class; ),
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    ARTICLE METADATA MODEL                     -->
+<!--                    Full content model for the metadata that is
+                        specific to the article.
+                        Unlike in Archive DTD, some of the metadata
+                        is required here.                          -->
+<!ENTITY % article-meta-model
+                       "(article-id*, article-categories?,
+                         title-group,
+                         ( %contrib-group.class; |
+                           %aff-alternatives.class;)*,
+                         author-notes?, pub-date+,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id)?,
+                         (%address-link.class; | product |
+                          supplementary-material)*, 
+                         history?, permissions?, self-uri*, 
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    CONFERENCE MODEL                           -->
+<!--                    The content model of the <conference>
+                        element                                    -->
+<!ENTITY % conference-model
+                        "(conf-date, (conf-name | conf-acronym )+,
+                         conf-num?, conf-loc?, conf-sponsor*,
+                         conf-theme?)"                               >
+
+
+<!--                    CONTRIBUTOR MODEL                          -->
+<!--                    Content model for the <contrib> element    -->
+<!ENTITY % contrib-model
+                        "((%contrib-id.class;)*, (%name.class;)*, 
+                          (%degree.class;)*,
+                          (%contrib-info.class;)* )"                 >
+
+
+<!--                    DATE ELEMENTS MODEL                        -->
+<!--                    The content models for elements that describe
+                        dates, such as Publication Date <pub-date> and
+                        History Dates <date>.  The <string-date>
+                        element holds dates for which months and
+                        years are not given, for example "first
+                        quarter", "spring", etc.
+                        Unlike the base DTD Suite, this <date>
+                        requires a <year> and may not take a string
+                        date as an alternative.                    -->
+<!ENTITY % date-model   "(((day?, month?) | season)?, year, era?)"   >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM ELEMENTS  -->
+<!--                    The content model of a <def-item>.         -->
+<!ENTITY % def-item-model
+                        "(term, def*)"                               >
+
+
+<!--                    FIGURE-LIKE CONTENT MODEL                  -->
+<!--                    Content model for the Figure element and any
+                        similarly structured elements
+                        Made <label> and <caption> non-repeatable. -->
+<!ENTITY % fig-model    "((%id.class;)*, label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%block-math.class; |
+                           %chem-struct-wrap.class; |
+                           %intable-para.class; |
+                           %just-table.class; | %just-para.class; |
+                           %list.class; | %simple-display.class;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    FIGURE GROUP MODEL                         -->
+<!--                    Content model for a <fig-group>            -->
+<!ENTITY % fig-group-model
+                        "(label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%fig-display.class; |
+                           %just-base-display.class;)* )"            >
+
+
+<!--                    JOURNAL METADATA MODEL                     -->
+<!--                    Content model for the journal metadata
+                        element <journal-meta>                     -->
+<!ENTITY % journal-meta-model
+                        "(journal-id+, journal-title-group*,
+                          (%contrib-group.class; |
+                          %aff-alternatives.class;)*,
+                          issn+, issn-l?, isbn*, publisher?, notes*,
+                          self-uri*)"                                >
+
+
+<!--                    LIST MODEL                                 -->
+<!--                    Content model for the <list> element       -->
+<!ENTITY % list-model   "(label?, title?, (%list-item.class;)+)"     >
+
+
+<!--                    ON BEHALF OF CONTENT ELEMENTS              -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <on-behalf-of>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix beguines with
+                        an OR bar.                                 -->
+<!ENTITY % on-behalf-of-elements
+                        "%rendition-plus; | %institution-wrap.class; |
+                         %simple-link.class;"                        >
+
+
+<!--                    REFERENCE ITEM MODEL                       -->
+<!--                    Content model for the <ref> element        -->
+<!ENTITY % ref-model    "(label?,
+                         (%citation.class; | %note.class;)+ )"       >
+
+
+<!--                    CONTENT MODEL FOR A STRUCTURAL SECTION     -->
+<!--                    The model for a section that requires that a
+                        either <title> or a <label> (which in some
+                        journals takes the place of a title) must be
+                        present. One or the other must be present
+                        for autogeneration of a Table of Contents or
+                        other navigation.                          -->
+<!ENTITY % sec-model    "(sec-meta?, ( (label, title?) | title ),
+                          (%para-level;)*,
+                          (%sec-level;)*,
+                          (%sec-back-matter-mix;)* )"                >
+
+
+<!--                    TRANSLATED ABSTRACT MODEL                  -->
+<!--                    Content model for an <trans-abstract>
+                        element                                    -->
+<!ENTITY % trans-abstract-model
+                        "(label?, title?, (%just-para.class;)*, 
+                          (%sec.class;)*)"                           >
+
+
+<!-- ============================================================= -->
+<!--                    DUPLICATE ATTRIBUTE DECLARATIONS           -->
+<!--                    (These are unchanged from the base Suite,  -->
+<!--                    but are used in attribute over-rides below)-->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES                          -->
+<!--                    These lists of attributes will be added to 
+                        nearly every element, in both the document 
+                        metadata and the document body, of the entire 
+                        Tag Set:
+                          - including table elements for both the 
+                              XHTML-inspired and OASIS-inspired
+                              table model elements
+                          - excluding only <mml:math> and 
+                              <xi:include> (whose namespaces JATS
+                              does not control).
+                           Great care should be taken to use these
+                        attributes judiciously, not as a shortcut to
+                        thinking through where an attribute should be
+                        used. Potential use cases include adding
+                        @xml:lang or some RDFa attribute to every 
+                        elements.                                  -->
+
+
+<!--                    JATS BASE ATTRIBUTES                       -->
+<!--                    Holds all the common attributes except @id.
+                        Used to keep the two common attribute lists 
+                        in sync. To add a global attribute, modify
+                        this list.                                 -->
+<!ENTITY % jats-base-atts
+            "xml:base   CDATA                             #IMPLIED"  >
+
+
+<!--                    JATS COMMON ATTRIBUTES                     -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus an
+                        optional @id.                              -->
+<!ENTITY % jats-common-atts
+            "id         ID                                #IMPLIED 
+             %jats-base-atts;"                                       >
+
+
+<!--                    JATS COMMON ATTRIBUTES (ID REQUIRED)       -->
+<!--                    Holds all the common attributes, as defined in
+                        the base attribute parameter entity, plus a 
+                        required @id.                              -->
+<!ENTITY % jats-common-atts-id-required
+            "id         ID                                #REQUIRED
+             %jats-base-atts;"                                       >
+
+
+<!--                    DISPLAY ATTRIBUTES                         -->
+<!--                    Attributes used for several of the block
+                        display elements                           -->
+<!ENTITY % display-atts
+            "position   (anchor | background | float | margin)
+                                                          'float'
+             orientation
+                        (portrait | landscape)            'portrait'
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    XLINK LINK ATTRIBUTES                      -->
+<!--                    Attributes for any element that must be a
+                        link                                       -->
+<!ENTITY % link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #REQUIRED
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!--                    MIGHT LINK XLINK ATTRIBUTES                -->
+<!--                    Attributes for any element that may be a link
+                        but need not be one                        -->
+<!ENTITY % might-link-atts
+            "xmlns:xlink CDATA                            #IMPLIED
+             xlink:type  (simple)                         #IMPLIED
+             xlink:href  CDATA                            #IMPLIED
+             xlink:role  CDATA                            #IMPLIED
+             xlink:title CDATA                            #IMPLIED
+             xlink:show  (embed | new | none | other | replace)
+                                                          #IMPLIED
+             xlink:actuate
+                         (none | onLoad | onRequest | other)
+                                                          #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    OVER-RIDES OF ATTRIBUTE LISTS              -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE TYPE VALUES                       -->
+<!--                    Used to mark the semantics of the footnote,
+                        what information does this footnote convey.
+                                                                   -->
+<!ENTITY % fn-types     "abbr | com | con | conflict |
+                         corresp | current-aff | deceased |
+                         edited-by | equal |
+                         financial-disclosure | on-leave |
+                         participating-researchers |
+                         presented-at | presented-by |
+                         present-address | previously-at |
+                         study-group-members |
+                         supplementary-material |
+                         supported-by | other"                       >
+
+
+<!--                    FOOTNOTE ATTRIBUTES                        -->
+<!--                    Attribute list for Footnote element
+                        Unlike base, "fn-type" values have been made
+                        explicit and removed the symbol attribute  -->
+<!ENTITY % fn-atts
+            "%jats-common-atts;                                       
+             fn-type    (%fn-types;)                      #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             symbol     CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INLINE GRAPHIC ATTRIBUTES                  -->
+<!--                    Attributes for Inline Graphic
+                        <inline-graphic>                           -->
+<!ENTITY % inline-graphic-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                              #IMPLIED
+             baseline-shift
+                       CDATA                              #IMPLIED
+             mimetype  CDATA                              #IMPLIED
+             mime-subtype
+                       CDATA                              #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %link-atts;"                                            >
+
+
+<!--                    PERSON GROUP ATTRIBUTES                    -->
+<!--                    Attributes for the <person-group> element  -->
+<!ENTITY % person-group-atts
+            "%jats-common-atts;                                       
+             person-group-type
+                        (allauthors | assignee | author | compiler |
+                         curator | director | editor | guest-editor |
+                         inventor | translator | transed) #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED" >
+
+
+<!--                    SECTION ATTRIBUTES                         -->
+<!--                    Attribute list for Section element         -->
+<!ENTITY % sec-atts
+            "%jats-common-atts;                                       
+             xml:lang   NMTOKEN                            #IMPLIED
+             sec-type   CDATA                              #IMPLIED
+             specific-use
+                        CDATA                              #IMPLIED" >
+
+
+<!-- ================== End Publishing Content/ATT Override ====== -->

--- a/publishing/1.1/JATS-journalpubcustom-modules1.ent
+++ b/publishing/1.1/JATS-journalpubcustom-modules1.ent
@@ -1,0 +1,261 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD-Specific Modules           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.1 20151215//EN"
+     Delivered as file "JATS-journalpubcustom-modules1.ent"        -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the                     -->
+<!--             JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    To name any modules created explicitly for this   -->
+<!--             Publishing DTD, that is, not present in the       -->
+<!--             JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- CONTAINS:   Full external Parameter Entity declarations       -->
+<!--             for all Journal Publishing DTD-Specific modules   -->
+<!--             used by this DTD. (Note: the modules are DECLARED -->
+<!--             in this module, but referenced [invoked] in the   -->
+<!--             Journal Publishing DTD module.)                   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES DECLARED             -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element classes in the
+                        DTD Suite.                                 -->
+<!ENTITY % journalpubcustom-classes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.1 20151215//EN"
+"JATS-journalpubcustom-classes1.ent"                                 >
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        mix definitions that will be used to
+                        over-ride some element mixes in the DTD
+                        Suite.                                     -->
+<!ENTITY % journalpubcustom-mixes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.1 20151215//EN"
+"JATS-journalpubcustom-mixes1.ent"                                   >
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Set up the Parameter Entities for element-
+                        specific element groups, complete content
+                        models, and attribute list and value over-
+                        rides. These PEs will over-ride selected
+                        content models and attribute lists for the
+                        Journal Archiving and Interchange DTD.     -->
+<!ENTITY % journalpubcustom-models.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.1 20151215//EN"
+"JATS-journalpubcustom-models1.ent"                                  >
+
+
+<!--                    NLM CITATION MODULE                        -->
+<!--                    The only new element created for the
+                        Publishing DTD, the highly structured NLM
+                        citation, to enforce a slightly loose version
+                        of an NLM-structured bibliographic reference.
+                        Sequence is enforced and interior punctuation
+                        is expected to be generated.               -->
+<!ENTITY % nlmcitation.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+"JATS-nlmcitation1.ent"                                              >
+
+
+<!-- =================== End Publishing DTD Module of Modules ==== -->

--- a/publishing/1.1/JATS-journalpublishing-oasis-article1-mathml3.dtd
+++ b/publishing/1.1/JATS-journalpublishing-oasis-article1-mathml3.dtd
@@ -1,0 +1,889 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD with OASIS Tables          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables with MathML3 v1.1 20151215//EN"
+     Delivered as file "JATS-journalpublishing-oasis-article1-mathml3.dtd" -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD with OASIS Tables          -->
+<!--             of the JATS DTD Suite                             -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD for the creation of new journal articles.     -->
+<!--             This model is an extension of the Journal         -->
+<!--             Publishing DTD that contains both the XHTML       -->
+<!--             table and the CALS OASIS Exchange Table models.   -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is an application of   -->
+<!--             the ANSI/NISO Z39.96 Journal Publishing Tag Set.  --> 
+<!--             It is a subset of the Journal Archiving and       -->
+<!--             Interchange DTD that is optimized for the         -->
+<!--             creation or publishing of existing journal        -->
+<!--             articles and some non-article material such as    -->
+<!--             product and book reviews in XML. It describes     -->
+<!--             both the metadata for a journal article and       -->
+<!--             the full content of the article.                  -->               
+<!--                                                               -->
+<!--             This DTD was constructed using the modules in the -->
+<!--             JATS DTD Suite.                                   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2003                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 23. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-0301)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 22. ALI - Added ALI namespace for NISO Access and Indicator 
+     license reference and free to read elements.
+
+ 21. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 20. <VOLUME> INSIDE <ARTICLE-META> and <FRONT-STUB>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+
+ 19. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 18. MATHML 3.0 - Created a new version of the Publishing DTD to
+     take MathML 3.0 instead of MathML 2.0.
+     Nothing else changed from regular Publishing DTD.
+     Call to MathML setup module changed and added call to the
+     specific MathML 3.0 modules.
+   
+ 17. DTD Version - Updated the DTD-version attribute to "1.1d1" and 
+     the formal public identifier to the date: "v1.1d1 20130915//EN".
+
+ 16. GLOBAL ATTRIBUTES - Added the new module for Common (global)
+     attributes: %JATS-common-atts.ent;, called in before the
+     customizations models module.
+
+ 15. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - back
+      - front
+      - front-stub
+                          
+ 14. ABSTRACTS AND KEYWORDS
+     - Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - front-stub (through %front-stub-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 13. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <front-stub> using front-stub-model.
+   
+ 12. OASIS NAMESPACE - Added the OASIS table namespace handling,
+     which, by default, places a namespace prefix of "oasis" on
+     the OASIS CALS Exchange Table Model.
+      - Added call to JATS-oasis-namespace.ent 
+   
+ 11. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 10. Updated the DTD-version attribute to "0.4" 
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  8. OASIS TABLES - Replaced the XHTML table model with the
+     OASIS CALS exchange Table Model
+
+  7. BODY ATTRIBUTES - Added attribute list and new PE %body-atts;
+     to the model of <body>. The only current attribute is
+     @specific-use, which indicates, for example, not a real
+     tagged XML body, but a 'bag of words" for indexing purposes.
+
+  6. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <sub-article> through %sub-article-atts;
+      - <response> through %response-atts;
+
+  5. XML:LANG - Added @xml:lang to the following elements:
+     Added to facilitate multiple languages.
+       - article
+
+  4. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <front-stub> through %front-stub-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  3. LANGUAGE CODES - Codes for languages as well as variants,
+     transliterations, regions, scripts, and combinations
+     such as "Jpan"(Han + Hiragana + Katakana). These values should be
+     taken from RFC 5646/W3C/IANA Subtag Registry recommendations
+     and can be found online at:
+       http://www.iana.org/assignments/language-subtag-registry
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+<!-- MODULAR DTD LIBRARY
+                        A set of journal archiving and interchange
+                        DTD modules was written as the basis for
+                        publishing, interchange, and repository
+                        DTDs, with the intention that DTDs for
+                        specific purposes, such as this publishing
+                        DTD, would be developed based on them.
+
+                        This publishing DTD has been optimized for
+                        the creation of new journal articles. This
+                        means that it is far smaller (fewer elements,
+                        and fewer choices in many contexts) than was
+                        the interchange DTD. Where in the interchange
+                        DTD there may have been several ways to
+                        express the same information, only one is
+                        provided for authoring. It was not the
+                        intention to limit the expressive power
+                        licensed by the DTD, but rather to limit the
+                        meaningless choices needed in a full
+                        archiving and interchange DTD that make
+                        conversion from a wide variety of formats as
+                        easy as possible.
+
+                        This Publishing DTD has been developed from
+                        the JATS DTD Suite modules, in the approved 
+                        manner, making changes to the declarations 
+                        in those modules by overriding Parameter 
+                        Entity contents by redefining the entities 
+                        in the:
+                           %journalpub-oasis-custom-classes.ent;
+                           %journalpubcustom-mixes.ent;
+                           %journalpubcustom-models.ent;
+                        modules, which are called from this DTD file.
+                        
+                        Additional Publishing-DTD-Specific material
+                        is defined in the module(s):
+                           %nlmcitation.ent;
+                        No changes to any of the original JATS DTD 
+                        Suite modules are required in order to 
+                        use this DTD.                              -->
+
+<!-- ============================================================= -->
+<!--                    MODULES OF MODULES INVOKED                 -->
+<!-- ============================================================= -->
+
+<!--                    MODULE TO NAME DTD-SPECIFIC MODULES        -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % journalpub-oasis-custom-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+"JATS-journalpub-oasis-custom-modules1.ent"                          >
+%journalpub-oasis-custom-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MATHML 3.0 MODULES      -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % mathml3-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.1 20151215//EN"
+"JATS-mathml3-modules1.ent"                                          >
+%mathml3-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MODULES                 -->
+<!--                    Declares all the external modules that are
+                        part of the modular JATS DTD Suite library. 
+                        Thus it does NOT declare itself; 
+                        the DTD-specific module-of-modules; or 
+                        any of the DTD-specific class, mix, or model
+                        over-ride modules. Those are declared in the 
+                        DTD-specific module of modules.
+                           Since this module declares but does not
+                        invoke modules, this DTD invokes any modules
+                        it uses by referencing the external
+                        Parameter Entities defined in the Module of
+                        Modules. To include a set of elements (such
+                        as all the lists or the table elements) this
+                        module defines the external Parameter Entity
+                        for the module(s) that contains the MathML
+                        declarations and the DTD references that
+                        entity.                                    -->
+<!ENTITY % modules.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+"JATS-modules1.ent"                                                  >
+%modules.ent;
+
+<!-- ============================================================= -->
+<!--                    NISO ALI NAMESPACE SETUP                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE ALI NAMESPACE ATTRIBUTE AND PREFIX  -->
+<!--                    Names the module defines the NISO Access and 
+                        Indicators Exchange Model namespace, prefix, 
+                        and pseudo-attribute @xmlns.               -->
+%JATS-ali-namespace.ent;
+
+
+<!-- ============================================================= -->
+<!--                    OASIS NAMESPACE SETUP                      -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE OASIS NAMESPACE ATTRIBUTE AND PREFIX-->
+<!--                    Names the module defines the OASIS CALS
+                        Exchange Model namespace, prefix, and
+                        pseudo-attribute @xmlns and all the 
+                        element qnames for CALS Tables.            -->
+%JATS-oasis-namespace.ent;
+                                                            
+
+<!-- ============================================================= -->
+<!--                    SET UP COMMON (ALL ELEMENT) ATTRIBUTES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES MODULE                   -->
+<!--                    Set up the common attributes, those used on
+                        nearly all elements.
+                        Must be called before the custom models
+                        module.                                    -->
+%JATS-common-atts.ent;
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES INVOKED              -->
+<!--                    Note: These modules must be called after   -->
+<!--                    all Module of Modules but before any other -->
+<!--                    modules. Unlike any other grouping, order  -->
+<!--                    of these modules matters.                  -->
+<!-- ============================================================= -->
+
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Names the module that holds the DTD-specific
+                        class definitions for the Journal Publishing
+                        DTD that will over-ride classes in the Suite.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpub-oasis-custom-classes.ent;
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Names the module that holds the standard
+                        class definitions for the JATS DTD Suite.  -->
+%default-classes.ent;
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element mixes in this DTD.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpubcustom-mixes.ent;
+
+
+<!--                    DEFAULT MIX CUSTOMIZATIONS MODULE          -->
+<!--                    Names the module that holds the standard
+                        mix definitions for the JATS DTD Suite.    -->
+%default-mixes.ent;
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Names the module that holds the over-rides
+                        of content models, attribute lists, elements
+                        lists to be used in content models, and
+                        attribute values. These are DTD-specific.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpubcustom-models.ent;
+
+
+
+<!-- ============================================================= -->
+<!--                    COMMON (SHARED) ELEMENTS MODULE INVOKED    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) DECLARATIONS               -->
+<!--                    Declarations for elements, attributes,
+                        entities, and Notations that are shared by
+                        more than one class module. Note: Must be
+                        called before any of the class modules.    -->
+
+%common.ent;
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE CLASS ELEMENTS (alpha)     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+%articlemeta.ent;
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+%backmatter.ent;
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS               -->
+%display.ent;
+
+
+<!--                    FORMATTING ELEMENT CLASSES                 -->
+<!--                    Elements that change rendition/display.    -->
+%format.ent;
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that describe the sponsorship or
+                        open access                                -->
+%funding.ent;
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+%journalmeta.ent;
+
+
+<!--                    LINK CLASS ELEMENTS                        -->
+%link.ent;
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+%list.ent;
+
+
+<!--                    MATH ELEMENTS                              -->
+%math.ent;
+
+
+<!--                    NLM CITATION ELEMENT                       -->
+%nlmcitation.ent;
+
+
+<!--                    OASIS EXCHANGE (CALS) TABLE SETUP MODULE   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invokes OASIS Exchange table
+                        module                                     -->
+%oasis-tablesetup.ent;
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+%para.ent;
+
+
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+%phrase.ent;
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION)
+                        CLASS ELEMENTS                             -->
+%references.ent;
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+%related-object.ent;
+
+
+<!--                    SECTION ELEMENTS                           -->
+%section.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML SETUP MODULE                        -->
+<!--                    Invoke the MathML modules                  -->
+%mathml3-mathmlsetup.ent;
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invoke XHTML (HTML 4.0) table
+                        module                                     -->
+%XHTMLtablesetup.ent;
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Standard XML special character entities
+                        used in this DTD                           -->
+%xmlspecchars.ent;
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Custom special character entities created
+                        specifically for use in this DTD Suite     -->
+%chars.ent;
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+%notat.ent;
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD VERSION                                -->
+<!--                    What version of this DTD was used to make
+                        the document instance under consideration.
+                        Note that this is a fixed value that should
+                        change every time the DTD changes versions or
+                        revisions.                                 -->
+<!ENTITY % dtd-version
+            "dtd-version
+                        CDATA                        #FIXED '1.1'"   >
+
+
+<!--                    ARTICLE ATTRIBUTES                         -->
+<!--                    Attributes for the top-level element
+                        <article>. OASIS Tables are namespaced at
+                        the <table> level rather than here.        -->
+<!ENTITY % article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             %dtd-version;
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           'en'
+             %XLINK.xmlns.attrib;
+             %MATHML.xmlns.attrib;
+             %Schema.xmlns.attrib;
+             %ali.xmlns.attrib;
+             %oasis.xmlns.attrib;"                                   >
+
+
+<!--                    BACK ATTRIBUTES                            -->
+<!--                    Attributes for the <back> element          -->
+<!ENTITY % back-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    BODY ATTRIBUTES                            -->
+<!--                    Attributes for the <body> element          -->
+<!ENTITY % body-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FRONT ATTRIBUTES                           -->
+<!--                    Attributes for the <front> element         -->
+<!ENTITY % front-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FRONT STUB ATTRIBUTES                      -->
+<!--                    Attributes for the <front-stub> element    -->
+<!ENTITY % front-stub-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SUB-ARTICLE ATTRIBUTES                     -->
+<!--                    Attributes for the <sub-article> element   -->
+<!ENTITY % sub-article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESPONSE ATTRIBUTES                        -->
+<!--                    Attributes for the <response> element      -->
+<!ENTITY % response-atts
+            "%jats-common-atts;                                       
+             response-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE MODEL (LIMITED)                    -->
+<!--                    Article-like model used for, for example,
+                        a short sub-article such as a news brief that
+                        is contained in side a journal article.
+                                                                   -->
+<!ENTITY % article-short-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?)"                            >
+
+
+<!--                    ARTICLE MODEL WITH SUB-ARTICLE OR RESPONSE -->
+<!--                    Typical journal article model, which may
+                        contain extended components, such as
+                        sub-articles or responses, but which usually
+                        contains neither.
+                                                                   -->
+<!ENTITY % article-full-model
+                        "(front, body?, back?, floats-group?,
+                         (sub-article* | response*) )"               >
+
+
+<!--                    ARTICLE                                    -->
+<!--                    The complete content of a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article
+                                                                   -->
+<!ELEMENT  article    %article-full-model;                         >
+<!ATTLIST  article
+             %article-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FRONT MATTER MODEL                         -->
+<!--                    Model for the <front> matter (the header
+                        metadata) of a journal article)            -->
+<!ENTITY % front-model  "(journal-meta, article-meta,
+                          (%front-back.class;)? )"                   >
+
+
+<!--                    FRONT MATTER                               -->
+<!--                    The metadata concerning an article, such as
+                        the name and issue of the journal in which it
+                        appears and the name and author(s) of the
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front
+                                                                   -->
+<!ELEMENT  front        %front-model;                                >
+<!ATTLIST  front
+             %front-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BODY ELEMENTS                              -->
+<!-- ============================================================= -->
+
+
+<!--                    BODY MODEL                                 -->
+<!--                    Content model for the Body (main textual
+                        content) of a journal article.             -->
+<!ENTITY % body-model   "((%para-level;)*, (%sec-level;)*,
+                          sig-block?)"                               >
+
+
+<!--                    BODY OF THE ARTICLE                        -->
+<!--                    The main textual portion of the article that
+                        conveys the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=body
+                                                                   -->
+<!ELEMENT  body         %body-model;                                 >
+<!ATTLIST  body
+             %body-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    BACK MATTER MODEL                          -->
+<!--                    Content model for the Back Matter (ancillary
+                        material such as appendices) of a journal
+                        article.                                   -->
+<!ENTITY % back-model   "(label?, title*, (%doc-back-matter-mix;)* )">
+
+
+<!--                    BACK MATTER                                -->
+<!--                    Ancillary or supporting material not included
+                        as part of the main textual content of a
+                        journal article, for example appendices and
+                        acknowledgments.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=back
+                                                                   -->
+<!ELEMENT  back         %back-model;                                 >
+<!ATTLIST  back
+             %back-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUB-ARTICLE                                -->
+<!-- ============================================================= -->
+
+
+<!--                    SUB-ARTICLE MODEL                          -->
+<!--                    Content model for the <sub-article> element
+                                                                   -->
+<!ENTITY % sub-article-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?,
+                          (sub-article* | response*) )"              >
+
+
+<!--                    SUB-ARTICLE                                -->
+<!--                    An article that is completely contained
+                        inside another article. Both the article and
+                        the sub-article have their own metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sub-article
+                                                                   -->
+<!ELEMENT  sub-article  %sub-article-model;                          >
+<!ATTLIST  sub-article
+             %sub-article-atts;                                      >
+
+
+<!--                    FRONT MODEL STUB                           -->
+<!--                    Content model for the <front-stub> element,
+                        a reduced metadata set for use in
+                        sub-articles and responses                 -->
+<!ENTITY % front-stub-model
+                       "(article-id*, article-categories?,
+                         title-group?,
+                         ( %contrib-group.class; |
+                           %aff-alternatives.class;)*,
+                         author-notes?, pub-date*,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id)?,
+                         ( %address-link.class; | product |
+                           supplementary-material)*, 
+                         history?, permissions?, self-uri*, 
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    STUB FRONT METADATA                        -->
+<!--                    A reduced metadata set for use in
+                        sub-articles and responses, which will
+                        inherit metadata not defined in the stub
+                        from the enclosing article
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front-stub
+                                                                   -->
+<!ELEMENT  front-stub   %front-stub-model;                           >
+<!ATTLIST  front-stub
+             %front-stub-atts;                                       >
+
+<!-- ============================================================= -->
+<!--                    RESPONSE ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    RESPONSE                                   -->
+<!--                    Reply, response, or commentary concerning the
+                        journal article. In the typical case, the
+                        response is included in the same XML package
+                        as the original article, and thus attached
+                        at the end of the article proper.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=response
+                                                                   -->
+<!ELEMENT  response     %article-short-model;                        >
+<!ATTLIST  response
+             %response-atts;                                         >
+
+
+<!-- ================== End Journal Publishing DTD =============== -->

--- a/publishing/1.1/JATS-journalpublishing-oasis-article1.dtd
+++ b/publishing/1.1/JATS-journalpublishing-oasis-article1.dtd
@@ -1,0 +1,872 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD with OASIS Tables          -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables v1.1 20151215//EN"
+     Delivered as file "JATS-journalpublishing-oasis-article1.dtd" -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD with OASIS Tables          -->
+<!--             of the JATS DTD Suite                             -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD for the creation of new journal articles.     -->
+<!--             This model is an extension of the Journal         -->
+<!--             Publishing DTD that contains both the XHTML       -->
+<!--             table and the CALS OASIS Exchange Table models.   -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is an application of   -->
+<!--             the ANSI/NISO Z39.96 Journal Publishing Tag Set.  --> 
+<!--             It is a subset of the Journal Archiving and       -->
+<!--             Interchange DTD that is optimized for the         -->
+<!--             creation or publishing of existing journal        -->
+<!--             articles and some non-article material such as    -->
+<!--             product and book reviews in XML. It describes     -->
+<!--             both the metadata for a journal article and       -->
+<!--             the full content of the article.                  -->               
+<!--                                                               -->
+<!--             This DTD was constructed using the modules in the -->
+<!--             JATS DTD Suite.                                   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2003                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 23. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 22. ALI - Added ALI namespace for NISO Access and Indicator 
+     license reference and free to read elements.
+
+ 21. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 23. <VOLUME> INSIDE <ARTICLE-META> and <FRONT-STUB>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+
+ 18. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 17. DTD Version - Updated the DTD-version attribute to "1.1d1" and 
+     the formal public identifier to the date: "v1.1d1 20130915//EN".
+
+ 16. GLOBAL ATTRIBUTES - Added the new module for Common (global)
+     attributes: %JATS-common-atts.ent;, called in before the
+     customizations models module.
+
+ 15. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - back
+      - front
+      - front-stub
+                          
+ 14. ABSTRACTS AND KEYWORDS
+     - Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - front-stub (through %front-stub-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 13. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <front-stub> using front-stub-model.
+   
+ 12. OASIS NAMESPACE - Added the OASIS table namespace handling,
+     which, by default, places a namespace prefix of "oasis" on
+     the OASIS CALS Exchange Table Model.
+      - Added call to JATS-oasis-namespace.ent 
+   
+ 11. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+ 10. Updated the DTD-version attribute to "0.4" 
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  8. OASIS TABLES - Replaced the XHTML table model with the
+     OASIS CALS exchange Table Model
+
+  7. BODY ATTRIBUTES - Added attribute list and new PE %body-atts;
+     to the model of <body>. The only current attribute is
+     @specific-use, which indicates, for example, not a real
+     tagged XML body, but a 'bag of words" for indexing purposes.
+
+  6. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <sub-article> through %sub-article-atts;
+      - <response> through %response-atts;
+
+  5. XML:LANG - Added @xml:lang to the following elements:
+     Added to facilitate multiple languages.
+       - article
+
+  4. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <front-stub> through %front-stub-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  3. LANGUAGE CODES - Codes for languages as well as variants,
+     transliterations, regions, scripts, and combinations
+     such as "Jpan"(Han + Hiragana + Katakana). These values should be
+     taken from RFC 5646/W3C/IANA Subtag Registry recommendations
+     and can be found online at:
+       http://www.iana.org/assignments/language-subtag-registry
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+<!-- MODULAR DTD LIBRARY
+                        A set of journal archiving and interchange
+                        DTD modules was written as the basis for
+                        publishing, interchange, and repository
+                        DTDs, with the intention that DTDs for
+                        specific purposes, such as this publishing
+                        DTD, would be developed based on them.
+
+                        This publishing DTD has been optimized for
+                        the creation of new journal articles. This
+                        means that it is far smaller (fewer elements,
+                        and fewer choices in many contexts) than was
+                        the interchange DTD. Where in the interchange
+                        DTD there may have been several ways to
+                        express the same information, only one is
+                        provided for authoring. It was not the
+                        intention to limit the expressive power
+                        licensed by the DTD, but rather to limit the
+                        meaningless choices needed in a full
+                        archiving and interchange DTD that make
+                        conversion from a wide variety of formats as
+                        easy as possible.
+
+                        This Publishing DTD has been developed from
+                        the JATS DTD Suite modules, in the approved 
+                        manner, making changes to the declarations 
+                        in those modules by overriding Parameter 
+                        Entity contents by redefining the entities 
+                        in the:
+                           %journalpub-oasis-custom-classes.ent;
+                           %journalpubcustom-mixes.ent;
+                           %journalpubcustom-models.ent;
+                        modules, which are called from this DTD file.
+                        
+                        Additional Publishing-DTD-Specific material
+                        is defined in the module(s):
+                           %nlmcitation.ent;
+                        No changes to any of the original JATS DTD 
+                        Suite modules are required in order to 
+                        use this DTD.                              -->
+
+<!-- ============================================================= -->
+<!--                    MODULES OF MODULES INVOKED                 -->
+<!-- ============================================================= -->
+
+<!--                    MODULE TO NAME DTD-SPECIFIC MODULES        -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % journalpub-oasis-custom-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+"JATS-journalpub-oasis-custom-modules1.ent"                          >
+%journalpub-oasis-custom-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MODULES                 -->
+<!--                    Declares all the external modules that are
+                        part of the modular JATS DTD Suite library. 
+                        Thus it does NOT declare itself; 
+                        the DTD-specific module-of-modules; or 
+                        any of the DTD-specific class, mix, or model
+                        over-ride modules. Those are declared in the 
+                        DTD-specific module of modules.
+                           Since this module declares but does not
+                        invoke modules, this DTD invokes any modules
+                        it uses by referencing the external
+                        Parameter Entities defined in the Module of
+                        Modules. To include a set of elements (such
+                        as all the lists or the MathML elements) this
+                        module defines the external Parameter Entity
+                        for the module(s) that contains the MathML
+                        declarations and the DTD references that
+                        entity.                                    -->
+<!ENTITY % modules.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+"JATS-modules1.ent"                                                  >
+%modules.ent;
+
+<!-- ============================================================= -->
+<!--                    NISO ALI NAMESPACE SETUP                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE ALI NAMESPACE ATTRIBUTE AND PREFIX  -->
+<!--                    Names the module defines the NISO Access and 
+                        Indicators Exchange Model namespace, prefix, 
+                        and pseudo-attribute @xmlns.               -->
+%JATS-ali-namespace.ent;
+
+<!-- ============================================================= -->
+<!--                    OASIS NAMESPACE SETUP                      -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE OASIS NAMESPACE ATTRIBUTE AND PREFIX-->
+<!--                    Names the module defines the OASIS CALS
+                        Exchange Model namespace, prefix, and
+                        pseudo-attribute @xmlns and all the 
+                        element qnames for CALS Tables.            -->
+%JATS-oasis-namespace.ent;
+                                                            
+
+<!-- ============================================================= -->
+<!--                    SET UP COMMON (ALL ELEMENT) ATTRIBUTES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES MODULE                   -->
+<!--                    Set up the common attributes, those used on
+                        nearly all elements.
+                        Must be called before the custom models
+                        module.                                    -->
+%JATS-common-atts.ent;
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES INVOKED              -->
+<!--                    Note: These modules must be called after   -->
+<!--                    all Module of Modules but before any other -->
+<!--                    modules. Unlike any other grouping, order  -->
+<!--                    of these modules matters.                  -->
+<!-- ============================================================= -->
+
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Names the module that holds the DTD-specific
+                        class definitions for the Journal Publishing
+                        DTD that will over-ride classes in the Suite.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpub-oasis-custom-classes.ent;
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Names the module that holds the standard
+                        class definitions for the JATS DTD Suite.  -->
+%default-classes.ent;
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element mixes in this DTD.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpubcustom-mixes.ent;
+
+
+<!--                    DEFAULT MIX CUSTOMIZATIONS MODULE          -->
+<!--                    Names the module that holds the standard
+                        mix definitions for the JATS DTD Suite.    -->
+%default-mixes.ent;
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Names the module that holds the over-rides
+                        of content models, attribute lists, elements
+                        lists to be used in content models, and
+                        attribute values. These are DTD-specific.
+                        (Defined in 
+                          %journalpub-oasis-custom-modules.ent; )  -->
+%journalpubcustom-models.ent;
+
+
+
+<!-- ============================================================= -->
+<!--                    COMMON (SHARED) ELEMENTS MODULE INVOKED    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) DECLARATIONS               -->
+<!--                    Declarations for elements, attributes,
+                        entities, and Notations that are shared by
+                        more than one class module. Note: Must be
+                        called before any of the class modules.    -->
+
+%common.ent;
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE CLASS ELEMENTS (alpha)     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+%articlemeta.ent;
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+%backmatter.ent;
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS               -->
+%display.ent;
+
+
+<!--                    FORMATTING ELEMENT CLASSES                 -->
+<!--                    Elements that change rendition/display.    -->
+%format.ent;
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that describe the sponsorship or
+                        open access                                -->
+%funding.ent;
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+%journalmeta.ent;
+
+
+<!--                    LINK CLASS ELEMENTS                        -->
+%link.ent;
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+%list.ent;
+
+
+<!--                    MATH ELEMENTS                              -->
+%math.ent;
+
+
+<!--                    NLM CITATION ELEMENT                       -->
+%nlmcitation.ent;
+
+
+<!--                    OASIS EXCHANGE (CALS) TABLE SETUP MODULE   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invokes OASIS Exchange table
+                        module                                     -->
+%oasis-tablesetup.ent;
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+%para.ent;
+
+
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+%phrase.ent;
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION)
+                        CLASS ELEMENTS                             -->
+%references.ent;
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+%related-object.ent;
+
+
+<!--                    SECTION ELEMENTS                           -->
+%section.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML SETUP MODULE                        -->
+<!--                    Invoke the MathML modules                  -->
+%mathmlsetup.ent;
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invoke XHTML (HTML 4.0) table
+                        module                                     -->
+%XHTMLtablesetup.ent;
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Standard XML special character entities
+                        used in this DTD                           -->
+%xmlspecchars.ent;
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Custom special character entities created
+                        specifically for use in this DTD Suite     -->
+%chars.ent;
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+%notat.ent;
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD VERSION                                -->
+<!--                    What version of this DTD was used to make
+                        the document instance under consideration.
+                        Note that this is a fixed value that should
+                        change every time the DTD changes versions or
+                        revisions.                                 -->
+<!ENTITY % dtd-version
+            "dtd-version
+                        CDATA                        #FIXED '1.1'"   >
+
+
+<!--                    ARTICLE ATTRIBUTES                         -->
+<!--                    Attributes for the top-level element
+                        <article>. OASIS Tables are namespaced at
+                        the <table> level rather than here.        -->
+<!ENTITY % article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             %dtd-version;
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           'en'
+             %XLINK.xmlns.attrib;
+             %MATHML.xmlns.attrib;
+             %Schema.xmlns.attrib;
+             %ali.xmlns.attrib;
+             %oasis.xmlns.attrib;"                                   >
+
+
+<!--                    BACK ATTRIBUTES                            -->
+<!--                    Attributes for the <back> element          -->
+<!ENTITY % back-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    BODY ATTRIBUTES                            -->
+<!--                    Attributes for the <body> element          -->
+<!ENTITY % body-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FRONT ATTRIBUTES                           -->
+<!--                    Attributes for the <front> element         -->
+<!ENTITY % front-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FRONT STUB ATTRIBUTES                      -->
+<!--                    Attributes for the <front-stub> element    -->
+<!ENTITY % front-stub-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SUB-ARTICLE ATTRIBUTES                     -->
+<!--                    Attributes for the <sub-article> element   -->
+<!ENTITY % sub-article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESPONSE ATTRIBUTES                        -->
+<!--                    Attributes for the <response> element      -->
+<!ENTITY % response-atts
+            "%jats-common-atts;                                       
+             response-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE MODEL (LIMITED)                    -->
+<!--                    Article-like model used for, for example,
+                        a short sub-article such as a news brief that
+                        is contained in side a journal article.
+                                                                   -->
+<!ENTITY % article-short-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?)"                            >
+
+
+<!--                    ARTICLE MODEL WITH SUB-ARTICLE OR RESPONSE -->
+<!--                    Typical journal article model, which may
+                        contain extended components, such as
+                        sub-articles or responses, but which usually
+                        contains neither.
+                                                                   -->
+<!ENTITY % article-full-model
+                        "(front, body?, back?, floats-group?,
+                         (sub-article* | response*) )"               >
+
+
+<!--                    ARTICLE                                    -->
+<!--                    The complete content of a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article
+                                                                   -->
+<!ELEMENT  article    %article-full-model;                         >
+<!ATTLIST  article
+             %article-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FRONT MATTER MODEL                         -->
+<!--                    Model for the <front> matter (the header
+                        metadata) of a journal article)            -->
+<!ENTITY % front-model  "(journal-meta, article-meta,
+                          (%front-back.class;)? )"                   >
+
+
+<!--                    FRONT MATTER                               -->
+<!--                    The metadata concerning an article, such as
+                        the name and issue of the journal in which it
+                        appears and the name and author(s) of the
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front
+                                                                   -->
+<!ELEMENT  front        %front-model;                                >
+<!ATTLIST  front
+             %front-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BODY ELEMENTS                              -->
+<!-- ============================================================= -->
+
+
+<!--                    BODY MODEL                                 -->
+<!--                    Content model for the Body (main textual
+                        content) of a journal article.             -->
+<!ENTITY % body-model   "((%para-level;)*, (%sec-level;)*,
+                          sig-block?)"                               >
+
+
+<!--                    BODY OF THE ARTICLE                        -->
+<!--                    The main textual portion of the article that
+                        conveys the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=body
+                                                                   -->
+<!ELEMENT  body         %body-model;                                 >
+<!ATTLIST  body
+             %body-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    BACK MATTER MODEL                          -->
+<!--                    Content model for the Back Matter (ancillary
+                        material such as appendices) of a journal
+                        article.                                   -->
+<!ENTITY % back-model   "(label?, title*, (%doc-back-matter-mix;)* )">
+
+
+<!--                    BACK MATTER                                -->
+<!--                    Ancillary or supporting material not included
+                        as part of the main textual content of a
+                        journal article, for example appendices and
+                        acknowledgments.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=back
+                                                                   -->
+<!ELEMENT  back         %back-model;                                 >
+<!ATTLIST  back
+             %back-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUB-ARTICLE                                -->
+<!-- ============================================================= -->
+
+
+<!--                    SUB-ARTICLE MODEL                          -->
+<!--                    Content model for the <sub-article> element
+                                                                   -->
+<!ENTITY % sub-article-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?,
+                          (sub-article* | response*) )"              >
+
+
+<!--                    SUB-ARTICLE                                -->
+<!--                    An article that is completely contained
+                        inside another article. Both the article and
+                        the sub-article have their own metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sub-article
+                                                                   -->
+<!ELEMENT  sub-article  %sub-article-model;                          >
+<!ATTLIST  sub-article
+             %sub-article-atts;                                      >
+
+
+<!--                    FRONT MODEL STUB                           -->
+<!--                    Content model for the <front-stub> element,
+                        a reduced metadata set for use in
+                        sub-articles and responses                 -->
+<!ENTITY % front-stub-model
+                       "(article-id*, article-categories?,
+                         title-group?,
+                         ( %contrib-group.class; |
+                           %aff-alternatives.class;)*,
+                         author-notes?, pub-date*,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id)?,
+                         ( %address-link.class; | product |
+                           supplementary-material)*, 
+                         history?, permissions?, self-uri*, 
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    STUB FRONT METADATA                        -->
+<!--                    A reduced metadata set for use in
+                        sub-articles and responses, which will
+                        inherit metadata not defined in the stub
+                        from the enclosing article
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front-stub
+                                                                   -->
+<!ELEMENT  front-stub   %front-stub-model;                           >
+<!ATTLIST  front-stub
+             %front-stub-atts;                                       >
+
+<!-- ============================================================= -->
+<!--                    RESPONSE ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    RESPONSE                                   -->
+<!--                    Reply, response, or commentary concerning the
+                        journal article. In the typical case, the
+                        response is included in the same XML package
+                        as the original article, and thus attached
+                        at the end of the article proper.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=response
+                                                                   -->
+<!ELEMENT  response     %article-short-model;                        >
+<!ATTLIST  response
+             %response-atts;                                         >
+
+
+<!-- ================== End Journal Publishing DTD =============== -->

--- a/publishing/1.1/JATS-journalpublishing1-mathml3.dtd
+++ b/publishing/1.1/JATS-journalpublishing1-mathml3.dtd
@@ -1,0 +1,861 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with MathML3 v1.1 20151215//EN"
+     Delivered as file "JATS-journalpublishing1-mathml3.dtd"
+     Available at: 
+     http://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd
+                                                                   -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the JATS DTD Suite      -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD for creation of new journal articles          -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is an application of   -->
+<!--             the ANSI/NISO Z39.96 Journal Publishing Tag Set.  --> 
+<!--             IT is a subset of the Journal Archiving and       -->
+<!--             Interchange DTD that is optimized for the         -->
+<!--             creation or publishing of existing journal        -->
+<!--             articles and some non-article material such as    -->
+<!--             product and book reviews in XML. It describes     -->
+<!--             both the metadata for a journal article and       -->
+<!--             the full content of the article.                  -->                       
+<!--                                                               -->
+<!--             This DTD was constructed using the modules in the -->
+<!--             JATS DTD Suite.                                   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2003                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 24. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 23. ALI - Added ALI namespace for NISO Access and Indicator 
+     license reference and free to read elements.
+
+ 22. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 21. <VOLUME> INSIDE <ARTICLE-META> and <FRONT-STUB>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+
+ 20. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 19. MATHML 3.0 - Created a new version of the Publishing DTD to
+     take MathML 3.0 instead of MathML 2.0.
+     Nothing else changed from regular Publishing DTD.
+     Call to MathML setup module changed and added call to the
+     specific MathML 3.0 modules.
+   
+ 18. DTD Version - Updated the DTD-version attribute to "1.1d1" and 
+     the formal public identifier to the date: "v1.1d1 20130915//EN".
+
+ 17. GLOBAL ATTRIBUTES - Added the new module for Common (global)
+     attributes: %JATS-common-atts.ent;, called in before the
+     customizations models module.
+
+ 16. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - back
+      - front
+      - front-stub
+      - sub-article
+                          
+ 15. ABSTRACTS AND KEYWORDS
+       Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - front-stub (through %front-stub-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 11. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <front-stub> using front-stub-model.
+   
+ 10. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  8. BODY ATTRIBUTES - Added attribute list and new PE %body-atts;
+     to the model of <body>. The only current attribute is
+     @specific-use, which indicates, for example, not a real
+     tagged XML body, but a 'bag of words" for indexing purposes.
+
+  7. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <sub-article> through %sub-article-atts;
+      - <response> through %response-atts;
+
+  6. XML:LANG - Added @xml:lang to the following elements:
+     Added to facilitate multiple languages.
+       - article
+
+  5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <front-stub> through %front-stub-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  4. LANGUAGE CODES - Codes for languages as well as variants,
+     transliterations, regions, scripts, and combinations
+     such as "Jpan"(Han + Hiragana + Katakana). These values should be
+     taken from RFC 5646/W3C/IANA Subtag Registry recommendations
+     and can be found online at:
+       http://www.iana.org/assignments/language-subtag-registry
+   
+  3. Updated the DTD-version attribute to "0.4" 
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+
+<!-- MODULAR DTD LIBRARY
+                        A set of journal archiving and interchange
+                        DTD modules was written as the basis for
+                        publishing, interchange, and repository
+                        DTDs, with the intention that DTDs for
+                        specific purposes, such as this publishing
+                        DTD, would be developed based on them.
+
+                        This publishing DTD has been optimized for
+                        the creation of new journal articles. This
+                        means that it is far smaller (fewer elements,
+                        and fewer choices in many contexts) than was
+                        the interchange DTD. Where in the interchange
+                        DTD there may have been several ways to
+                        express the same information, only one is
+                        provided for authoring. It was not the
+                        intention to limit the expressive power
+                        licensed by the DTD, but rather to limit the
+                        meaningless choices needed in a full
+                        archiving and interchange DTD that make
+                        conversion from a wide variety of formats as
+                        easy as possible.
+
+                        This Publishing DTD has been developed from
+                        the JATS DTD Suite modules, in the approved 
+                        manner, making changes to the declarations 
+                        in those modules by overriding Parameter 
+                        Entity contents by redefining the entities 
+                        in the:
+                           %journalpubcustom-classes.ent;
+                           %journalpubcustom-mixes.ent;
+                           %journalpubcustom-models.ent;
+                        modules, which are called from this DTD file.
+                        
+                        Additional Publishing-DTD-Specific material
+                        is defined in the module(s):
+                           %nlmcitation.ent;
+                        No changes to any of the original JATS DTD 
+                        Suite modules are required in order to 
+                        use this DTD.                              -->
+
+
+<!-- ============================================================= -->
+<!--                    MODULES OF MODULES INVOKED                 -->
+<!-- ============================================================= -->
+
+
+<!--                    MODULE TO NAME DTD-SPECIFIC MODULES        -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % journalpubcustom-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.1 20151215//EN"
+"JATS-journalpubcustom-modules1.ent"                                 >
+%journalpubcustom-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MATHML 3.0 MODULES      -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % mathml3-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.1 20151215//EN"
+"JATS-mathml3-modules1.ent"                                          >
+%mathml3-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MODULES                 -->
+<!--                    Declares all the external modules that are
+                        part of the modular Journal Archiving and
+                        Interchange DTD Suite library. Thus it does
+                        NOT declare itself; the DTD-specific
+                        module-of-modules; or the DTD-specific class,
+                        mix, or model over-ride modules. Those are
+                        declared in the DTD-specific module of modules.
+                           Since this module declares but does not
+                        invoke modules, this DTD invokes any modules
+                        it uses by referencing the external
+                        Parameter Entities defined in the Module of
+                        Modules. To include a set of elements (such
+                        as all the lists or the table elements) this
+                        module defines the external Parameter Entity
+                        for the module(s) that contains the table
+                        declarations and the DTD references that
+                        entity.                                    -->
+<!ENTITY % modules.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+"JATS-modules1.ent"                                                  >
+%modules.ent;
+
+<!-- ============================================================= -->
+<!--                    NISO ALI NAMESPACE SETUP                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE ALI NAMESPACE ATTRIBUTE AND PREFIX  -->
+<!--                    Names the module defines the NISO Access and 
+                        Indicators Exchange Model namespace, prefix, 
+                        and pseudo-attribute @xmlns.               -->
+%JATS-ali-namespace.ent;
+                                                            
+
+<!-- ============================================================= -->
+<!--                    SET UP COMMON (ALL ELEMENT) ATTRIBUTES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES MODULE                   -->
+<!--                    Set up the common attributes, those used on
+                        nearly all elements.
+                        Must be called before the custom models
+                        module.                                    -->
+%JATS-common-atts.ent;
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES INVOKED              -->
+<!--                    Note: These modules must be called after   -->
+<!--                    all Module of Modules but before any other -->
+<!--                    modules. Unlike any other grouping, order  -->
+<!--                    of these modules matters.                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Names the module that holds the DTD-specific
+                        class definitions for the Journal Publishing
+                        DTD that will over-ride classes in the Suite.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-classes.ent;
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Names the module that holds the standard
+                        class definitions for the JATS DTD Suite.  -->
+%default-classes.ent;
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element mixes in this DTD.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-mixes.ent;
+
+
+<!--                    DEFAULT MIX CUSTOMIZATIONS MODULE          -->
+<!--                    Names the module that holds the standard
+                        mix definitions for the JATS DTD Suite.    -->
+%default-mixes.ent;
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Names the module that holds the over-rides
+                        of content models, attribute lists, elements
+                        lists to be used in content models, and
+                        attribute values. These are DTD-specific.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-models.ent;
+
+
+
+<!-- ============================================================= -->
+<!--                    COMMON (SHARED) ELEMENTS MODULE INVOKED    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) DECLARATIONS               -->
+<!--                    Declarations for elements, attributes,
+                        entities, and Notations that are shared by
+                        more than one class module. Note: Must be
+                        called before any of the class modules.    -->
+
+%common.ent;
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE CLASS ELEMENTS (alpha)     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+%articlemeta.ent;
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+%backmatter.ent;
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS               -->
+%display.ent;
+
+
+<!--                    FORMATTING ELEMENT CLASSES                 -->
+<!--                    Elements that change rendition/display.    -->
+%format.ent;
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that describe the sponsorship or
+                        open access                                -->
+%funding.ent;
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+%journalmeta.ent;
+
+
+<!--                    LINK CLASS ELEMENTS                        -->
+%link.ent;
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+%list.ent;
+
+
+<!--                    MATH ELEMENTS                              -->
+%math.ent;
+
+
+<!--                    NLM CITATION ELEMENT                       -->
+%nlmcitation.ent;
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+%para.ent;
+
+
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+%phrase.ent;
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION)
+                        CLASS ELEMENTS                             -->
+%references.ent;
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+%related-object.ent;
+
+
+<!--                    SECTION ELEMENTS                           -->
+%section.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML SETUP MODULE                        -->
+<!--                    Invoke the MathML modules                  -->
+%mathml3-mathmlsetup.ent;
+
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invoke XHTML (HTML 4.0) table
+                        module                                     -->
+%XHTMLtablesetup.ent;
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Standard XML special character entities
+                        used in this DTD                           -->
+%xmlspecchars.ent;
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Custom special character entities created
+                        specifically for use in this DTD Suite     -->
+%chars.ent;
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+%notat.ent;
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD VERSION                                -->
+<!--                    What version of this DTD was used to make
+                        the document instance under consideration.
+                        Note that this is a fixed value that should
+                        change every time the DTD changes versions or
+                        revisions.                                 -->
+<!ENTITY % dtd-version
+            "dtd-version
+                        CDATA                        #FIXED '1.1'"   >
+
+
+
+<!--                    ARTICLE ATTRIBUTES                         -->
+<!--                    Attributes for the top-level element
+                        <article>                                  -->
+<!ENTITY % article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             %dtd-version;
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           'en'
+             %XLINK.xmlns.attrib;
+             %MATHML.xmlns.attrib;
+             %ali.xmlns.attrib;
+             %Schema.xmlns.attrib;"                                  >
+
+
+<!--                    BACK ATTRIBUTES                            -->
+<!--                    Attributes for the <back> element          -->
+<!ENTITY % back-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    BODY ATTRIBUTES                            -->
+<!--                    Attributes for the <body> element          -->
+<!ENTITY % body-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FRONT ATTRIBUTES                           -->
+<!--                    Attributes for the <front> element         -->
+<!ENTITY % front-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FRONT STUB ATTRIBUTES                      -->
+<!--                    Attributes for the <front-stub> element    -->
+<!ENTITY % front-stub-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SUB-ARTICLE ATTRIBUTES                     -->
+<!--                    Attributes for the <sub-article> element   -->
+<!ENTITY % sub-article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESPONSE ATTRIBUTES                        -->
+<!--                    Attributes for the <response> element      -->
+<!ENTITY % response-atts
+            "%jats-common-atts;                                       
+             response-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE MODEL (LIMITED)                    -->
+<!--                    Article-like model used for, for example,
+                        a short sub-article such as a news brief that
+                        is contained in side a journal article.
+                                                                   -->
+<!ENTITY % article-short-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?)"                            >
+
+
+<!--                    ARTICLE MODEL WITH SUB-ARTICLE OR RESPONSE -->
+<!--                    Typical journal article model, which may
+                        contain extended components, such as
+                        sub-articles or responses, but which usually
+                        contains neither.
+                                                                   -->
+<!ENTITY % article-full-model
+                        "(front, body?, back?, floats-group?,
+                         (sub-article* | response*) )"               >
+
+
+<!--                    ARTICLE                                    -->
+<!--                    The complete content of a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article
+                                                                   -->
+<!ELEMENT  article      %article-full-model;                         >
+<!ATTLIST  article
+             %article-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FRONT MATTER MODEL                         -->
+<!--                    Model for the <front> matter (the header
+                        metadata) of a journal article)            -->
+<!ENTITY % front-model  "(journal-meta, article-meta,
+                          (%front-back.class;)? )"                   >
+
+
+<!--                    FRONT MATTER                               -->
+<!--                    The metadata concerning an article, such as
+                        the name and issue of the journal in which it
+                        appears and the name and author(s) of the
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front
+                                                                   -->
+<!ELEMENT  front        %front-model;                                >
+<!ATTLIST  front
+             %front-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BODY ELEMENTS                              -->
+<!-- ============================================================= -->
+
+
+<!--                    BODY MODEL                                 -->
+<!--                    Content model for the Body (main textual
+                        content) of a journal article.             -->
+<!ENTITY % body-model   "((%para-level;)*, (%sec-level;)*,
+                          sig-block?)"                               >
+
+
+<!--                    BODY OF THE ARTICLE                        -->
+<!--                    The main textual portion of the article that
+                        conveys the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=body
+                                                                   -->
+<!ELEMENT  body         %body-model;                                 >
+<!ATTLIST  body
+             %body-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    BACK MATTER MODEL                          -->
+<!--                    Content model for the Back Matter (ancillary
+                        material such as appendices) of a journal
+                        article.                                   -->
+<!ENTITY % back-model   "(label?, title*, (%doc-back-matter-mix;)* )">
+
+
+<!--                    BACK MATTER                                -->
+<!--                    Ancillary or supporting material not included
+                        as part of the main textual content of a
+                        journal article, for example appendices and
+                        acknowledgments.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=back
+                                                                   -->
+<!ELEMENT  back         %back-model;                                 >
+<!ATTLIST  back
+             %back-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUB-ARTICLE                                -->
+<!-- ============================================================= -->
+
+
+<!--                    SUB-ARTICLE MODEL                          -->
+<!--                    Content model for the <sub-article> element
+                                                                   -->
+<!ENTITY % sub-article-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?,
+                          (sub-article* | response*) )"              >
+
+
+<!--                    SUB-ARTICLE                                -->
+<!--                    An article that is completely contained
+                        inside another article. Both the article and
+                        the sub-article have their own metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sub-article
+                                                                   -->
+<!ELEMENT  sub-article  %sub-article-model;                          >
+<!ATTLIST  sub-article
+             %sub-article-atts;                                      >
+
+
+<!--                    FRONT MODEL STUB                           -->
+<!--                    Content model for the <front-stub> element,
+                        a reduced metadata set for use in
+                        sub-articles and responses                 -->
+<!ENTITY % front-stub-model
+                       "(article-id*, article-categories?,
+                         title-group?,
+                         ( %contrib-group.class; |
+                           %aff-alternatives.class;)*,
+                         author-notes?, pub-date*,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id)?,
+                         ( %address-link.class; | product |
+                           supplementary-material)*, 
+                         history?, permissions?, self-uri*, 
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    STUB FRONT METADATA                        -->
+<!--                    A reduced metadata set for use in
+                        sub-articles and responses, which will
+                        inherit metadata not defined in the stub
+                        from the enclosing article
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front-stub
+                                                                   -->
+<!ELEMENT  front-stub   %front-stub-model;                           >
+<!ATTLIST  front-stub 
+             %front-stub-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    RESPONSE ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    RESPONSE                                   -->
+<!--                    Reply, response, or commentary concerning the
+                        journal article. In the typical case, the
+                        response is included in the same XML package
+                        as the original article, and thus attached
+                        at the end of the article proper.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=response
+                                                                   -->
+<!ELEMENT  response     %article-short-model;                        >
+<!ATTLIST  response
+             %response-atts;                                         >
+
+
+<!-- ================== End Journal Publishing DTD =============== -->

--- a/publishing/1.1/JATS-journalpublishing1.dtd
+++ b/publishing/1.1/JATS-journalpublishing1.dtd
@@ -1,0 +1,845 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Journal Publishing DTD                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
+     Delivered as file "JATS-journalpublishing1.dtd"
+     Available at: 
+     http://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd
+                                                                   -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     Journal Publishing DTD of the JATS DTD Suite      -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD for creation of new journal articles          -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is an application of   -->
+<!--             the ANSI/NISO Z39.96 Journal Publishing Tag Set.  --> 
+<!--             IT is a subset of the Journal Archiving and       -->
+<!--             Interchange DTD that is optimized for the         -->
+<!--             creation or publishing of existing journal        -->
+<!--             articles and some non-article material such as    -->
+<!--             product and book reviews in XML. It describes     -->
+<!--             both the metadata for a journal article and       -->
+<!--             the full content of the article.                  -->                       
+<!--                                                               -->
+<!--             This DTD was constructed using the modules in the -->
+<!--             JATS DTD Suite.                                   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2003                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 23. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 22. ALI - Added ALI namespace for NISO Access and Indicator 
+     license reference and free to read elements.
+
+ 21. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 20. <VOLUME> INSIDE <ARTICLE-META> and <FRONT-STUB>
+   - Allowed <volume> to repeat inside <article-meta>, the types to 
+     be distinguished using @content-type
+   - Added new optional element <volume-issue-group> inside 
+     <article-meta) following all volume and issue elements
+     to hold volume-issue pairs (or n-tuples) when a second
+     and subsequent <volume> has its own related issue
+     information.
+   - Made <issue> repeatable, for those who choose not to use
+     the new wrapper element.
+
+ 19. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 18. DTD Version - Updated the DTD-version attribute to "1.1d1" and 
+     the formal public identifier to the date: "v1.1d1 20130915//EN".
+
+ 17. GLOBAL ATTRIBUTES - Added the new module for Common (global)
+     attributes: %JATS-common-atts.ent;, called in before the
+     customizations models module.
+
+ 16. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - back
+      - front
+      - front-stub
+                          
+ 15. ABSTRACTS AND KEYWORDS
+       Changed "abstract*" to "(%abstract.class;)*"
+       and "kwd-group*" to "(%kwd-group.class;)*" since those
+       classes now exist. Elements should have a limited number of
+       ways to be invoked.
+        - front-stub (through %front-stub-model;)
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 11. RELATED OBJECT - Added <related-object> everywhere
+     <related-article> was used, including inside 
+     <front-stub> using front-stub-model.
+   
+ 10. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  9. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  8. BODY ATTRIBUTES - Added attribute list and new PE %body-atts;
+     to the model of <body>. The only current attribute is
+     @specific-use, which indicates, for example, not a real
+     tagged XML body, but a 'bag of words" for indexing purposes.
+
+  7. I18N - Changed the default for @xml:lang from "en" to
+     #IMPLIED, so that the @xml:lang would inherit properly and
+     not need to be over-ridden in
+      - <sub-article> through %sub-article-atts;
+      - <response> through %response-atts;
+
+  6. XML:LANG - Added @xml:lang to the following elements:
+     Added to facilitate multiple languages.
+       - article
+
+  5. AFFILIATION ALTERNATIVES - Added the element <aff-alternatives>
+     to <front-stub> through %front-stub-model;. This element
+     will hold multiple <aff>s that are a representation of a
+     single affiliation, for example, the name of an institution
+     in two languages or two scripts.
+
+  4. LANGUAGE CODES - Codes for languages as well as variants,
+     transliterations, regions, scripts, and combinations
+     such as "Jpan"(Han + Hiragana + Katakana). These values should be
+     taken from RFC 5646/W3C/IANA Subtag Registry recommendations
+     and can be found online at:
+       http://www.iana.org/assignments/language-subtag-registry
+   
+  3. Updated the DTD-version attribute to "0.4" 
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  2. Changed default @xml:lang from "EN" from "en" to match latest
+     RFC 4646/W3C/IANA Subtag Registry recommendations
+
+  1. Updated public identifier to "v3.0 20071031//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DESIGN CONSIDERATIONS                      -->
+<!-- ============================================================= -->
+
+
+<!-- MODULAR DTD LIBRARY
+                        A set of journal archiving and interchange
+                        DTD modules was written as the basis for
+                        publishing, interchange, and repository
+                        DTDs, with the intention that DTDs for
+                        specific purposes, such as this publishing
+                        DTD, would be developed based on them.
+
+                        This publishing DTD has been optimized for
+                        the creation of new journal articles. This
+                        means that it is far smaller (fewer elements,
+                        and fewer choices in many contexts) than was
+                        the interchange DTD. Where in the interchange
+                        DTD there may have been several ways to
+                        express the same information, only one is
+                        provided for authoring. It was not the
+                        intention to limit the expressive power
+                        licensed by the DTD, but rather to limit the
+                        meaningless choices needed in a full
+                        archiving and interchange DTD that make
+                        conversion from a wide variety of formats as
+                        easy as possible.
+
+                        This Publishing DTD has been developed from
+                        the JATS DTD Suite modules, in the approved 
+                        manner, making changes to the declarations 
+                        in those modules by overriding Parameter 
+                        Entity contents by redefining the entities 
+                        in the:
+                           %journalpubcustom-classes.ent;
+                           %journalpubcustom-mixes.ent;
+                           %journalpubcustom-models.ent;
+                        modules, which are called from this DTD file.
+                        
+                        Additional Publishing-DTD-Specific material
+                        is defined in the module(s):
+                           %nlmcitation.ent;
+                        No changes to any of the original JATS DTD 
+                        Suite modules are required in order to 
+                        use this DTD.                              -->
+
+
+<!-- ============================================================= -->
+<!--                    MODULES OF MODULES INVOKED                 -->
+<!-- ============================================================= -->
+
+
+<!--                    MODULE TO NAME DTD-SPECIFIC MODULES        -->
+<!--                    Names all DTD-specific external modules    -->
+<!ENTITY % journalpubcustom-modules.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.1 20151215//EN"
+"JATS-journalpubcustom-modules1.ent"                                 >
+%journalpubcustom-modules.ent;
+
+
+<!--                    MODULE TO NAME THE MODULES                 -->
+<!--                    Declares all the external modules that are
+                        part of the modular Journal Archiving and
+                        Interchange DTD Suite library. Thus it does
+                        NOT declare itself; the DTD-specific
+                        module-of-modules; or the DTD-specific class,
+                        mix, or model over-ride modules. Those are
+                        declared in the DTD-specific module of modules.
+                           Since this module declares but does not
+                        invoke modules, this DTD invokes any modules
+                        it uses by referencing the external
+                        Parameter Entities defined in the Module of
+                        Modules. To include a set of elements (such
+                        as all the lists or the MathML elements) this
+                        module defines the external Parameter Entity
+                        for the module(s) that contains the MathML
+                        declarations and the DTD references that
+                        entity.                                    -->
+<!ENTITY % modules.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+"JATS-modules1.ent"                                                  >
+%modules.ent;
+
+<!-- ============================================================= -->
+<!--                    NISO ALI NAMESPACE SETUP                   -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINE ALI NAMESPACE ATTRIBUTE AND PREFIX  -->
+<!--                    Names the module defines the NISO Access and 
+                        Indicators Exchange Model namespace, prefix, 
+                        and pseudo-attribute @xmlns.               -->
+%JATS-ali-namespace.ent;
+                                                            
+
+<!-- ============================================================= -->
+<!--                    SET UP COMMON (ALL ELEMENT) ATTRIBUTES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES MODULE                   -->
+<!--                    Set up the common attributes, those used on
+                        nearly all elements.
+                        Must be called before the custom models
+                        module.                                    -->
+%JATS-common-atts.ent;
+
+
+<!-- ============================================================= -->
+<!--                    CUSTOMIZATION MODULES INVOKED              -->
+<!--                    Note: These modules must be called after   -->
+<!--                    all Module of Modules but before any other -->
+<!--                    modules. Unlike any other grouping, order  -->
+<!--                    of these modules matters.                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD-SPECIFIC CLASS CUSTOMIZATIONS MODULE   -->
+<!--                    Names the module that holds the DTD-specific
+                        class definitions for the Journal Publishing
+                        DTD that will over-ride classes in the Suite.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-classes.ent;
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Names the module that holds the standard
+                        class definitions for the JATS DTD Suite.  -->
+%default-classes.ent;
+
+
+<!--                    DTD-SPECIFIC MIX CUSTOMIZATIONS MODULE     -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        over-ride some element mixes in this DTD.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-mixes.ent;
+
+
+<!--                    DEFAULT MIX CUSTOMIZATIONS MODULE          -->
+<!--                    Names the module that holds the standard
+                        mix definitions for the JATS DTD Suite.    -->
+%default-mixes.ent;
+
+
+<!--                    DTD-SPECIFIC MODELS/ATTRIBUTES CUSTOMIZATIONS
+                        MODULE                                     -->
+<!--                    Names the module that holds the over-rides
+                        of content models, attribute lists, elements
+                        lists to be used in content models, and
+                        attribute values. These are DTD-specific.
+                        (Defined in %journalpubcustom-modules.ent;)-->
+%journalpubcustom-models.ent;
+
+
+
+<!-- ============================================================= -->
+<!--                    COMMON (SHARED) ELEMENTS MODULE INVOKED    -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) DECLARATIONS               -->
+<!--                    Declarations for elements, attributes,
+                        entities, and Notations that are shared by
+                        more than one class module. Note: Must be
+                        called before any of the class modules.    -->
+
+%common.ent;
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE CLASS ELEMENTS (alpha)     -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+%articlemeta.ent;
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+%backmatter.ent;
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS               -->
+%display.ent;
+
+
+<!--                    FORMATTING ELEMENT CLASSES                 -->
+<!--                    Elements that change rendition/display.    -->
+%format.ent;
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that describe the sponsorship or
+                        open access                                -->
+%funding.ent;
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+%journalmeta.ent;
+
+
+<!--                    LINK CLASS ELEMENTS                        -->
+%link.ent;
+
+
+<!--                    LIST CLASS ELEMENTS                        -->
+%list.ent;
+
+
+<!--                    MATH ELEMENTS                              -->
+%math.ent;
+
+
+<!--                    NLM CITATION ELEMENT                       -->
+%nlmcitation.ent;
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+%para.ent;
+
+
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+%phrase.ent;
+
+
+<!--                    BIBLIOGRAPHIC REFERENCE (CITATION)
+                        CLASS ELEMENTS                             -->
+%references.ent;
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+%related-object.ent;
+
+
+<!--                    SECTION ELEMENTS                           -->
+%section.ent;
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE EXTERNAL MODULES INVOKED   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML SETUP MODULE                        -->
+<!--                    Invoke the MathML modules                  -->
+%mathmlsetup.ent;
+
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set up the necessary Parameter Entity values
+                        and then invoke XHTML (HTML 4.0) table
+                        module                                     -->
+%XHTMLtablesetup.ent;
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Standard XML special character entities
+                        used in this DTD                           -->
+%xmlspecchars.ent;
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Custom special character entities created
+                        specifically for use in this DTD Suite     -->
+%chars.ent;
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+%notat.ent;
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DTD VERSION                                -->
+<!--                    What version of this DTD was used to make
+                        the document instance under consideration.
+                        Note that this is a fixed value that should
+                        change every time the DTD changes versions or
+                        revisions.                                 -->
+<!ENTITY % dtd-version
+            "dtd-version
+                        CDATA                        #FIXED '1.1'"   >
+
+
+
+<!--                    ARTICLE ATTRIBUTES                         -->
+<!--                    Attributes for the top-level element
+                        <article>                                  -->
+<!ENTITY % article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             %dtd-version;
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           'en'
+             %XLINK.xmlns.attrib;
+             %MATHML.xmlns.attrib;
+             %ali.xmlns.attrib;
+             %Schema.xmlns.attrib;"                                  >
+
+
+<!--                    BACK ATTRIBUTES                            -->
+<!--                    Attributes for the <back> element          -->
+<!ENTITY % back-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    BODY ATTRIBUTES                            -->
+<!--                    Attributes for the <body> element          -->
+<!ENTITY % body-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    FRONT ATTRIBUTES                           -->
+<!--                    Attributes for the <front> element         -->
+<!ENTITY % front-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    FRONT STUB ATTRIBUTES                      -->
+<!--                    Attributes for the <front-stub> element    -->
+<!ENTITY % front-stub-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SUB-ARTICLE ATTRIBUTES                     -->
+<!--                    Attributes for the <sub-article> element   -->
+<!ENTITY % sub-article-atts
+            "%jats-common-atts;                                       
+             article-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    RESPONSE ATTRIBUTES                        -->
+<!--                    Attributes for the <response> element      -->
+<!ENTITY % response-atts
+            "%jats-common-atts;                                       
+             response-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    JOURNAL ARTICLE ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE MODEL (LIMITED)                    -->
+<!--                    Article-like model used for, for example,
+                        a short sub-article such as a news brief that
+                        is contained in side a journal article.
+                                                                   -->
+<!ENTITY % article-short-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?)"                            >
+
+
+<!--                    ARTICLE MODEL WITH SUB-ARTICLE OR RESPONSE -->
+<!--                    Typical journal article model, which may
+                        contain extended components, such as
+                        sub-articles or responses, but which usually
+                        contains neither.
+                                                                   -->
+<!ENTITY % article-full-model
+                        "(front, body?, back?, floats-group?,
+                         (sub-article* | response*) )"               >
+
+
+<!--                    ARTICLE                                    -->
+<!--                    The complete content of a journal article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=article
+                                                                   -->
+<!ELEMENT  article      %article-full-model;                         >
+<!ATTLIST  article
+             %article-atts;                                          >
+
+
+<!-- ============================================================= -->
+<!--                    FRONT MATTER ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FRONT MATTER MODEL                         -->
+<!--                    Model for the <front> matter (the header
+                        metadata) of a journal article)            -->
+<!ENTITY % front-model  "(journal-meta, article-meta,
+                          (%front-back.class;)? )"                   >
+
+
+<!--                    FRONT MATTER                               -->
+<!--                    The metadata concerning an article, such as
+                        the name and issue of the journal in which it
+                        appears and the name and author(s) of the
+                        article.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front
+                                                                   -->
+<!ELEMENT  front        %front-model;                                >
+<!ATTLIST  front
+             %front-atts;                                            >
+
+
+<!-- ============================================================= -->
+<!--                    BODY ELEMENTS                              -->
+<!-- ============================================================= -->
+
+
+<!--                    BODY MODEL                                 -->
+<!--                    Content model for the Body (main textual
+                        content) of a journal article.             -->
+<!ENTITY % body-model   "((%para-level;)*, (%sec-level;)*,
+                          sig-block?)"                               >
+
+
+<!--                    BODY OF THE ARTICLE                        -->
+<!--                    The main textual portion of the article that
+                        conveys the content.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=body
+                                                                   -->
+<!ELEMENT  body         %body-model;                                 >
+<!ATTLIST  body
+             %body-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BACK MATTER ELEMENTS                       -->
+<!-- ============================================================= -->
+
+
+<!--                    BACK MATTER MODEL                          -->
+<!--                    Content model for the Back Matter (ancillary
+                        material such as appendices) of a journal
+                        article.                                   -->
+<!ENTITY % back-model   "(label?, title*, (%doc-back-matter-mix;)* )">
+
+
+<!--                    BACK MATTER                                -->
+<!--                    Ancillary or supporting material not included
+                        as part of the main textual content of a
+                        journal article, for example appendices and
+                        acknowledgments.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=back
+                                                                   -->
+<!ELEMENT  back         %back-model;                                 >
+<!ATTLIST  back
+             %back-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    SUB-ARTICLE                                -->
+<!-- ============================================================= -->
+
+
+<!--                    SUB-ARTICLE MODEL                          -->
+<!--                    Content model for the <sub-article> element
+                                                                   -->
+<!ENTITY % sub-article-model
+                        "((front | front-stub), body?, back?,
+                          floats-group?,
+                          (sub-article* | response*) )"              >
+
+
+<!--                    SUB-ARTICLE                                -->
+<!--                    An article that is completely contained
+                        inside another article. Both the article and
+                        the sub-article have their own metadata.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sub-article
+                                                                   -->
+<!ELEMENT  sub-article  %sub-article-model;                          >
+<!ATTLIST  sub-article
+             %sub-article-atts;                                      >
+
+
+<!--                    FRONT MODEL STUB                           -->
+<!--                    Content model for the <front-stub> element,
+                        a reduced metadata set for use in
+                        sub-articles and responses                 -->
+<!ENTITY % front-stub-model
+                       "(article-id*, article-categories?,
+                         title-group?,
+                         ( %contrib-group.class; |
+                           %aff-alternatives.class;)*,
+                         author-notes?, pub-date*,
+                         volume*, volume-id*, volume-series?,
+                         issue*, issue-id*, issue-title*,
+                         issue-sponsor*, issue-part?, 
+                         volume-issue-group*, isbn*,
+                         supplement?,
+                         ( (fpage, lpage?, page-range?) |
+                            elocation-id)?,
+                         ( %address-link.class; | product |
+                           supplementary-material)*, 
+                         history?, permissions?, self-uri*, 
+                         (%related-article.class;)*, 
+                         (%abstract.class;)*, trans-abstract*, 
+                         (%kwd-group.class;)*,
+                         funding-group*, conference*, counts?,
+                         custom-meta-group?)"                        >
+
+
+<!--                    STUB FRONT METADATA                        -->
+<!--                    A reduced metadata set for use in
+                        sub-articles and responses, which will
+                        inherit metadata not defined in the stub
+                        from the enclosing article
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=front-stub
+                                                                   -->
+<!ELEMENT  front-stub   %front-stub-model;                           >
+<!ATTLIST  front-stub 
+             %front-stub-atts;                                       >
+
+
+<!-- ============================================================= -->
+<!--                    RESPONSE ELEMENTS                          -->
+<!-- ============================================================= -->
+
+
+<!--                    RESPONSE                                   -->
+<!--                    Reply, response, or commentary concerning the
+                        journal article. In the typical case, the
+                        response is included in the same XML package
+                        as the original article, and thus attached
+                        at the end of the article proper.
+                        Details at:
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=response
+                                                                   -->
+<!ELEMENT  response     %article-short-model;                        >
+<!ATTLIST  response
+             %response-atts;                                         >
+
+
+<!-- ================== End Journal Publishing DTD =============== -->

--- a/publishing/1.1/JATS-link1.ent
+++ b/publishing/1.1/JATS-link1.ent
@@ -1,0 +1,416 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Link Element Classes                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-link1.ent"                            -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the link class. These are   -->
+<!--             elements that are links (internal or external)    -->
+<!--             by definition, such as URLs <uri> and             -->
+<!--             Cross(X)-references <xref>.                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd) 
+      =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+    =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+  7. REFERENCE TYPES
+      - Added "collab"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+           http://jats.nlm.nih.gov/1.1/
+
+  6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. ACCESSIBILITY - Added @alt to <xref> thru %xref-atts;
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE VALUES              -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFAULT TYPE OF CROSS(X)-REFERENCE         -->
+<!--                    Used to say to what the reference is pointing.
+                        Values are, for example: Affiliation "aff",
+                        or Figure "fig".                           -->
+<!ENTITY % ref-types    "aff | app | author-notes | bibr |
+                         boxed-text | chem | collab | contrib | 
+                         corresp | disp-formula | fig | fn | kwd | 
+                         list | plate | scheme | sec | statement |
+                         supplementary-material |
+                         table | table-fn |
+                         other"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE ATTRIBUTES                        -->
+<!--                    Attribute list for Footnote element        -->
+<!ENTITY % fn-atts
+            "%jats-common-atts;                                       
+             symbol     CDATA                             #IMPLIED
+             fn-type    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL              -->
+<!--                    Attribute list for inline supplementary
+                        material                                   -->
+<!ENTITY % inline-supplementary-material-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             mimetype   CDATA                             #IMPLIED
+             mime-subtype
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    TARGET ATTRIBUTES                          -->
+<!--                    Attribute list for <target> element        -->
+<!ENTITY % target-atts
+            "%jats-common-atts-id-required;                                       
+             target-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    X(CROSS) REFERENCE ATTRIBUTES              -->
+<!--                    Attribute list for cross references        -->
+<!ENTITY % xref-atts
+            "%jats-common-atts;                                       
+             alt        CDATA                             #IMPLIED
+             ref-type   (%ref-types;)                     #IMPLIED
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    INTERNAL LINKS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    FOOTNOTE MODEL                             -->
+<!--                    Content model for Footnote <fn>            -->
+<!ENTITY % fn-model     "(label?, (%just-para.class;)+ )"            >
+
+
+<!--                    FOOTNOTE                                   -->
+<!--                    Additional information concerning material in
+                        a particular location in the text. This
+                        material is not considered to be part of the
+                        body of the text, but in addition to or a
+                        commentary on the body.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=fn
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=fn
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=fn
+                                                                   -->
+<!ELEMENT  fn           %fn-model;                                   >
+<!ATTLIST  fn
+             %fn-atts;                                               >
+
+
+<!--                    TARGET ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <target>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % target-elements
+                        "%link-elements;"                            >
+
+
+<!--                    TARGET OF AN INTERNAL LINK                 -->
+<!--                    May be placed anywhere within textual
+                        material such as a paragraph to provide a
+                        location (anchor) to which a cross reference
+                        can point
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=target
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=target
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=target
+                                                                   -->
+<!ELEMENT  target       (#PCDATA %target-elements;)*                 >
+<!ATTLIST  target
+             %target-atts;                                           >
+
+
+<!--                    X(CROSS) REFERENCE ELEMENTS                -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        an <xref>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %link-elements; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % xref-elements
+                        "%link-elements;"                            >
+
+
+<!--                    X(CROSS) REFERENCE                         -->
+<!--                    Used for any kind of internal article
+                        referencing. The content of the reference
+                        (if present) will be displayed as the link.
+                        This element may be used to point to any
+                        element that takes an "id" attribute.
+                        The "ref-type" attribute may be used to name
+                        the element or type of object to which the
+                        <xref> is pointing.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=xref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=xref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=xref
+                                                                   -->
+<!ELEMENT  xref         (#PCDATA %xref-elements;)*                   >
+<!ATTLIST  xref
+             %xref-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    EXTERNAL LINKS                             -->
+<!-- ============================================================= -->
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL ELEMENTS     -->
+<!--                    Elements for use in the
+                        <inline-supplementary-material> element    -->
+<!ENTITY % inline-supplementary-material-elements
+                        "| %access.class; | %address-link.class; |
+                         %emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    INLINE SUPPLEMENTARY MATERIAL              -->
+<!--                    An in-text link to an external file that
+                        provides supplementary information for
+                        the document, for example, an audio clip
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=inline-supplementary-material
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=inline-supplementary-material
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=inline-supplementary-material
+                                                                   -->
+<!ELEMENT  inline-supplementary-material
+                        (#PCDATA
+                         %inline-supplementary-material-elements;)*  >
+<!ATTLIST  inline-supplementary-material
+             %inline-supplementary-material-atts;                    >
+
+
+<!-- ================== End Link Class Module ==================== -->

--- a/publishing/1.1/JATS-list1.ent
+++ b/publishing/1.1/JATS-list1.ent
@@ -1,0 +1,494 @@
+<!-- ============================================================= -->
+<!--  MODULE:    List Element Classes                              -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-list1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the list class. These are   -->
+<!--             all lists except the lists of bibliographic       -->
+<!--             references (citations). Lists are considered      -->
+<!--             to be composed of items.                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 12. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+ 
+ 10. TITLE FOR LIST ITEMS
+     Added an optional <title> to the beginning of each <list-item>.
+
+  9. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  8. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new attribute list to:
+      - def-head
+      - term-head
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  7. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - def-item through def-item-atts (both)
+      - def-list through def-list-atts (@xml:lang-only;
+          @specific-use already)
+      - list through list-atts (@xml:lang-only; @specific-use already)
+      - list-item through list-item-atts (both)
+      - term through term-atts (both)
+
+  3. DEFINITION LIST HEADS - Removed the dependency in which
+     <term-head> and <def-head> both used the parameter entity
+     %def-list-head-elements; One uses %term-head-elements; and
+     the other uses %def-head-elements; But the
+     %def-list-head-elements; was retained for backward
+     compatibility.
+
+  2. DEF LIST ATTRIBUTES - Removed the dependency whereby <def-list>
+     used both %def-list-atts; and %list-atts;. <def-list> now uses
+     only %def-list-atts; No documents need change.
+     *****Customization Alert: New parameter entity could break some
+     customizations. Check your <def-list> attributes.        *****
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULT PE FOR ATTRIBUTE LISTS             -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST: DEFINITION HEAD ATTRIBUTES-->
+<!--                    Attributes for the <def-head> element      -->
+<!ENTITY % def-head-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM ATTRIBUTES-->
+<!--                    Attributes for the <def-item> element      -->
+<!ENTITY % def-item-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT DEFINITION LIST ATTRIBUTES         -->
+<!--                    Default attribute lists to be used for
+                        Definition (2-part) lists                  -->
+<!ENTITY % def-list-atts
+            "%jats-common-atts;                                       
+             list-type  CDATA                             #IMPLIED
+             prefix-word
+                        CDATA                             #IMPLIED
+             list-content
+                        CDATA                             #IMPLIED
+             continued-from
+                        IDREF                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT LIST CLASS ATTRIBUTES              -->
+<!--                    Default attribute lists to be used for most
+                        of the types of lists.                     -->
+<!ENTITY % list-atts
+            "%jats-common-atts;                                       
+             list-type  CDATA                             #IMPLIED
+             prefix-word
+                        CDATA                             #IMPLIED
+             list-content
+                        CDATA                             #IMPLIED
+             continued-from
+                        IDREF                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFAULT LIST ITEM ATTRIBUTES               -->
+<!--                    Default attribute for list items           -->
+<!ENTITY % list-item-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: TERM ATTRIBUTES           -->
+<!--                    Attributes for the <term> element          -->
+<!ENTITY % term-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DEFINITION LIST: TERM HEAD ATTRIBUTES      -->
+<!--                    Attributes for the <term-head> element     -->
+<!ENTITY % term-head-atts
+            "%jats-common-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    DEFINITION LIST                            -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFINITION LIST MODEL                      -->
+<!--                    Content model for the <def-list> element   -->
+<!ENTITY % def-list-model
+                        "(label?, title?, term-head?, def-head?,
+                          (%def-item.class;)*, (%def-list.class;)* )">
+
+
+<!--                    DEFINITION LIST                            -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=def-list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=def-list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=def-list
+                                                                   -->
+<!ELEMENT  def-list     %def-list-model;                             >
+<!ATTLIST  def-list
+             %def-list-atts;                                         >
+
+
+<!--                    DEFINITION LIST HEAD ELEMENTS              -->
+<!--                    Elements for use in the <def-list> heading
+                        elements <term-head> and <def-head>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % def-list-head-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    DEFINITION LIST TERM HEAD ELEMENTS         -->
+<!--                    Elements for use in the <term-head> element-->
+<!ENTITY % term-head-elements
+                        "%def-list-head-elements;"                   >
+
+
+<!--                    DEFINITION LIST DEFINITION HEAD ELEMENTS   -->
+<!--                    Elements for use in the <def-head> element -->
+<!ENTITY % def-head-elements
+                        "%def-list-head-elements;"                   >
+
+
+<!--                    DEFINITION LIST: TERM HEAD                 -->
+<!--                    Title over the first (term) column of a
+                        two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=term-head
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=term-head
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=term-head
+                                                                   -->
+<!ELEMENT  term-head    (#PCDATA %term-head-elements;)*              >
+<!ATTLIST  term-head
+             %term-head-atts;                                        >
+
+
+<!--                    DEFINITION LIST: DEFINITION HEAD           -->
+<!--                    Title over the second (definition) column
+                        of a two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=def-head
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=def-head
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=def-head
+                                                                   -->
+<!ELEMENT  def-head     (#PCDATA %def-head-elements;)*               >
+<!ATTLIST  def-head
+             %def-head-atts;                                         >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM MODEL     -->
+<!--                    The content model of a <def-item>          -->
+<!ENTITY % def-item-model
+                        "(label?, term, def*)"                       >
+
+
+<!--                    DEFINITION LIST: DEFINITION ITEM           -->
+<!--                    A term and definition pair inside a
+                        definition or two-part list
+                        of a two-part list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=def-item
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=def-item
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=def-item
+                                                                   -->
+<!ELEMENT  def-item     %def-item-model;                             >
+<!ATTLIST  def-item
+             %def-item-atts;                                         >
+
+
+<!--ELEM   def          Defined in %common.ent;                    -->
+
+
+<!--                    DEFINITION LIST: TERM ELEMENTS             -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <term>.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % term-elements
+                        "%simple-phrase; | %block-math.class; |
+                         %simple-display-noalt.class;"               >
+
+
+<!--                    DEFINITION LIST: TERM                      -->
+<!--                    The word, phrase, picture, or other noun
+                        being defined or description that occupies
+                        the first column of a definition or 2-part
+                        list and is the subject of the definition or
+                        description.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=term
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=term
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=term
+                                                                   -->
+<!ELEMENT  term         (#PCDATA %term-elements;)*                   >
+<!ATTLIST  term
+             %term-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    LIST ELEMENTS (PARAGRAPH-LEVEL ELEMENTS)   -->
+<!-- ============================================================= -->
+
+
+<!--                    LIST MODEL                                 -->
+<!--                    Content model for the <list> element       -->
+<!ENTITY % list-model   "(label?, title?, (%list-item.class;)+)"     >
+
+
+<!--                    LIST                                       -->
+<!--                    Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=list
+                                                                   -->
+<!ELEMENT  list         %list-model;                                 >
+<!ATTLIST  list
+             %list-atts;                                             >
+
+
+<!--                    LIST ITEM ELEMENTS                         -->
+<!--                    The content model of a <list-item>.        -->
+<!ENTITY % list-item-model
+                        "(label?, title?, 
+                          (%just-para.class; | %list.class;)+ )"     >
+
+
+<!--                    LIST ITEM                                  -->
+<!--                    One item in a list
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=list-item
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=list-item
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=list-item
+                                                                   -->
+<!ELEMENT  list-item    %list-item-model;                            >
+<!ATTLIST  list-item
+             %list-item-atts;                                        >
+
+
+<!-- ================== End List Class Module ==================== -->

--- a/publishing/1.1/JATS-math1.ent
+++ b/publishing/1.1/JATS-math1.ent
@@ -1,0 +1,402 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Math Class Elements                               -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-math1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names all elements in the math classes            -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 11. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 10. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. TEXT-MATH - Added @specific-use to the attributes for
+     <text-math>, primarily for use when <tex-math> is used
+     inside <alternatives>.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+ 
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+  6. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - disp-formula (through %disp-formula-elements;)
+        - disp-formula-group (through %disp-formula-group-model;)
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+
+      - disp-formula through disp-formula-atts (@xml:lang-only;
+          @specific-use already)
+      - disp-formula-group through disp-formula-group-atts
+          (@xml:lang-only; @specific-use already)
+      - inline-formula through inline-formula-atts
+          (@specific-use-only; @xml:lang already)
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY FORMULA ATTRIBUTES                 -->
+<!--                    Attributes for the <disp-formula> element  -->
+<!ENTITY % disp-formula-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DISPLAY FORMULA GROUP ATTRIBUTES           -->
+<!--                    Attributes for the <disp-formula-group>
+                        element                                    -->
+<!ENTITY % disp-formula-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    INLINE FORMULA ATTRIBUTES                  -->
+<!--                    Attribute list for the <inline-formula>
+                        element                                    -->
+<!ENTITY % inline-formula-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TEX MATH ATTRIBUTES                        -->
+<!--                    Attributes for the <disp-formula> element  -->
+<!ENTITY % tex-math-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             notation   NOTATION (LaTeX | tex | TEX | TeX)
+                                                          #IMPLIED
+             version    CDATA                             #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    MATH ELEMENTS (INLINE LEVEL)               -->
+<!-- ============================================================= -->
+
+
+<!--                    FORMULA, INLINE ELEMENTS                   -->
+<!--                    Elements for use in the <inline-formula>
+                        element                                    -->
+<!ENTITY % inline-formula-elements
+                        "| %emphasis.class; | %inline-display.class; |
+                         %inline-math.class; |
+                         %math.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    FORMULA, INLINE MODEL                      -->
+<!--                    Content model for an <inline-formula>      -->
+<!ENTITY % inline-formula-model
+                        "(#PCDATA %inline-formula-elements;)*"       >
+
+
+<!--                    FORMULA, INLINE                            -->
+<!--                    Inline element for a mathematical
+                        equation, expression, or formula
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=inline-formula
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=inline-formula
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=inline-formula
+                                                                   -->
+<!ELEMENT  inline-formula
+                        %inline-formula-model;                       >
+<!ATTLIST  inline-formula
+             %inline-formula-atts;                                   >
+
+
+<!-- ============================================================= -->
+<!--                    MATH ELEMENTS (INLINE LEVEL)               -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY FORMULA ELEMENTS                   -->
+<!--                    Elements for use in the <disp-formula>
+                        element                                    -->
+<!ENTITY % disp-formula-elements
+                        "| %access.class; | %abstract.class; |
+                         %address-link.class; |
+                         %break.class; | %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %kwd-group.class; |
+                         %label.class; | %phrase-content.class; |
+                         %math.class; |  %simple-display.class; |
+                         %subsup.class;"                             >
+
+
+<!--                    FORMULA, DISPLAY MODEL                     -->
+<!--                    Content model for an <disp-formula>        -->
+<!ENTITY % disp-formula-model
+                        "(#PCDATA %disp-formula-elements;)*"         >
+
+
+<!--                    FORMULA, DISPLAY                           -->
+<!--                    Block-level (callout) element for a
+                        mathematical equation, expression, or
+                        formula.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=disp-formula
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=disp-formula
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=disp-formula
+                                                                   -->
+<!ELEMENT  disp-formula %disp-formula-model;                         >
+<!ATTLIST  disp-formula
+             %disp-formula-atts;                                     >
+
+
+<!--                    FORMULA, DISPLAY GROUP MODEL               -->
+<!--                    Content model for an <disp-formula-group>  -->
+<!ENTITY % disp-formula-group-model
+                        "(label?, (%caption.class;)?,
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%access.class; | %address-link.class;)*,
+                          (%block-math.class;)* )"                   >
+
+
+<!--                    FORMULA, DISPLAY GROUP                     -->
+<!--                    Used for a group of equations or other
+                        mathematical expressions that are displayed
+                        together.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=disp-formula-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=disp-formula-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=disp-formula-group
+                                                                   -->
+<!ELEMENT  disp-formula-group
+                        %disp-formula-group-model;                   >
+<!ATTLIST  disp-formula-group
+             %disp-formula-group-atts;                               >
+
+
+<!--                    TEX MATH EQUATION                          -->
+<!--                    Used to hold encoded math, expressed in TeX
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=tex-math
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=tex-math
+                                                                   -->
+<!ELEMENT  tex-math     (#PCDATA)                                    >
+<!ATTLIST  tex-math
+             %tex-math-atts;                                         >
+
+
+<!-- ================== End Math Class Elements Module =========== -->

--- a/publishing/1.1/JATS-mathml3-mathmlsetup1.ent
+++ b/publishing/1.1/JATS-mathml3-mathmlsetup1.ent
@@ -1,0 +1,350 @@
+<!-- ============================================================= -->
+<!--  MODULE:    MathML DTD SETUP MODULE                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.1 20151215//EN"
+     Delivered as file "JATS-mathml3-mathmlsetup1.ent"             -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the           -->
+<!--             MathML 3.0 DTD                                    -->
+<!--              - Overrides to standard parameter entities used  -->
+<!--                in the MathML 3.0 DTD                          -->
+<!--             - Calls the MathML 3.0 DTD                        -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) mathml3.dtd  (MathML 3.0 DTD)                  -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2013                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1d3 20150301"
+    
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  8. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. PARAMETER ENTITY NAME CHANGE IN THE MATHML DTD
+     When MathML 2.0 became MathML 3.0, the parameter entity
+     %product.class; was defined both in the MathML 3.0 DTD and also 
+     in JATS-default-classes.ent. Renamed class in the MathML DTD
+     until JATS names can be changed. Renamed the MathML parameter 
+     entity to "mml-product.class".
+
+     The name of the parameter entity that establishes the model of
+     the <annotation-xml> element was changed.
+     "Annotation-xml.content" became "annotation-xml.model".
+
+  6. PARAMETER ENTITY NAME CHANGE - When MathML 2.0 became MathML 3.0,
+     the name of the parameter entity that establishes the model of
+     the <annotation-xml> element was changed.
+     "Annotation-xml.content" became "annotation-xml.model".
+
+  5.  MAJOR CHANGE: MathML 2.0 replaced with MathML 3.0
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE MathML MODULE               -->
+<!-- ============================================================= -->
+
+
+<!--                    MathML DTD                                 -->
+<!--                    The official version of the MathML 3.0 can
+                        be found at: http://www.w3.org/TR/MathML3/
+
+                        PUBLIC "-//W3C//DTD MathML 3.0//EN"
+                        SYSTEM "mathml3.dtd"                       -->
+
+
+<!-- ============================================================= -->
+<!--                    SET UP W3C XML SCHEMA                      -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE PREFIX EQUAL "xsi" (same as MathML)   -->
+<!ENTITY % Schema.prefix
+                        "xsi"                                        >
+
+<!--                    SET UP NAMESPACE FOR SCHEMA
+                           (same as MathML)                        -->
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance"  >
+
+
+<!--                    OVER-RIDE MATHML DTD TO MAKE EXPLICIT NS   -->
+<!--                    MathML sets this up but then lets the
+                        attribute be a CDATA one, not the real
+                        namespace URI                              -->
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA          #FIXED '%Schema.xmlns;'" >
+
+
+<!-- ============================================================= -->
+<!--                    SET UP "mml" AS THE MATH PREFIX            -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE MATH PREFIX PARAMETER ENTITY HAPPEN   -->
+<!ENTITY % MATHML.prefixed 
+                        "INCLUDE"                                    >
+
+
+<!--                    MAKE PREFIX EQUAL "mml"                    -->
+<!ENTITY % MATHML.prefix "mml"                                       >
+
+
+<!--                    SET UP "pfx"                               -->
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx   "%MATHML.prefix;:"                           >
+]]>
+
+
+<!--                    USE "pfx" TO SET THE MATH ELEMENT NAME     -->
+<!ENTITY % math.qname   "%MATHML.pfx;math"                           >
+
+
+
+<!-- ============================================================= -->
+<!--                    CALL THE MATHML ENTITIES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML CHARACTER ENTITIES                  -->
+<!--                    Set the "INCLUDE" or "IGNORE" marked section
+                        switch for the MATHML 3.0 DTD. This switch
+                        determines whether the math processing in
+                        the -%mathml.dtd; module or the
+                        -%xmlspecchars.ent; module in this DTD Suite
+                        will invoke the sets of special characters
+                        that are defined AND INVOKED in the
+                        -%xmlspecchars.ent; module.
+                        A value of "IGNORE" turns off the second
+                        invocation from the MathML DTD.            -->
+<!ENTITY % mathml-charent.module
+                        "IGNORE"                                     >
+
+
+<!--                    MATHML-SPECIFIC CHARACTER ENTITIES         -->
+<!--                    Because the MATHML invocation is canceled
+                        using the parameter entity just defined,
+                        the two external entities below must be
+                        invoked from here, as neither XMLspecchars
+                        nor the MathML DTD will invoke them.       -->
+
+<!--                    New characters defined by MathML           -->
+%ent-mmlextra;
+
+
+<!--                    MathML aliases for characters defined above-->
+%ent-mmlalias;
+
+
+<!-- ============================================================= -->
+<!--                    RESTRICT CONTENT OF ANNOTATION             -->
+<!-- ============================================================= -->
+
+<!--                    MATHML ANNOTATION MODEL                    -->
+<!--                    The MathML 3.0 DTD establishes the content of 
+                        the <mml:annotation-xml> element as any MathML
+                        expression. This is unnecessarily broad, 
+                        causing inconvenience during conversion. 
+                        The model has been restricted to
+                        one or more paragraphs.                    -->
+<!ENTITY % annotation-xml.model
+                        "(p+)"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    MathML 3.0 INVOCATION                      -->
+<!-- ============================================================= -->
+
+%mathml.dtd;
+
+
+<!-- ================== End MATHML Setup Module ================== -->

--- a/publishing/1.1/JATS-mathml3-modules1.ent
+++ b/publishing/1.1/JATS-mathml3-modules1.ent
@@ -1,0 +1,190 @@
+<!-- ============================================================= -->
+<!--  MODULE:    JATS MathML 3.0 Modules                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.1 20151215//EN"
+     Delivered as file "JATS-mathml3-modules1.ent"                 -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To name any modules needed for MathML 3.0 (since  -->
+<!--             NISO JATS V1.0 was MathMl 2.0, and the two are    -->
+<!--             not backwards compatible.                         -->
+<!--                                                               -->
+<!-- CONTAINS:   Modules declarations for MathML 3.0               -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This DTD was created from the JATS DTD Suite.     -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             November 2013                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  4. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  3. JATS became version "1.1d3" and "v1.1d3 20150301"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+   2. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-20125 concerning 
+     ANSI/NISO Z39.96-2012 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  1. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+                                                                   -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                     MATHML 3.0 MODULES (Invoked for V1d1)     -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML 3.0 QUALIFIED NAMES                 -->
+<!ENTITY % mathml-qname.mod
+                        PUBLIC
+"-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"
+"mathml3-qname1.mod"                                                 >
+
+
+<!--                    MATHML 3.0 DTD                             -->
+<!ENTITY % mathml.dtd   PUBLIC
+"-//W3C//DTD MathML 3.0//EN" 
+"mathml3.dtd"                                                        >
+
+
+<!--                    MATHML 3.0 EXTRA ENTITIES                  -->
+<!ENTITY % ent-mmlextra
+                        PUBLIC
+"-//W3C//ENTITIES Extra for MathML 3.0//EN" 
+"mathml/mmlextra.ent"                                                >
+
+
+<!--                    MATHML 3.0 ALIASES                         -->
+<!ENTITY % ent-mmlalias
+                        PUBLIC
+"-//W3C//ENTITIES Aliases for MathML 3.0//EN" 
+"mathml/mmlalias.ent"                                                >
+
+
+<!-- =================== End MathML 3.0 Modules ================== -->

--- a/publishing/1.1/JATS-mathmlsetup1.ent
+++ b/publishing/1.1/JATS-mathmlsetup1.ent
@@ -1,0 +1,348 @@
+<!-- ============================================================= -->
+<!--  MODULE:    MathML DTD SETUP MODULE                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.1 20151215//EN"
+     Delivered as file "JATS-mathmlsetup1.ent"                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the           -->
+<!--             MathML DTD:                                       -->
+<!--             1) Overrides the standard parameter entities used -->
+<!--                in the MathML 2.0 DTD                          -->
+<!--             2) Calls the MathML 2.0 DTD                       -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) mathml2.dtd  (MathML 2.0 DTD)                  -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+    
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  6. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+   
+  5. Updated the DTD-version attribute to "1.1d1" and the formal
+     public identifier to the date: "v1.1d1 20130915//EN".
+
+       =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE MathML MODULE               -->
+<!-- ============================================================= -->
+
+
+<!--                    MathML DTD                                 -->
+<!--                    The official version of the MathML 2.0 can
+                        be found at: http://www.w3.org/TR/MathML2/
+
+                        See also Mathematical Markup Language
+                        (MathML) Version 2.0
+
+                        A. Parsing MathML
+                        A.6 The MathML DTD
+            http://www.w3.org/TR/MathML2/appendixa.html#parsing-dtd
+
+                        A zip file with entity declarations is
+                        available from
+            http://www.w3.org/TR/MathML2/DTD-MathML-20010221.zip   -->
+
+
+<!-- ============================================================= -->
+<!--                    SET UP W3C XML SCHEMA                      -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE PREFIX EQUAL "xsi" (same as MathML)   -->
+<!ENTITY % Schema.prefix
+                        "xsi"                                        >
+
+<!--                    SET UP NAMESPACE FOR SCHEMA
+                           (same as MathML)                        -->
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance"  >
+
+
+<!--                    OVER-RIDE MATHML DTD TO MAKE EXPLICIT NS   -->
+<!--                    MathML sets this up but then lets the
+                        attribute be a CDATA one, not the real
+                        namespace URI                              -->
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA          #FIXED '%Schema.xmlns;'" >
+
+
+<!-- ============================================================= -->
+<!--                    SET UP "mml" AS THE MATH PREFIX            -->
+<!-- ============================================================= -->
+
+
+<!--                    MAKE MATH PREFIX PARAMETER ENTITY HAPPEN   -->
+<!ENTITY % MATHML.prefixed 
+                        "INCLUDE"                                    >
+
+
+<!--                    MAKE PREFIX EQUAL "mml"                    -->
+<!ENTITY % MATHML.prefix "mml"                                       >
+
+
+<!--                    SET UP "pfx"                               -->
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx   "%MATHML.prefix;:"                           >
+]]>
+
+
+<!--                    USE "pfx" TO SET THE MATH ELEMENT NAME     -->
+<!ENTITY % math.qname   "%MATHML.pfx;math"                           >
+
+
+
+<!-- ============================================================= -->
+<!--                    CALL THE MATHML ENTITIES                   -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML CHARACTER ENTITIES                  -->
+<!--                    Set the "INCLUDE" or "IGNORE" marked section
+                        switch for the MATHML 2.0 DTD. This switch
+                        determines whether the math processing in
+                        the -%mathml.dtd; module or the
+                        -%xmlspecchars.ent; module in this DTD Suite
+                        will invoke the sets of special characters
+                        that are defined AND INVOKED in the
+                        -%xmlspecchars.ent; module.
+                        A value of "IGNORE" turns off the second
+                        invocation from the MathML DTD.            -->
+<!ENTITY % mathml-charent.module
+                        "IGNORE"                                     >
+
+
+<!--                    MATHML-SPECIFIC CHARACTER ENTITIES         -->
+<!--                    Because the MATHML invocation is canceled
+                        using the parameter entity just defined,
+                        the two external entities below must be
+                        invoked from here, as neither XMLspecchars
+                        nor the MathML DTD will invoke them.       -->
+
+<!--                    New characters defined by MathML           -->
+%ent-mmlextra;
+
+
+<!--                    MathML aliases for characters defined above-->
+%ent-mmlalias;
+
+
+<!-- ============================================================= -->
+<!--                    RESTRICT CONTENT OF ANNOTATION             -->
+<!-- ============================================================= -->
+
+<!--                    MATHML ANNOTATION MODEL                    -->
+<!--                    The MathML DTD establishes the content of the
+                        <mml:annotation-xml> element as ANY. This is
+                        unnecessarily broad, causing inconvenience for
+                        conversion. The model has been restricted to
+                        one or more paragraphs.                    -->
+<!ENTITY % Annotation-xml.content
+                        "(p+)"                                       >
+
+
+<!-- ============================================================= -->
+<!--                    MathML 2.0 INVOCATION                      -->
+<!-- ============================================================= -->
+
+%mathml.dtd;
+
+
+<!-- ================== End MATHML Setup Module ================== -->

--- a/publishing/1.1/JATS-modules1.ent
+++ b/publishing/1.1/JATS-modules1.ent
@@ -1,0 +1,584 @@
+<!-- ============================================================= -->
+<!--  MODULE:    JATS DTD Suite Module of Modules                  -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+     Delivered as file "JATS-modules1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    For naming all the external modules (except       -->
+<!--             this module itself and the customization modules) -->
+<!--             that are part of the JATS DTD Suite. A specific   -->
+<!--             DTD will select from these modules by referencing -->
+<!--             the external Parameter Entities defined below that-->
+<!--             name the modules of the suite. To include a set   -->
+<!--             of elements (such as all the lists or the MathML  -->
+<!--             elements), reference the external Parameter Entity-->
+<!--             of the module that contains these declarations,   -->
+<!--             then modify the classes or content models to use  -->
+<!--             the new elements.                                 -->
+<!--                                                               -->
+<!-- CONTAINS:   Entity declarations and public names for all the  -->
+<!--             JATS DTD Suite external modules. Note: The modules-->
+<!--             are NOT referenced (called/invoked) in this       -->
+<!--             module, they are merely DECLARED.  The DTD or     -->
+<!--             a setup module (such as for the XHTML tables)     -->
+<!--             will invoke the external parameter entity to      -->
+<!--             call each module.                                 -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based 
+     DTDs, XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. NLMCITATION - Added module for deprecated element <nlm-citation>
+     because the element is called in a default class 
+     (citation.class) that, for reasons of backwards compatibility,
+     will not be changed at this time.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULT CLASSES AND MIXES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    DEFAULT ELEMENT CLASSES MODULE             -->
+<!--                    Set up the Parameter Entities and element
+                        class definitions that will be used to
+                        establish the content models for the
+                        Archiving and Interchange DTD.             -->
+<!ENTITY % default-classes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.1 20151215//EN"
+"JATS-default-classes1.ent"                                          >
+
+
+<!--                    DEFAULT ELEMENT MIXES MODULE               -->
+<!--                    Set up the Parameter Entities and element
+                        mix definitions that will be used in
+                        content models for the Archiving and
+                        Interchange DTD.                           -->
+<!ENTITY % default-mixes.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.1 20151215//EN"
+"JATS-default-mixes1.ent"                                            >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ATTRIBUTES SHARED BY ALL ELEMENTS   -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON ATTRIBUTES SHARED BY ALL ELEMENTS   -->
+<!ENTITY % JATS-common-atts.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.1 20151215//EN"
+"JATS-common-atts1.ent"                                              >
+
+
+<!-- ============================================================= -->
+<!--                    COMMON ELEMENTS SHARED BY MANY MODULES     -->
+<!-- ============================================================= -->
+
+
+<!--                    COMMON (SHARED) ELEMENT DECLARATIONS       -->
+<!ENTITY % common.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.1 20151215//EN"
+"JATS-common1.ent"                                                   >
+
+
+<!-- ============================================================= -->
+<!--                    CLASS MODULES (ALPHABETICAL ORDER)         -->
+<!-- ============================================================= -->
+
+
+<!--                    ARTICLE METADATA ELEMENTS                  -->
+<!ENTITY % articlemeta.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.1 20151215//EN"
+"JATS-articlemeta1.ent"                                              >
+
+
+<!--                    BACK MATTER ELEMENTS                       -->
+<!ENTITY % backmatter.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.1 20151215//EN"
+"JATS-backmatter1.ent"                                               >
+
+
+<!--                    DISPLAY (GRAPHICAL) ELEMENTS INVOCATION    -->
+<!ENTITY % display.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.1 20151215//EN"
+"JATS-display1.ent"                                                  >
+
+
+<!--                    FORMATTING ELEMENTS                        -->
+<!--                    Elements that change rendition/display. This
+                        module includes the Appearance Class, the
+                        Break Class, and the Emphasis Class        -->
+<!ENTITY % format.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.1 20151215//EN"
+"JATS-format1.ent"                                                   >
+
+
+<!--                    FUNDING ELEMENTS                           -->
+<!--                    Elements that model open access, grant,
+                        sponsorship, or other funding information,
+                        for example the grant number (<award-id>)
+                        and the <principal-investigator>           -->
+<!ENTITY % funding.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.1 20151215//EN"
+"JATS-funding1.ent"                                                  >
+
+
+<!--                    JOURNAL METADATA ELEMENTS                  -->
+<!ENTITY % journalmeta.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.1 20151215//EN"
+"JATS-journalmeta1.ent"                                              >
+
+
+<!--                    LINK ELEMENTS                              -->
+<!ENTITY % link.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.1 20151215//EN"
+"JATS-link1.ent"                                                     >
+
+
+<!--                    LIST ELEMENTS                              -->
+<!ENTITY % list.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.1 20151215//EN"
+"JATS-list1.ent"                                                          >
+
+
+<!--                    MATH ELEMENTS                              -->
+<!ENTITY % math.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.1 20151215//EN"
+"JATS-math1.ent"                                                     >
+
+
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!ENTITY % para.ent  PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.1 20151215//EN"
+"JATS-para1.ent"                                                          >
+
+
+<!--                    PHRASE-LEVEL CONTENT ELEMENTS              -->
+<!ENTITY % phrase.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.1 20151215//EN"
+"JATS-phrase1.ent"                                                   >
+
+
+<!--                    BIBLIOGRAPHY REFERENCES (CITATION) ELEMENTS-->
+<!ENTITY % references.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.1 20151215//EN"
+"JATS-references1.ent"                                               >
+
+
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!--                    Defines the <related-object> element to
+                        describe a related object such as a
+                        related book or a dataset.                 -->
+<!ENTITY % related-object.ent
+                       PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.1 20151215//EN"
+"JATS-related-object1.ent"                                           >
+
+
+<!--                    SECTION ELEMENTS                           -->
+<!ENTITY % section.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.1 20151215//EN"
+"JATS-section1.ent"                                                  >
+
+
+<!-- ============================================================= -->
+<!--                    TABLES: XHTML TABLE MODULES                -->
+<!-- ============================================================= -->
+
+
+<!--                    XHTML TABLE SETUP MODULE                   -->
+<!--                    Set all Parameter Entities needed by the
+                        HTML 4.0 (XHTML) table model, and then
+                        call the module containing that model.
+                        Authoring Note: If wanted, this module
+                        will be invoked in the DTD module          -->
+<!ENTITY % XHTMLtablesetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.1 20151215//EN"
+"JATS-XHTMLtablesetup1.ent"                                          >
+
+
+<!--                    XHTML TABLE MODEL                          -->
+<!--                    The public XML version of the XHTML 1.1
+                        table model. This module is invoked in the
+                         module %XHTMLtablesetup3.ent;             -->
+<!ENTITY % xhtml-table-1.mod
+                        PUBLIC
+"-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+"xhtml-table-1.mod"                                                  >
+
+
+<!--                    XHTML TABLE INLINE STYLE MODULE            -->
+<!--                    The public XML version of the XHTML 1.1
+                        inline style module for use in XHTML tables.
+                        This module is invoked in the
+                         module %XHTMLtablesetup3.ent;             -->
+<!ENTITY % xhtml-inlstyle-1.mod
+                        PUBLIC
+"-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+"xhtml-inlstyle-1.mod"                                                  >
+
+
+<!-- ============================================================= -->
+<!--                    ALI: NISO ACCESS AND INDICATORS            -->
+<!-- ============================================================= -->
+
+
+<!--                    NISO ACCESS AND INDICATORS (RP-22-1015)    -->
+<!--                    Set all Parameter Entities needed by the
+                        NISO ALI licensing elements.
+                        This module is invoked by each DTD.        -->
+<!ENTITY % JATS-ali-namespace.ent
+                        PUBLIC
+"-//NLM//DTD JATS ALI Namespace Module v1.1 20151215//EN"
+"JATS-ali-namespace1.ent"                                            >
+
+
+<!-- ============================================================= -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES       -->
+<!-- ============================================================= -->
+
+
+<!--                    OASIS XML TABLE SETUP MODULE               -->
+<!--                    Set all Parameter Entities needed by the
+                        OASIS (CALS) Table Exchange table model.
+                        Authoring Note: If wanted, this module
+                        will be invoked in the DTD module          -->
+<!ENTITY % oasis-tablesetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.1 20151215//EN"
+"JATS-oasis-tablesetup1.ent"                                         >
+
+
+<!--                    OASIS XML TABLE MODEL                      -->
+<!--                    The OASIS (CALS) Table Exchange table model
+                        This module is invoked in
+                        %OASIStablesetup3.ent;                     -->
+<!ENTITY % oasis-exchange.ent
+                        PUBLIC
+"-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+"oasis-exchange.ent"                                                 >
+
+
+<!-- ============================================================= -->
+<!--                    SPECIAL CHARACTER MODULES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    SPECIAL CHARACTERS DECLARATIONS            -->
+<!--                    Declares any standard XML special character
+                        entities used in this DTD                  -->
+<!ENTITY % xmlspecchars.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.1 20151215//EN"
+"JATS-xmlspecchars1.ent"                                             >
+
+
+<!--                    CUSTOM SPECIAL CHARACTERS DECLARATIONS     -->
+<!--                    Declares any custom special character
+                        entities created for this Suite            -->
+<!ENTITY % chars.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.1 20151215//EN"
+"JATS-chars1.ent"                                                    >
+
+
+<!-- ============================================================= -->
+<!--                    MATH: MATHML MODULES                       -->
+<!--                    Only one of the modules below may be       -->
+<!--                    invoked by a DTD.                          -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML 2.0 SETUP MODULE                    -->
+<!--                    Called from the DTD to include the MathML 2.0
+                        elements in the tag set.                   -->
+<!ENTITY % mathmlsetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.1 20151215//EN"
+"JATS-mathmlsetup1.ent"                                              >
+
+
+<!--                    MATHML 3.0 SETUP MODULE                    -->
+<!--                    Called from the DTD to include the MathML 3.0
+                        elements in the tag set.                   -->
+<!ENTITY % mathml3-mathmlsetup.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.1 20151215//EN"
+"JATS-mathml3-mathmlsetup1.ent"                                      >
+
+
+<!-- ============================================================= -->
+<!--                     MATHML 2.0 MODULES (below for JATS V1)    -->
+<!--                     MATHML 3.0 modules are invoked in the DTD -->
+<!-- ============================================================= -->
+
+
+<!--                    MATHML 2.0 QUALIFIED NAMES                 -->
+<!ENTITY % mathml-qname.mod
+                        PUBLIC
+"-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+"mathml2-qname-1.mod"                                                >
+
+
+<!--                    MATHML 2.0 DTD                             -->
+<!ENTITY % mathml.dtd   PUBLIC
+"-//W3C//DTD MathML 2.0//EN"
+"mathml2.dtd"                                                        >
+
+
+<!--                    MATHML 2.0 EXTRA ENTITIES                  -->
+<!ENTITY % ent-mmlextra
+                        PUBLIC
+"-//W3C//ENTITIES Extra for MathML 2.0//EN"
+"mathml/mmlextra.ent"                                               >
+
+
+<!--                    MATHML 2.0 ALIASES                         -->
+<!ENTITY % ent-mmlalias
+                        PUBLIC
+"-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+"mathml/mmlalias.ent"                                               >
+
+
+<!-- ============================================================= -->
+<!--                     NOTATIONS MODULE                          -->
+<!-- ============================================================= -->
+
+
+<!--                    NOTATION DECLARATIONS MODULE               -->
+<!--                    Container module for the Notation Declarations
+                        to be used with this DTD suite.  Placed in
+                        their own module for easy expansion or
+                        replacement.                               -->
+<!ENTITY % notat.ent PUBLIC
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.1 20151215//EN"
+"JATS-notat1.ent"                                                    >
+
+
+<!-- ============================================================= -->
+<!--                     NLM CITATION (DEPRECATED ELEMENT) MODULE  -->
+<!-- ============================================================= -->
+
+
+<!--                    NLM CITATION MODULE                        -->
+<!--                    The only new element created for the
+                        Publishing DTD, the highly structured NLM
+                        citation, to enforce a slightly loose version
+                        of an NLM-structured bibliographic reference.
+                        Sequence is enforced and interior punctuation
+                        is expected to be generated.               -->
+<!ENTITY % nlmcitation.ent
+                        PUBLIC
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+"JATS-nlmcitation1.ent"                                              >
+
+
+<!-- =================== End Journal Article Module of Modules === -->

--- a/publishing/1.1/JATS-nlmcitation1.ent
+++ b/publishing/1.1/JATS-nlmcitation1.ent
@@ -1,0 +1,285 @@
+<!-- ============================================================= -->
+<!--  MODULE:    NLM Citation                                      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+Delivered as file "JATS-nlmcitation1.ent"                          -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Deprecated 2012                                   -->
+<!--             This DTD Suite module adds the model for the      -->
+<!--             NLM Structured bibliographic citation. This model -->
+<!--             The model loosely reflects the NLM's style, in    -->
+<!--             that it allows the tagging of all "legal" NLM     -->
+<!--             citations and enforces the sequence in which      -->
+<!--             content must appear if it is present. However,    -->
+<!--             this model does not provide guidance on what      -->
+<!--             information is required for each type of cited    -->
+<!--             content.                                          -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             September 2004                                    -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+ Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+      =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  9. JATS became version "1.1" and "v1.1 20151215"
+
+    =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d3" and "v1.1d3 20150301"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. NLM CITATION ATTRIBUTES - Removed the dependency whereby
+     the NLM citation used the same attributes as the other types
+     of citation via %citation-atts;. <nlm-citation> now uses
+     only %nlm-citation-atts; No documents need change.
+     - added @xml:lang
+     - added @specific-use
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    NEW ELEMENT DECLARATIONS                   -->
+<!--                    Declarations of elements that are new to   -->
+<!--                    this DTD.                                  -->
+<!--                    NOTE: All new structures must be mappable  -->
+<!--                    to the archiving/interchange DTD and the   -->
+<!--                    mapping should be described when the new   -->
+<!--                    element is declared.                       -->
+<!-- ============================================================= -->
+
+
+<!--                    NLM CITATION ATTRIBUTES                    -->
+<!--                    Attributes for all three types of
+                        citations (<mixed-citation>,
+                        <element-citation>, and <nlm-citation>).   -->
+<!ENTITY % nlm-citation-atts
+            "%jats-common-atts;                                       
+             publication-type
+                        CDATA                             #IMPLIED
+             publisher-type
+                        CDATA                             #IMPLIED
+             publication-format
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    NLM CITATION MODEL                         -->
+<!--                    This structured citation model is loosely
+                        reflects the NLM's house style, in that
+                        it allows the tagging of all "legal" NLM
+                        citations and enforces the sequence in which
+                        content must appear if it is present.
+                        This model assumes that punctuation between
+                        the parts of a citation will be generated
+                        on display or on export.
+                        (Deprecated after Version 3.0)
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=nlm-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=nlm-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=nlm-citation
+                                                                   -->
+<!ELEMENT  nlm-citation
+                        ((person-group | collab)*,
+                         (article-title | trans-title)*,
+                         source?, patent?, trans-source?, year?,
+                         ((month?, day?, time-stamp?) | season?),
+                         access-date?, volume?, edition?,
+                         conf-name?, conf-date?, conf-loc?,
+                         (issue | supplement)*, publisher-loc?,
+                         publisher-name?, (fpage?, lpage?)*,
+                         page-count?, series?, comment*, pub-id*,
+                         annotation?)                                >
+
+<!ATTLIST  nlm-citation
+             %nlm-citation-atts;                                     >
+
+
+<!-- ================== End NLM Citation Module ================== -->

--- a/publishing/1.1/JATS-notat1.ent
+++ b/publishing/1.1/JATS-notat1.ent
@@ -1,0 +1,269 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Notation Declarations                             -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.1 20151215//EN"
+     Delivered as file "JATS-notat1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To name all the allowable notations               -->
+<!--                                                               -->
+<!-- CONTAINS:   Notation Declarations                             -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+ Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1d3 20150301"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+ 
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--               NOTATION DECLARATIONS                           -->
+<!-- ============================================================= -->
+
+
+<!--               LATEX (for Mathematics)                         -->
+<!NOTATION  LaTeX  PUBLIC
+           "+//ISBN 3-893-196463::Goosens//NOTATION Der LaTeX Begleiter//DE"  >
+
+
+<!--               TEX (for Mathematics)                           -->
+<!NOTATION  TEX  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+<!NOTATION  tex  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+<!NOTATION  TeX  PUBLIC
+           "+//ISBN 0-201-13448-9::Knuth//NOTATION The TeXbook//EN"  >
+
+
+<!-- ============================================================= -->
+<!--               POTENTIAL NOTATION DECLARATIONS                 -->
+<!-- ============================================================= -->
+
+
+<!--               CGM (Computer Graphics Metafile)                -->
+<!NOTATION cgmchar PUBLIC
+"ISO 8632/2//NOTATION Character encoding//EN"
+                                                                     >
+<!NOTATION cgmclear PUBLIC
+"ISO 8632/4//NOTATION Clear text encoding//EN"
+                                                                     >
+
+
+<!--               GIF (Graphic Interchange Format)                -->
+<!NOTATION gif     PUBLIC
+"-//ISBN 0-7923-9432-1::Graphic Notation//NOTATION CompuServe
+Graphic Interchange Format//EN"
+                                                                     >
+
+<!--               EPS (Adobe's Encapsulate Postscript)            -->
+<!NOTATION eps     PUBLIC
+"+//ISBN 0-201-18127-4::Adobe//NOTATION PostScript Language Reference Manual//EN"
+                                                                     >
+
+
+<!--               JPEG (Joint Photographic Experts Group raster)  -->
+<!NOTATION jpeg    PUBLIC
+"+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Joint Photographic Experts Group raster//EN"
+                                                                     >
+
+<!--               TIFF (Uncompressed)                             -->
+<!NOTATION tiff    PUBLIC
+"+//ISBN 0-7923-9432-1::Graphic Notation//NOTATION Aldus/Microsoft
+Tagged Interchange File Format//EN"                                  >
+
+
+<!-- ================== End Notation Module ====================== -->

--- a/publishing/1.1/JATS-oasis-namespace1.ent
+++ b/publishing/1.1/JATS-oasis-namespace1.ent
@@ -1,0 +1,223 @@
+<!-- ============================================================= -->
+<!--  MODULE:    OASIS Table Namespace Module                      -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS OASIS Table Namespace Module v1.1 20151215//EN"
+     Delivered as file "JATS-oasis-namespace1.ent"                 -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     OASIS-Table Version of the JATS DTD Suite         -->
+<!--                                                               -->
+<!-- PURPOSE:    Establish the prefix for the OASIS CALS Exchange  -->
+<!--             Table model, typically "oasis" (<oasis:table>).   -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2012                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  3. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  2. JATS became version "1.1d3" and "v1.1 20150301//EN"
+  
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  1. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/
+                                                                   -->
+
+<!-- ============================================================= -->
+<!--                    OASIS NAMESPACE SETUP                      -->
+<!-- ============================================================= -->
+
+
+<!--                    NAME OASIS NAMESPACE BASE URI              -->
+<!--                    Set the oasis namespace URI.               -->
+<!ENTITY % oasis.xmlns   
+      "http://www.niso.org/standards/z39-96/ns/oasis-exchange/table" >
+
+
+<!--                    NAME OASIS NAMESPACE PREFIX                -->
+<!--                    Set the namespace prefix for the OASIS tables
+                        to the JATS-named prefix "oasis". 
+                        Implementor's Note: This parameter entity
+                        should always be set, even if you need to turn
+                        off the namespace prefix.                  -->
+<!ENTITY % oasis.prefix "oasis"                                      >
+
+
+<!--                    NAME OASIS NAMESPACE PREFIX                -->
+<!--                    Construct the OASIS namespace prefix to be 
+                        used in the xmlns pseudo-attribute from:
+                          - the word "xmlns", 
+                          - a colon, and 
+                          - the prefix just defined in %oasis.prefix;
+                                                                   -->
+<!ENTITY % oasis.xmlns.attrname
+                        "xmlns:%oasis.prefix;"                       >
+
+
+<!--                    SET OASIS NAMESPACE PREFIX                 -->
+<!--                    Set the OASIS prefix string to the prefix
+                        "oasis" plus a colon ==> "oasis:" for use
+                        in the QNames of elements. This is NOT used in
+                        setting up the OASIS prefix in the XMLNS
+                        pseudo-attribute, only for naming elements. -->
+<!ENTITY % oasis.pfx     "%oasis.prefix;:"                            >
+
+
+<!--                    DEFAULT NAMESPACE-OASIS TABLE EXCHANGE     -->
+<!--                    The default namespace to be used when
+                        calling in the OASIS Open Exchange (CALS)
+                        Table Model. This is set on the article level
+                        as well as on the OASIS table elements.
+                        Implementor's Note: The parameter entity is
+                        constructed from the parameter entities set 
+                        above.                                     -->
+<!ENTITY % oasis.xmlns.attrib
+     "%oasis.xmlns.attrname; 
+                        CDATA               #FIXED '%oasis.xmlns;'"  >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR QUALIFIED NAMES     -->
+<!--                    Implementor's Note: the following QNames   -->
+<!--                    are set up to include the OASIS prefix, by -->
+<!--                    default "oasis". Following the practice of -->
+<!--                    MathML, DocBook, et al., a parameter entity-->
+<!--                    named "xyz.qname" defines the qualified    -->
+<!--                    name for each element. These parameter     -->
+<!--                    entities all contain an "o" in front of    -->
+<!--                    them ("otable.qname", "otgroup.qname")     -->
+<!--                    because the XHTML table model uses the     -->
+<!--                    same QName parameter entity naming         -->
+<!--                    convention. The "o" is used for the NISO   -->
+<!--                    JATS entities to avoid parameter entity    -->
+<!--                    name clashes.                              -->
+<!-- ============================================================= -->
+
+<!ENTITY % otable.qname  "%oasis.pfx;table"                          >
+<!ENTITY % otgroup.qname "%oasis.pfx;tgroup"                         >
+<!ENTITY % otbody.qname  "%oasis.pfx;tbody"                          >
+<!ENTITY % othead.qname  "%oasis.pfx;thead"                          >
+<!ENTITY % ocol.qname    "%oasis.pfx;col"                            >
+<!ENTITY % ocolspec.qname        
+                         "%oasis.pfx;colspec"                        >
+<!ENTITY % orow.qname    "%oasis.pfx;row"                            >
+<!ENTITY % oentry.qname  "%oasis.pfx;entry"                          >
+
+
+<!-- ================== End OASIS Namespace Setup  =============== -->

--- a/publishing/1.1/JATS-oasis-tablesetup1.ent
+++ b/publishing/1.1/JATS-oasis-tablesetup1.ent
@@ -1,0 +1,409 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Namespaced OASIS XML Table Setup Module           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.1 20151215//EN"
+     Delivered as file "JATS-oasis-tablesetup1.ent"                -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:    OASIS-Table Version of the JATS DTD Suite          -->
+<!--                                                               -->
+<!-- PURPOSE:    Provides the organization for using the           -->
+<!--             OASIS Open exchange CALS table model (XML         -->
+<!--             version)                                          -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             1) %oasis-exchange.ent;  OASIS exchange table     -->
+<!--                                        model (XML version)    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             March 2007                                        -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. TABLE ATTRIBUTES - Added @specific-use to the attributes for
+     <oasis:table>, primarily for use when <oasis:table> is used
+     inside <alternatives>.
+
+  7. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  6. GLOBAL ATTRIBUTES - Added the new parameter entity 
+        "%jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added a new (to JATS) additive attribute list to:
+     - tbl.colspec
+     - tbl.entry
+     - tbl.row.att
+     - tbl.tbody
+     - tbl.tgroup
+     - tbl.thead
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. OASIS NAMESPACE - The Working Group requested the ability to
+     remove the OASIS namespace prefix by changing a single 
+     parameter entity. The Working Group also decided that the
+     namespace itself should be preserved for the OASIS table model.
+      - Replaced the names of all the OASIS table elements (in this
+        module and the classes module) with parameter entities that
+        name the QName of the element. (The entities would have
+        been named as "table.qname" following the pattern used by
+        MathML, XHTML, DocBook, et al., but due to name clashes
+        with the XHTML parameter entities forced these to be
+        different, and an "o" was prefixed to each :
+        "otable.qname", "otbody.qname", etc.
+      - Set up the OASIS namespace prefix (using several parameter
+        entities to build the namespace in parts) in a new module
+        called JATS-oasis-namespace1.ent.
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+           http://jats.nlm.nih.gov/0.4.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    SET UP FOR THE PUBLIC TABLE MODULE         -->
+<!-- ============================================================= -->
+
+
+<!--                    OVER-RIDES FOR STANDARD PARAMETER ENTITIES -->
+<!--                    In order to use the OASIS-OPEN (CALS)
+                        Exchange table model, various Parameter
+                        ENTITY declarations are required.  Brief
+                        descriptions of the Parameter Entities in
+                        the exchange table model that this module
+                        will over-ride are given below:
+                        (adapted from the Exchange module itself)
+
+     ENTITY NAME        WHERE USED       WHAT IT IS
+
+     %yesorno           In ATTLIST of:   An attribute declared
+                        almost all       value for a "boolean"
+                        table elements   attribute
+
+     %titles            In content of:    The "title" part of the
+                        table element     table model has been set
+                                          to the empty string,
+                                          since the title is in the
+                                          Table Wrapper element
+
+     %tbl.table-titles.mdl
+                        In content of:    The model group for the
+                        table elements    "title" part of the
+                                          content model for table
+                                          element
+
+     %paracon           In content of:    The "text" (logical
+                        <entry>           content) of the model for
+                                          <entry>
+
+     %tbl.table.att     In ATTLIST of:    Additional attributes on
+                        table element     the table element
+
+     %tbl.entry.att     In ATTLIST of:    Additional attributes on
+                        <entry>           the <entry> element      -->
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR QUALIFIED NAMES     -->
+<!-- ============================================================= -->
+
+<!--                    TABLE ELEMENT NAME                         -->
+<!ENTITY % tbl.table.name
+                        "%otable.qname;"                             >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITY FOR ATTRIBUTES            -->
+<!-- ============================================================= -->
+
+
+<!--                    YES OR NO                                  -->
+<!--                    The boolean value, "0" to indicate "no",
+                        any other number, usually "1", to indicate
+                        "yes"                                      -->
+<!ENTITY % yesorno      "NMTOKEN"                                    >
+
+
+<!--                    TABLE ATTRIBUTES                           -->
+<!--                    Additional attributes on the table element -->
+<!ENTITY % tbl.table.att
+             "%oasis.xmlns.attrib;
+              %jats-common-atts;
+              specific-use
+                        CDATA                             #IMPLIED
+              content-type
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    TABLE ENTRY ATTRIBUTES                     -->
+<!--                    Additional attributes on the table entry
+                        element, that is, attributes for a table
+                        cell                                       -->
+<!ENTITY % tbl.entry.att
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TABLE GROUP ATTRIBUTES                     -->
+<!--                    Additional attributes on the tgroup element-->
+<!ENTITY % tbl.tgroup.att 
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TABLE HEAD ATTRIBUTES                      -->
+<!--                    Additional attributes on the thead element -->
+<!ENTITY % tbl.thead.att
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TABLE BODY ATTRIBUTES                      -->
+<!--                    Additional attributes on the tbody element -->
+<!ENTITY % tbl.tbody.att 
+            "%jats-common-atts;"                                     >
+
+
+<!--                    COLUMN SPECIFICATION ATTRIBUTES            -->
+<!--                    Additional attributes on the colspec 
+                        element                                    -->
+<!ENTITY % tbl.colspec.att
+            "%jats-common-atts;"                                     >
+
+
+<!--                    TABLE ROW ATTRIBUTES                       -->
+<!--                    Additional attributes on the row element   -->
+<!ENTITY % tbl.row.att
+            "%jats-common-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR CONTENT MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    TITLE OF THE TABLE                         -->
+<!--                    The "title" part of the table element has
+                        been set to the empty string, since the
+                        title is contained within the Table
+                        Wrapper element                            -->
+<!ENTITY % titles       ""                                           >
+<!ENTITY % tbl.table-titles.mdl
+                        ""                                           >
+
+
+<!--                    CONTENTS OF AN ENTRY (TABLE CELL)          -->
+<!--                    Names all the elements that may occur
+                        inside a table cell (<entry>)              -->
+<!ENTITY % paracon      "#PCDATA | %inside-cell;"                    >
+
+
+<!--                    CONTENTS OF TABLE                          -->
+<!--                    Names all the elements that may occur
+                        inside a table (<table>)                   -->
+<!ENTITY % tbl.table-main.mdl
+                        "%otgroup.qname;+"                           >
+
+
+<!--                    CONTENTS OF TABLE GROUP (ORIGINAL OASIS)   -->
+<!--                    Names all the elements that may occur
+                        inside a Table Group (<tgroup>)            -->
+<!ENTITY % tbl.tgroup.mdl
+                        "%ocolspec.qname;*, %othead.qname;?, 
+                         %otbody.qname;"                             >
+
+
+<!--                    CONTENTS OF TABLE ROW                      -->
+<!--                    Names all the elements that may occur
+                        inside a Table Row (<row>)                 -->
+<!ENTITY % tbl.row.mdl  "%oentry.qname;+"                            >
+
+
+<!-- ============================================================= -->
+<!--                    THE OASIS CALS TABLE INVOCATION            -->
+<!-- ============================================================= -->
+
+
+<!--                    OASIS XML TABLE MODEL                      -->
+<!--                    ENTITY % oasis-exchange.ent PUBLIC
+"-//OASIS//DTD XML Exchange Table Model 19990315//EN"              -->
+%oasis-exchange.ent;
+
+
+<!-- ================== End OASIS Table Setup Module ============= -->

--- a/publishing/1.1/JATS-para1.ent
+++ b/publishing/1.1/JATS-para1.ent
@@ -1,0 +1,481 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Paragraph-Like Elements                           -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.1 20151215//EN"
+     Delivered as file "JATS-para1.ent"                            -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Names structural elements that will appear in     -->
+<!--             the same places as a paragraph                    -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 14. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. STATEMENT - Added new statement.class inside the model
+     for <statement>, so that statements can be recursive.
+
+ 11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+
+
+  9. ABSTRACTS AND KEYWORDS ON NEW STRUCTURES
+     - Added <abstract> (through %abstract.class;) and <kwd-group> 
+       (through %kwd-group.class;) to the following elements:
+        - statement (through statement-model PE)
+   
+     =============================================================
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  4. Updated the DTD-version attribute to "0.4" 
+   
+  3. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  2. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - speaker through speaker-atts (both)
+      - statement through statement-atts (@xml:lang only; already
+          @specific-use))
+      - verse-line through verse-line-atts (both)
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    DISPLAY QUOTE ATTRIBUTES                   -->
+<!--                    Attribute list for the <disp-quote> element-->
+<!ENTITY % disp-quote-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PARAGRAPH ATTRIBUTES                       -->
+<!--                    Attribute list for the <p> element         -->
+<!ENTITY % p-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SPEAKER ATTRIBUTES                         -->
+<!--                    Attribute list for the <speaker> element   -->
+<!ENTITY % speaker-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SPEECH ATTRIBUTES                          -->
+<!--                    Attribute list for the <speech> element    -->
+<!ENTITY % speech-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STATEMENT ATTRIBUTES                       -->
+<!--                    Attribute list for the <statement> element -->
+<!ENTITY % statement-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSE GROUP ATTRIBUTES                     -->
+<!--                    Attribute list for the <verse-group> element
+                                                                   -->
+<!ENTITY % verse-group-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSE LINE ATTRIBUTES                      -->
+<!--                    Attribute list for the <verse-line> element-->
+<!ENTITY % verse-line-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PARAGRAPH-LEVEL ELEMENTS                   -->
+<!-- ============================================================= -->
+
+
+<!--                    PARAGRAPH                                  -->
+<!--                    The basic block-unit of textual information
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=p
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=p
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=p
+                                                                   -->
+<!ELEMENT  p            (#PCDATA %p-elements;)*                      >
+<!ATTLIST  p
+             %p-atts;                                                >
+
+
+<!-- ============================================================= -->
+<!--                    THE REST OF THE PARAGRAPH ELEMENTS         -->
+<!-- ============================================================= -->
+
+
+<!--                    QUOTE, DISPLAYED MODEL                     -->
+<!--                    Content model for the Display Quote element-->
+<!ENTITY % disp-quote-model
+                        "(label?, title?, (%para-level;)*,
+                          (%display-back-matter.class;)* )"          >
+
+
+<!--                    QUOTE, DISPLAYED                           -->
+<!--                    Extract or extended quoted passage from
+                        another work, usually made typographically
+                        distinct from the surrounding text.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=disp-quote
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=disp-quote
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=disp-quote
+                                                                   -->
+<!ELEMENT  disp-quote   %disp-quote-model;                           >
+<!ATTLIST  disp-quote
+             %disp-quote-atts;                                       >
+
+
+<!--                    SPEECH MODEL                               -->
+<!--                    Content model for the <speech> element     -->
+<!ENTITY % speech-model "(speaker, (%just-para.class;)+ )"           >
+
+
+<!--                    SPEECH                                     -->
+<!--                    One exchange in a real or imaginary
+                        conversation between two or more entities,
+                        for example, between a an interviewer and the
+                        person being interviewed, between a nurse or
+                        doctor and a patient, between a person and a
+                        computer, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=speech
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=speech
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=speech
+                                                                   -->
+<!ELEMENT  speech       %speech-model;                               >
+<!ATTLIST  speech
+             %speech-atts;                                           >
+
+
+<!--                    SPEAKER ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a speaker.                                 -->
+<!ENTITY % speaker-elements
+                        "| %person-name.class; | %simple-link.class;">
+
+
+<!--                    SPEAKER                                    -->
+<!--                    One who utters a speech as part of a
+                        speech, for example the computer "HAL" in
+                        the exchange 'Hal: "Hi Dave"'.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=speaker
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=speaker
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=speaker
+                                                                   -->
+<!ELEMENT  speaker      (#PCDATA %speaker-elements;)*                >
+<!ATTLIST  speaker
+             %speaker-atts;                                          >
+
+
+<!--                    STATEMENT, FORMAL MODEL                    -->
+<!--                    Content model for the <statement> element  -->
+<!ENTITY % statement-model
+                        "(label?, title?, 
+                          (%abstract.class;)*, (%kwd-group.class;)*,
+                          (%just-para.class; | %statement.class;)+,
+                          (%display-back-matter.class;)*)"           >
+
+
+<!--                    STATEMENT, FORMAL                          -->
+<!--                    A Theorem, Lemma, Proof, Postulate,
+                        Hypothesis, Proposition, Corollary, or
+                        other formal statement, identified as such
+                        with a label, usually made typographically
+                        distinct from the surrounding text
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=statement
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=statement
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=statement
+                                                                   -->
+<!ELEMENT  statement    %statement-model;                            >
+<!ATTLIST  statement
+             %statement-atts;                                        >
+
+
+<!--                    VERSE GROUP MODEL                          -->
+<!--                    Content model for the <verse-group> element-->
+<!ENTITY % verse-group-model
+                        "(label?, title?, subtitle?,
+                         (verse-line | verse-group)+,
+                         (%display-back-matter.class;)*) "           >
+
+
+<!--                    VERSE FORM FOR POETRY                      -->
+<!--                    A song, poem, or verse.
+                        Implementer's Note: No attempt has been made
+                        to retain the look or visual form of the
+                        original.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=verse-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=verse-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=verse-group
+                                                                   -->
+<!ELEMENT  verse-group  %verse-group-model;                          >
+<!ATTLIST  verse-group
+             %verse-group-atts;                                      >
+
+
+<!--                    VERSE-LINE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <verse-line>
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-text; is an inline
+                        mix, the OR bar is already there.          -->
+<!ENTITY % verse-line-elements
+                        "%simple-text; | %simple-link.class;"        >
+
+
+<!--                    LINE OF A VERSE                            -->
+<!--                    One line of a poem or verse
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=verse-line
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=verse-line
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=verse-line
+                                                                   -->
+<!ELEMENT  verse-line   (#PCDATA %verse-line-elements;)*             >
+<!ATTLIST  verse-line
+             %verse-line-atts;                                       >
+
+
+<!-- ================== End Paragraph Class Module =============== -->

--- a/publishing/1.1/JATS-phrase1.ent
+++ b/publishing/1.1/JATS-phrase1.ent
@@ -1,0 +1,502 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Subject Phrase Class Elements                     -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-phrase1.ent"                          -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the phrase.class, that is, names the      -->
+<!--             inline, subject-specific elements                 -->
+<!--                                                               -->
+<!--             If more specific subject words (such as "gene")   -->
+<!--             are added to later version of this DTD, they      -->
+<!--             should be added to the %phrase.class; entity and  -->
+<!--             defined in this module or in %common.ent;         -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             the DTD suite should be sent in email to:         -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 13. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 12. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 11. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 10. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+      
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  9. NAMED CONTENT ATTRIBUTE - Added @rid to the attributes of
+     <named-content>.
+   
+  8. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  7. Updated the DTD-version attribute to "0.4" 
+   
+  6. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  5. MILESTONE END ATTRIBUTES - The new parameter entity
+     %milestone-end-atts; now uses %milestone-atts;, as it used to,
+     for compatibility purposes. This had not been done.
+
+  4. ACCESSIBILITY- Added @alt to
+     - <abbrev> through %abbrev-atts;
+     - <named-content> through %named-content-atts;
+     - <styled-content> through %styled-content-atts:
+
+  3. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - abbrev through abbrev-atts (both)
+      - milestone-start through milestone-atts (@xml:lang only;
+           @specific-use already)
+      - milestone-end through milestone-end-atts (both)
+      - named-content through named-content-atts (@xml:lang only;
+           @specific-use already)
+      - styled-content through styled-content-atts (@xml:lang only;
+           @specific-use already)
+
+  2. MILESTONE - The attribute list for <milestone-start> was
+     named milestone-atts not milestone-start-atts. Added the
+     new PE milestone-start-atts, but set it to the value of
+     milestone-atts so as not to break customizations.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION ATTRIBUTES                    -->
+<!--                    Attributes for the <abbrev> element        -->
+<!ENTITY % abbrev-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             alt        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    MILESTONE ATTRIBUTES                       -->
+<!--                    Attributes for both the <milestone-start> 
+                        and <milestone-end> elements               -->
+<!ENTITY % milestone-atts
+            "%jats-common-atts;                                       
+             rid        IDREF                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             rationale  CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    MILESTONE START ATTRIBUTES                 -->
+<!--                    Attributes for the <milestone-start>
+                        element                                    -->
+<!ENTITY % milestone-start-atts
+            "%milestone-atts;"                                       >
+
+
+<!--                    MILESTONE END ATTRIBUTES                   -->
+<!--                    Attributes for the <milestone-end>
+                        element                                    -->
+<!ENTITY % milestone-end-atts
+            "%milestone-atts;"                                       >
+
+
+<!--                    NAMED CONTENT ATTRIBUTES                   -->
+<!--                    Attributes for the <named-content> element -->
+<!ENTITY % named-content-atts
+            "%jats-common-atts;                                       
+             rid        IDREFS                            #IMPLIED
+             alt        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #REQUIRED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    STYLED CONTENT ATTRIBUTES                  -->
+<!--                    Attributes for the <styled-content> element-->
+<!ENTITY % styled-content-atts
+            "%jats-common-atts; 
+             toggle     (yes | no)                        #IMPLIED
+             style      CDATA                             #IMPLIED
+             style-type
+                        CDATA                             #IMPLIED
+             alt        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    PHRASE-LEVEL ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    ABBREVIATION ELEMENTS                      -->
+<!--                    Elements for use in the <abbrev> element   -->
+<!ENTITY % abbrev-elements
+                        "| %def.class;"                              >
+
+
+<!--                    ABBREVIATION OR ACRONYM                    -->
+<!--                    Used to identify an abbreviation or acronym
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=abbrev
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=abbrev
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=abbrev
+                                                                   -->
+<!ELEMENT  abbrev       (#PCDATA %abbrev-elements;)*                 >
+<!ATTLIST  abbrev
+             %abbrev-atts;                                           >
+
+
+<!-- ============================================================= -->
+<!--                    MILESTONE ELEMENTS                         -->
+<!-- ============================================================= -->
+
+
+<!--                    MILESTONE MODEL                            -->
+<!--                    Model for both the <milestone-start> and
+                        <milestone-end> elements                   -->
+<!ENTITY % milestone-model
+                        "EMPTY"                                      >
+
+
+<!--                    MILESTONE START MODEL                      -->
+<!--                    Model for the both the <milestone-start>
+                        element                                    -->
+<!ENTITY % milestone-start-model
+                        "%milestone-model;"                          >
+
+
+<!--                    MILESTONE START                            -->
+<!--                    Used to mark the start of a non-hierarchically
+                        nested object, that is, a textual component
+                        which cannot be expressed in the normal
+                        non-overlapping, OCHO structure of an XML
+                        document. When this element is used, it is
+                        assumed that the end of the textual
+                        component will be marked with a
+                        <milestone-end> element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=milestone-start
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=milestone-start
+                                                                   -->
+<!ELEMENT  milestone-start
+                        %milestone-start-model;                      >
+<!ATTLIST  milestone-start
+             %milestone-start-atts;                                  >
+
+
+<!--                    MILESTONE END MODEL                        -->
+<!--                    Model for the both the <milestone-end>
+                        element                                    -->
+<!ENTITY % milestone-end-model
+                        "%milestone-model;"                          >
+
+
+<!--                    MILESTONE END                              -->
+<!--                    Used to mark the end of a non-hierarchically
+                        nested object, that is, a textual component
+                        which cannot be expressed in the normal
+                        non-overlapping, OCHO structure of an XML
+                        document. When this element is used, it is
+                        assumed that the start of the textual
+                        component was marked with a <milestone-start>
+                        element.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=milestone-end
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=milestone-end
+                                                                   -->
+<!ELEMENT  milestone-end
+                        %milestone-end-model;                        >
+<!ATTLIST  milestone-end
+             %milestone-end-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    NAMED CONTENT ELEMENTS                     -->
+<!-- ============================================================= -->
+
+
+<!--                    NAMED CONTENT ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <named-content> element                -->
+<!ENTITY % named-content-elements
+                        "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class;|
+                         %emphasis.class;  |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %list.class; |
+                         %math.class; | %phrase.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %rest-of-para.class;"      >
+
+
+<!--                    NAMED SPECIAL (SUBJECT) CONTENT            -->
+<!--                    A semantically distinct word or phrase
+                        within the text. Often such phrases are
+                        treated differently, for example, given a
+                        different typographic style or look, to call
+                        attention to the subject matter. For
+                        example, the word is a drug name or a
+                        gene or the phrase identifies an organism
+                        genus/species.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=named-content
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=named-content
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=named-content
+                                                                   -->
+<!ELEMENT  named-content
+                        (#PCDATA %named-content-elements;)*          >
+<!ATTLIST  named-content
+             %named-content-atts;                                    >
+
+
+<!-- ============================================================= -->
+<!--                    STYLED CONTENT ELEMENTS                    -->
+<!-- ============================================================= -->
+
+
+<!--                    STYLED CONTENT ELEMENTS                    -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <styled-content> element               -->
+<!ENTITY % styled-content-elements
+                        "| %address-link.class; |
+                         %article-link.class; |
+                         %block-display.class; | %block-math.class;|
+                         %emphasis.class; |
+                         %inline-display-noalt.class; |
+                         %inline-math.class; | %list.class; |
+                         %math.class; | %phrase.class; |
+                         %simple-link.class; |
+                         %subsup.class; | %rest-of-para.class;"      >
+
+
+<!--                    STYLED SPECIAL (SUBJECT) CONTENT           -->
+<!--                    A stylistically distinct word or phrase
+                        within the text, that cannot be tagged using
+                        any of the other mechanisms for such content.
+                        In other words: the content cannot be
+                        described with bold, italic, monospace or any
+                        of the other emphasis class elements and
+                        <named-content> is inappropriate because the
+                        semantic reason behind the typographic
+                        distinction is not clear.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=styled-content
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=styled-content
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=styled-content
+                                                                   -->
+<!ELEMENT  styled-content
+                        (#PCDATA %styled-content-elements;)*         >
+<!ATTLIST  styled-content
+             %styled-content-atts;                                   >
+
+
+<!-- ================== End Phrase Class Module ================== -->

--- a/publishing/1.1/JATS-references1.ent
+++ b/publishing/1.1/JATS-references1.ent
@@ -1,0 +1,1205 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Bibliographic Reference (Citation) Class Elements -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+ 
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.1 20151215//EN"
+Delivered as file "JATS-references1.ent"                           -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Defines the bibliographic reference elements      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 21. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 20. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 19. ATTRIBUTES FOR PUB-ID
+   - Added the linking attributes (optional version) to <pub-id> , 
+     so that a <pub-id> that is a DOI, for example, can carry the 
+     linking attributes and be made into a live link. In this use
+     of <pub-id>, the element is acting both as an identifier
+     and as a link.
+   - Added new attribute @assigning-authority to <pub-id>, to
+     carry new values such as "CrossRef" and to take some of the
+     semantic burden off the @pub-id-type attribute, when
+     values are organizations such as "Genbank" or "PDB".
+ 
+ 18. VERSION FOR DATASETS - Added new element <version>
+     for citing datasets and software. Similar to <edition>
+     for printed material.
+ 
+ 17. DATA TITLE FOR DATASETS - Added new element <data-title>
+     to name datasets and parts of datasets. Acts both as an
+     <article-title> equivalent and as a <source> equivalent,
+     since many levels of data may be cited.
+
+ 16. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+ 15. ACCESS DATE ELEMENT
+     Added attributes for @calendar and @iso-8601-date. The element is
+     deprecated but still in use.
+
+ 14. NEW <era> ELEMENT
+     Added <era> through date-parts.class to:
+      - <date-in-citation>
+
+ 13. INSTITUTIONS TO STANDARDS ORGANIZATIONS
+     Added the elements <institution-wrap> to the following elements
+     through the institution-wrap.class:
+      - <std-organization>
+
+ 12. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+ 11. EDITION 
+       a) Changed the long name of the <edition> element
+          ("Edition, Cited)") to "Edition Statement, Cited" to
+          indicate that element MAY contain more than just the
+          edition number.
+       b) Changed the definition of <edition> to include the full
+          edition statement and not just the edition number.
+       c) Added new element @designator to hold the edition
+          number, since the definition of edition is changing.
+          (through %edition-atts).
+   
+ 10. DATE IN CITATION ATTRIBUTES - Added to the attributes for
+     <date-in-citation> (through @date-in-citation-atts):
+       a) ISO 8601 standard date format attribute (@iso-8601-date) 
+          Format  YYYY-MM-DDThh:mm:ss 
+       b) Name of the calendar used (@calendar), to hold values
+          such as "Gregorian", "Japanese" (Emperor years), or
+          "Islamic".
+   
+  9. STANDARD ORGANIZATION - Added new element for the name of
+     the standards body that created or that promulgates a
+     standard. <std-organization> may be used as part of the
+     description of a cited standard inside a citation.
+     (New PEs: std-organization-atts; std-organization-elements)
+   
+  8. STANDARD MODEL - Updated the model for <std>, the description
+     of a cited standard in side a citation to include several
+     elements:
+         - <source> contains the name of the standard
+         - <pub-id> contains the standard designator
+         - date elements <month>, <day>, and <year> name the 
+              official date
+         - <std-organization> (new element) names the standards 
+             body
+         - <named-content> takes anything else a publisher/archive 
+             wishes to record, such as the standard status, et al.
+      The following elements were retained form the older model
+      and so will also be allowed inside <std:>
+
+         - <styled-content> because archives cannot always know the
+             reason behind a typographic change
+         - the emphasis elements (all face markup)
+         - <sub> and <sup>
+   
+ 7.  Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  6. Updated the DTD-version attribute to "0.4" 
+   
+  5. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+  4. @SPECIFIC-USE and @XML:LANG - Added the @specific-use and
+     @xml:lang to the following elements:
+      - access-date through access-date-atts (only @specific-use)
+      - annotation through annotation-atts (both)
+      - chapter-title through chapter-title-atts (both) NEW PE
+      - comment through comment-atts (both)
+      - date-in-citation through date-in-citation-atts (both)
+      - edition through edition-atts (both)
+      - gov through gov-atts (both)
+      - note through note-atts (both)
+      - part-title through part-title-atts (both) NEW PE
+      - patent through patent-atts (both)
+      - person-group through person-group-atts (both)
+      - pub-id through pub-id-atts (@specific-use only)
+      - ref through ref-atts (both)
+      - ref-list through ref-list-atts (@specific-use only)
+      - series through series-atts (both)
+      - source through source-atts (@specific-use only;
+          @xml:lang already)
+      - std through std-atts (both)
+      - time-stamp through time-stamp-atts (@specific-use only)
+      - trans-source through trans-source-atts (@specific-use only;
+          @xml:lang already)
+
+  3. PERSON GROUP - Changed the model of <person-group> to mixed
+     content. This entailed: creating new PE %person-group-elements;
+     that contained the elements to be used and Changing PE
+     %person-group-model to (#PCDATA %person-group-elements;)*.
+     The PE person-group-model has been retained in this module for
+     compatibility, but has been set to the mixed model using
+     person-group-elements.
+
+  2. ANNOTATION - Changed to content model to use the parameter
+     entity %annotation-model; Content model unchanged.
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR #PCDATA MODELS      -->
+<!-- ============================================================= -->
+
+
+<!--                    SOURCE ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <source> or <trans-source>.              -->
+<!ENTITY % source-elements
+                        "| %address-link.class; |%emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!-- ============================================================= -->
+<!--                    PARAMETER ENTITIES FOR ATTRIBUTE LISTS     -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESS DATE ATTRIBUTES                     -->
+<!--                    Attributes for the <access-date> element   -->
+<!ENTITY % access-date-atts
+            "%jats-common-atts;                                       
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    ANNOTATION ATTRIBUTES                      -->
+<!--                    Attributes for the <annotation> element    -->
+<!ENTITY % annotation-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    CHAPTER TITLE ATTRIBUTES                   -->
+<!--                    Attributes for the <chapter-title> element -->
+<!ENTITY % chapter-title-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    COMMENT ATTRIBUTES                         -->
+<!--                    Attributes for the <comment> element       -->
+<!ENTITY % comment-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DATA TITLE ATTRIBUTES                      -->
+<!--                    Attributes for the <data-title> element    -->
+<!ENTITY % data-title-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    DATE IN CITATION ATTRIBUTES                -->
+<!--                    Attributes for the <date-in-citation>
+                                                         element   -->
+<!ENTITY % date-in-citation-atts
+            "%jats-common-atts;                                       
+             iso-8601-date
+                        CDATA                             #IMPLIED
+             calendar   CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    EDITION ATTRIBUTES                         -->
+<!--                    Attributes for the <edition> element       -->
+<!ENTITY % edition-atts
+            "%jats-common-atts;                                       
+             designator CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    GOVERNMENT ATTRIBUTES                      -->
+<!--                    Attributes for the <gov> element           -->
+<!ENTITY % gov-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    NOTE ATTRIBUTES                            -->
+<!--                    Attributes for the <note> element          -->
+<!ENTITY % note-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PART TITLE ATTRIBUTES                      -->
+<!--                    Attributes for the <part-title> element    -->
+<!ENTITY % part-title-atts
+            "%jats-common-atts;                                       
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PATENT ATTRIBUTES                          -->
+<!--                    Attributes for the <patent> element        -->
+<!ENTITY % patent-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             country    CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PERSON GROUP ATTRIBUTES                    -->
+<!--                    Attributes for the <person-group> element  -->
+<!ENTITY % person-group-atts
+            "%jats-common-atts;                                       
+             person-group-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    PUBLICATION IDENTIFIER ATTRIBUTES          -->
+<!--                    Attributes for the <pub-id> element        -->
+<!ENTITY % pub-id-atts
+            "%jats-common-atts;                                       
+             pub-id-type
+                        (%pub-id-types;)                  #IMPLIED
+             assigning-authority                
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!--                    REFERENCE ATTRIBUTES                       -->
+<!--                    Attributes for the <ref> element           -->
+<!ENTITY % ref-atts
+            "%jats-common-atts;                                       
+              content-type
+                        CDATA                             #IMPLIED
+              specific-use
+                        CDATA                             #IMPLIED
+              xml:lang  NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    REFERENCE LIST ATTRIBUTES                  -->
+<!--                    Attributes for the <ref-list> element      -->
+<!ENTITY % ref-list-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SERIES ATTRIBUTES                          -->
+<!--                    Attributes for the <series> element        -->
+<!ENTITY % series-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    SOURCE ATTRIBUTES                          -->
+<!--                    Attributes for the <source> element        -->
+<!ENTITY % source-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STANDARDS ATTRIBUTES                       -->
+<!--                    Attributes for the <std> element           -->
+<!ENTITY % std-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    STANDARDS ORGANIZATION ATTRIBUTES          -->
+<!--                    Attributes for the <std-organization> 
+                        element                                    -->
+<!ENTITY % std-organization-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    TIME STAMP ATTRIBUTES                      -->
+<!--                    Attributes for the <time-stamp> element    -->
+<!ENTITY % time-stamp-atts
+            "%jats-common-atts;                                       
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED"  >
+
+
+<!--                    TRANSLATED SOURCE ATTRIBUTES               -->
+<!--                    Attributes for the <trans-source> element  -->
+<!ENTITY % trans-source-atts
+            "%jats-common-atts;                                       
+             content-type
+                       CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!--                    VERSION ATTRIBUTES                         -->
+<!--                    Attributes for the <version> element       -->
+<!ENTITY % version-atts
+            "%jats-common-atts;                                       
+             designator CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED"  >
+
+
+<!-- ============================================================= -->
+<!--                    BIBLIOGRAPHIC REFERENCE LIST ELEMENTS      -->
+<!-- ============================================================= -->
+
+
+<!--ELEM   article-title
+                        Defined in %common.ent;                    -->
+<!--ELEM   collab       Defined in %common.ent;                    -->
+<!--ELEM   conf-date    Defined in %common.ent;                    -->
+<!--ELEM   conf-loc     Defined in %common.ent;                    -->
+<!--ELEM   conf-name    Defined in %common.ent;                    -->
+<!--ELEM   day          Defined in %common.ent;                    -->
+<!--ELEM   elocation-id Defined in %common.ent;                    -->
+<!--ELEM   email        Defined in %common.ent;                    -->
+<!--ELEM   fpage        Defined in %common.ent;                    -->
+<!--ELEM   issn         Defined in %common.ent;                    -->
+<!--ELEM   issn-l       Defined in %common.ent;                    -->
+<!--ELEM   issue        Defined in %common.ent;                    -->
+<!--ELEM   lpage        Defined in %common.ent;                    -->
+<!--ELEM   month        Defined in %common.ent;                    -->
+<!--ELEM   publisher-loc
+                        Defined in %common.ent;                    -->
+<!--ELEM   publisher-name
+                        Defined in %common.ent;                    -->
+<!--ELEM   season       Defined in %common.ent;                    -->
+<!--ELEM   title        Defined in %common.ent;                    -->
+<!--ELEM   trans-title  Defined in %common.ent;                    -->
+<!--ELEM   volume       Defined in %common.ent;                    -->
+<!--ELEM   year         Defined in %common.ent;                    -->
+
+
+<!--                    REFERENCE LIST MODEL                       -->
+<!--                    Content model for the <ref-list> element   -->
+<!ENTITY % ref-list-model
+                        "(label?, title?, (%para-level;)*, ref*,
+                         (%ref-list.class;)* )"                      >
+
+
+<!--                    REFERENCE LIST (BIBLIOGRAPHIC REFERENCE LIST)
+                                                                   -->
+<!--                    List of references (citations) for the
+                        article.  Often called "References",
+                        "Bibliography", or "Additional Reading". No
+                        distinction is made between lists of cited
+                        references and lists of suggested references.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ref-list
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ref-list
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ref-list
+                                                                   -->
+<!ELEMENT  ref-list     %ref-list-model;                             >
+<!ATTLIST  ref-list
+             %ref-list-atts;                                         >
+
+
+<!--                    REFERENCE ITEM MODEL                       -->
+<!--                    Content model for the <ref> element        -->
+<!ENTITY % ref-model    "(label?,
+                         (%citation.class; | %note.class;)+ )"       >
+
+
+<!--                    REFERENCE ITEM                             -->
+<!--                    One item in a bibliographic list, typically
+                        a citation describing a referenced work, but
+                        some journals may place notes in this list as
+                        well as citations.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=ref
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=ref
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=ref
+                                                                   -->
+<!ELEMENT  ref          %ref-model;                                  >
+<!ATTLIST  ref
+             %ref-atts;                                              >
+
+
+<!--ELEM   element-citation
+                        Defined in %common.ent;                    -->
+<!--ELEM   mixed-citation
+                        Defined in %common.ent;                    -->
+
+
+<!--                    NOTE IN A REFERENCE LIST MODEL             -->
+<!--                    Content model for a note in a reference
+                        list element                               -->
+<!ENTITY % note-model   "(label?,
+                          (%just-para.class; | %product.class;)+ )"  >
+
+
+<!--                    NOTE IN A REFERENCE LIST                   -->
+<!--                    Used to tag non-citation material that
+                        sometimes within a reference list, for
+                        example, used to tag end note material when
+                        such a note is placed within a reference
+                        list.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=note
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=note
+                                                                   -->
+<!ELEMENT  note         %note-model;                                 >
+<!ATTLIST  note
+             %note-atts;                                             >
+
+
+<!-- ============================================================= -->
+<!--                    BIBLIOGRAPHIC REFERENCE CLASS              -->
+<!-- ============================================================= -->
+
+
+<!--                    ACCESS DATE ELEMENTS                       -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Access Date <access-date> element      -->
+<!ENTITY % access-date-elements
+                        ""                                           >
+
+
+<!--                    ACCESS DATE FOR CITED WORK                 -->
+<!--                    The date on which the work which is cited
+                        was examined. Some online resources are
+                        changing so quickly that a citation to the
+                        resource is not complete without the date
+                        on which the cited resource was examined,
+                        since a day before or a day later the
+                        relevant material might be different.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=access-date
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=access-date
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=access-date
+                                                                   -->
+<!ELEMENT  access-date  (#PCDATA %access-date-elements;)*            >
+<!ATTLIST  access-date
+             %access-date-atts;                                      >
+
+
+<!--                    ANNOTATION MODEL                           -->
+<!--                    The content model for the <annotation>
+                        element                                    -->
+<!ENTITY % annotation-model
+                        "((%just-para.class;)+)"                     >
+
+
+<!--                    ANNOTATION IN A CITATION                   -->
+<!--                    Most citations just provide the bibliographic
+                        information for a cited reference but a few
+                        describe or comment upon the nature or
+                        quality of the reference or summarize its
+                        findings.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=annotation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=annotation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=annotation
+                                                                   -->
+<!ELEMENT  annotation   %annotation-model;                           >
+<!ATTLIST  annotation
+             %annotation-atts;                                       >
+
+
+<!--                    CHAPTER TITLE ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <chapter-title> element                -->
+<!ENTITY % chapter-title-elements
+                        "%source-elements;"                          >
+
+
+<!--                    CHAPTER TITLE IN A CITATION                -->
+<!--                    Within a citation (such as a <mixed-citation>
+                        or an <element-citation>), the title of a
+                        cited book is tagged as <source> and the
+                        title of a chapter within that book is tagged
+                        as <chapter-title>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=chapter-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=chapter-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=chapter-title
+                                                                   -->
+<!ELEMENT  chapter-title
+                        (#PCDATA %chapter-title-elements;)*          >
+<!ATTLIST  chapter-title
+             %chapter-title-atts;                                    >
+
+
+<!--                    COMMENT ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Comment in a Citation <comment> element.
+                        Design Note: All inline mixes begin with an
+                        OR bar, but since %simple-phrase; is an
+                        inline mix, the OR bar is already there.   -->
+<!ENTITY % comment-elements
+                        "%simple-phrase;"                            >
+
+
+<!--                    COMMENT IN A CITATION                      -->
+<!--                    Used to mark unstructured text within an
+                        otherwise element structured reference.
+                        In an unstructured reference, this text would
+                        merely be data characters.
+                        Typical comments could include:
+                          <comment>[Abstract]</comment>
+                          <comment> translated from Russian</comment>
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=comment
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=comment
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=comment
+                                                                   -->
+<!ELEMENT  comment      (#PCDATA %comment-elements;)*                >
+<!ATTLIST  comment
+             %comment-atts;                                          >
+
+
+<!--                    DATA TITLE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <data-title>.                            -->
+<!ENTITY % data-title-elements
+                        "| %address-link.class; |%emphasis.class; |
+                         %phrase-content.class; | %subsup.class;"    >
+
+
+<!--                    DATA TITLE IN A CITATION                   -->
+<!--                    Within a citation (such as a <mixed-citation>
+                        or an <element-citation>), the title of a
+                        cited data source such as a dataset or
+                        spreadsheet. 
+                        REMARKS: Since datasets can contain very
+                        complex relationships, for citing data, this 
+                        element may describe different levels, taking
+                        the place of both <article-title> and <source>
+                        when citing data.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=data-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=data-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=data-title
+                                                                   -->
+<!ELEMENT  data-title
+                        (#PCDATA %data-title-elements;)*             >
+<!ATTLIST  data-title
+             %data-title-atts;                                       >
+
+<!--                    DATE IN CITATION ELEMENTS                  -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the Date Inside Citation <date-in-citation>
+                        element                                    -->
+<!ENTITY % date-in-citation-elements
+                        "| %date-parts.class;"                       >
+
+
+<!--                    DATE INSIDE CITATION                       -->
+<!--                    A container element for any date that may be
+                        referenced in a citation, other than the
+                        publication date of the cited work.
+                        The "content-type" attribute should be used
+                        to identify the purpose/type of date. For
+                        example, if the element contains the date
+                        on which the article contributor examined the
+                        cited work, the attribute might be
+                        "access-date".
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=date-in-citation
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=date-in-citation
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=date-in-citation
+                                                                   -->
+<!ELEMENT  date-in-citation
+                        (#PCDATA %date-in-citation-elements;)*       >
+<!ATTLIST  date-in-citation
+             %date-in-citation-atts;                                 >
+
+
+<!--                    EDITION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <edition>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % edition-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    EDITION STATEMENT, CITED                   -->
+<!--                    The full edition statement for a cited or
+                        referenced publication. This may include
+                        textual words ("Third print edition revised"),
+                        ordinals ("3rd"), superscripted ordinals
+                        ("3<sup>rd</sup>), or simply the edition number
+                        ("3"). 
+                        Remarks: The @designator attribute may be used
+                        to record the alphabetic or numerical 
+                        edition number.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=edition
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=edition
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=edition
+                                                                   -->
+<!ELEMENT  edition      (#PCDATA %edition-elements;)*                >
+<!ATTLIST  edition
+             %edition-atts;                                          >
+
+
+<!--                    GOVERNMENT REPORT ELEMENTS                 -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <gov>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % gov-elements "%rendition-plus;"                           >
+
+
+<!--                    GOVERNMENT REPORT, CITED                   -->
+<!--                    The identification information (typically the
+                        title and/or an identification number) for
+                        a cited governmental report or other
+                        government publication
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=gov
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=gov
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=gov
+                                                                   -->
+<!ELEMENT  gov          (#PCDATA %gov-elements;)*                    >
+<!ATTLIST  gov
+             %gov-atts;                                              >
+
+
+<!--                    PART TITLE ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        the <part-title> element                   -->
+<!ENTITY % part-title-elements
+                        "%source-elements;"                          >
+
+
+<!--                    PART TITLE IN A CITATION                   -->
+<!--                    Within a citation (such as a
+                        <mixed-citation> or an <element-citation>),
+                        when books are divided into Parts (which
+                        may then contain smaller units such as
+                        chapters), this element can be used to
+                        record the title of the cited Part.
+                        The book is tagged as <source>.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=part-title
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=part-title
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=part-title
+                                                                   -->
+<!ELEMENT  part-title   (#PCDATA %part-title-elements;)*             >
+<!ATTLIST  part-title
+             %part-title-atts;                                       >
+
+
+<!--                    PATENT NUMBER ELEMENTS                     -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <patent>
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % patent-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    PATENT NUMBER, CITED                       -->
+<!--                    The identification information (typically the
+                        patent number or number and name) for a
+                        cited patent
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=patent
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=patent
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=patent
+                                                                   -->
+<!ELEMENT  patent       (#PCDATA %patent-elements;)*                 >
+<!ATTLIST  patent
+             %patent-atts;                                           >
+
+
+<!--                    PERSON GROUP ELEMENTS                      -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <person-group>                             -->
+<!ENTITY % person-group-elements
+                        "| %name.class; |
+                          %person-group-info.class;"                 >
+
+
+<!--                    PERSON GROUP MODEL                         -->
+<!--                    Content model for the Person Group element -->
+<!ENTITY % person-group-model
+                        "(#PCDATA %person-group-elements;)*"         >
+
+
+<!--                    PERSON GROUP FOR A CITED PUBLICATION       -->
+<!--                    Wrapper element for one or more authors,
+                        editors, translators, etc. named in a cited
+                        reference.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=person-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=person-group
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=person-group
+                                                                   -->
+<!ELEMENT  person-group %person-group-model;                         >
+<!ATTLIST  person-group
+             %person-group-atts;                                     >
+
+
+<!--                    PUBLICATION IDENTIFIER FOR A CITED PUBLICATION
+                                                                   -->
+<!--                    The identifier of a publication such as a
+                        related journal article that is listed
+                        within a citation (such as a <mixed-citation>
+                        or an <element-citation>) inside the
+                        bibliographic reference list <ref-list> of
+                        an article.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=pub-id
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=pub-id
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=pub-id
+                                                                   -->
+<!ELEMENT  pub-id       (#PCDATA)                                    >
+<!ATTLIST  pub-id
+             %pub-id-atts;                                           >
+
+
+<!--                    SERIES ELEMENTS                            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <series>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % series-elements
+                        "%rendition-plus;"                           >
+
+
+<!--                    SERIES                                     -->
+<!--                    Container element for any series information
+                        used in a citation (such as a <mixed-citation>
+                        or an <element-citation>). For example,
+                        within a citation to a non-journal item that
+                        spans multiple volumes, this element could
+                        contain the unique title of the entire series:
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=series
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=series
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=series
+                                                                   -->
+<!ELEMENT  series       (#PCDATA %series-elements;)*                 >
+<!ATTLIST  series
+             %series-atts;                                           >
+
+
+<!--                    STANDARD ELEMENTS                          -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std>
+                        Design Note: -%rendition-plus; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % std-elements "| %emphasis.class; | %phrase-content.class; |
+                         %std.class; | %subsup.class;"               >
+
+
+<!--                    STANDARD, CITED                            -->
+<!--                    The identification information (typically the
+                        standard number, organization, and name) for
+                        a cited standard, where "standard" is defined
+                        as a document produced by a recognized
+                        standards body such ISO, IEEE, OASIS, ANSI,
+                        etc.
+                        The elements that can be used in the mixed
+                        content model of a <std> include:
+                          <source> contains the name of the standard
+                          <pub-id> contains the standard designator
+                          date elements name the official date
+                          <std-organization> names the standards body
+                          <named-content> takes anything else a 
+                            publisher/archive needs.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=std
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=std
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=std
+                                                                   -->
+<!ELEMENT  std          (#PCDATA %std-elements;)*                    >
+<!ATTLIST  std
+             %std-atts;                                              >
+
+
+<!--                    STANDARDS ORGANIZATION ELEMENTS            -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <std-organization>.                        -->
+<!ENTITY % std-organization-elements 
+                        "| %emphasis.class; | 
+                         %institution-wrap.class; | %subsup.class;"  >
+
+
+<!--                    STANDARDS ORGANIZATION                     -->
+<!--                    The name of the standards body that created 
+                        or that promulgates a standard, such as
+                        NISO, ISO, ANSI, or industry standards
+                        organizations.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=std-organization
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=std-organization
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=std-organization
+                                                                   -->
+<!ELEMENT  std-organization
+                        (#PCDATA %std-organization-elements;)*       >
+<!ATTLIST  std-organization
+             %std-organization-atts;                                 >
+
+
+<!--                    SOURCE                                     -->
+<!--                    Within a citation, this is the title of a
+                        journal, book, conference proceedings, etc.
+                        that is the source of the cited material.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=source
+                                                                   -->
+<!ELEMENT  source       (#PCDATA %source-elements;)*                 >
+<!ATTLIST  source
+             %source-atts;                                           >
+
+
+<!--                    TIME STAMP ELEMENTS                        -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        a <time-stamp>.                            -->
+<!ENTITY % time-stamp-elements
+                        ""                                           >
+
+
+<!--                    TIME STAMP FOR CITED WORK                  -->
+<!--                    Used to record any time stamp that was
+                        found on the cited resource when it was
+                        examined, for resources such as databases
+                        that may use a time signature to identify
+                        different versions.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=time-stamp
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=time-stamp
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=time-stamp
+                                                                   -->
+<!ELEMENT  time-stamp   (#PCDATA %time-stamp-elements;)*             >
+<!ATTLIST  time-stamp
+             %time-stamp-atts;                                       >
+
+
+<!--                    TRANSLATED SOURCE                          -->
+<!--                    Within a citation, this is the title of a
+                        journal, book, conference proceedings, etc.
+                        that is the source of the cited material,
+                        but with the source name given in a different
+                        language from the source as given in the
+                        <source> element. For example, if an article
+                        is originally in French, the <source> name
+                        would be the French name and the
+                        <trans-source> might be in English.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=trans-source
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=trans-source
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=trans-source
+                                                                   -->
+<!ELEMENT  trans-source (#PCDATA %source-elements;)*                 >
+<!ATTLIST  trans-source
+             %trans-source-atts;                                     >
+
+
+<!--                    VERSION ELEMENTS                           -->
+<!--                    The elements that can be included along with
+                        data characters inside the content model of
+                        <version>.
+                        Design Note: -%just-rendition; begins with
+                        an OR bar, so this inline mix begins with
+                        an OR bar.                                 -->
+<!ENTITY % version-elements
+                        "%just-rendition;"                           >
+
+
+<!--                    VERSION STATEMENT, CITED                   -->
+<!--                    The version number for a cited dataset or
+                        software package. This is similar to an
+                        edition statement for a publication, in that it
+                        may include textual words ("9th"), superscripted 
+                        ordinals ("3<sup>rd</sup>), or simply the 
+                        version number ("16.2"). 
+                        Remarks: The @designator attribute may be used
+                        to record the alphabetic or numerical 
+                        version number, when the version number contains
+                        more than just a number, so the numeric version
+                        can be preserved for search and comparison.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=version
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=version
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=version
+                                                                   -->
+<!ELEMENT  version      (#PCDATA %version-elements;)*                >
+<!ATTLIST  version
+             %version-atts;                                          >
+
+
+<!-- ================== End Bibliographic Class Module =========== -->

--- a/publishing/1.1/JATS-related-object1.ent
+++ b/publishing/1.1/JATS-related-object1.ent
@@ -1,0 +1,283 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Related Object Element                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.1 20150301//EN"
+     Delivered as file "JATS-related-object1.ent"                  -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Define the element <related-object>. [This        -->
+<!--             module was previously part of the NLM Book Tag Set-->
+<!--             and named bookrelated-object.ent.]                -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             February 2008 (book modules Oct 2006)             -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             The Journal Publishing DTD is built from the      -->
+<!--             Archiving and Interchange DTD Suite.              -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION\CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+ 10. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  9. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  8. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+   
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  7. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+  
+  6. RELATED-OBJECT ATTRIBUTES - Added the attribute @ext-link-type
+   
+  5. RELATED-OBJECT ATTRIBUTES - Added the linking attribute to
+     <related-object> through the "might-link-atts".
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    RELATED OBJECT ATTRIBUTES                  -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED OBJECT ATTRIBUTES                  -->
+<!--                    Attributes for <related-object>            -->
+<!ENTITY % related-object-atts
+            "%jats-common-atts;                                       
+             link-type  CDATA                             #IMPLIED
+             ext-link-type
+                        CDATA                             #IMPLIED
+             source-id  CDATA                             #IMPLIED
+             source-id-type
+                        CDATA                             #IMPLIED
+             source-type
+                        CDATA                             #IMPLIED
+             document-id
+                        CDATA                             #IMPLIED
+             document-id-type
+                        CDATA                             #IMPLIED
+             document-type
+                        CDATA                             #IMPLIED
+             object-id  CDATA                             #IMPLIED
+             object-id-type
+                        CDATA                             #IMPLIED
+             object-type
+                        CDATA                             #IMPLIED
+             content-type
+                        CDATA                             #IMPLIED
+             specific-use
+                        CDATA                             #IMPLIED
+             xml:lang   NMTOKEN                           #IMPLIED
+             %might-link-atts;"                                      >
+
+
+<!-- ============================================================= -->
+<!--                    RELATED OBJECT ELEMENT                     -->
+<!-- ============================================================= -->
+
+
+<!--                    RELATED OBJECT ELEMENTS                    -->
+<!--                    Elements allowed inside <related-object>   -->
+<!ENTITY % related-object-elements
+                        "| %emphasis.class; |
+                         %phrase-content.class; |
+                         %references.class; |  %subsup.class;"       >
+
+
+<!--                    RELATED OBJECT INFORMATION                 -->
+<!--                    Wrapper element, used as a container for
+                        text links to a related object, possibly
+                        accompanied by a very brief description of
+                        the object, for example a related book, a
+                        related chapter or figure in a book, a
+                        related dataset, etc.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=related-object
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=related-object
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=related-object
+                                                                   -->
+<!ELEMENT  related-object
+                        (#PCDATA %related-object-elements;)*         >
+<!ATTLIST  related-object
+             %related-object-atts;                                   >
+
+
+<!-- ================== End Related Object Element Module ======== -->

--- a/publishing/1.1/JATS-section1.ent
+++ b/publishing/1.1/JATS-section1.ent
@@ -1,0 +1,324 @@
+<!-- ============================================================= -->
+<!--  MODULE:    Section Class Elements                            -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.1 20151215//EN"
+     Delivered as file "JATS-section1.ent"                         -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->         
+<!--                                                               -->
+<!-- PURPOSE:    Defines the member of the sec.class, that is,     -->
+<!--             names all section-level elements in the           -->
+<!--             JATS DTD Suite                                    -->
+<!--                                                               -->
+<!--             At the time of the initial DTD creation           -->
+<!--             there is only one such element, Section itself    -->
+<!--             <sec>, but future expansion to named sections     -->
+<!--             (such as <methodology> or <materials> or any      -->
+<!--             new section-level structures would be added here. -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. JATS became version "1.1d3" and "v1.1 20150301//EN"
+ 
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  6. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.1d1           (DAL/BTU) v1.1 (2013-11-15)
+   
+     ANSI/NISO Z39.96-2012 (pre-release for V1.0 BITS; Version 1.1d1) 
+
+     NISO JATS Standing Committee met and answered the requests and
+     suggestions from the NISO request forms.
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+
+  5. GLOBAL ATTRIBUTES - Added the new parameter entity 
+         %jats-common-atts;
+     to every element in this module. This PE adds (for now) the
+     @id attribute and the @xml:base attribute to every element,
+     whether metadata or narrative.
+     Since the @id in this parameter entity is optional, a second
+     parameter entity jats-common-atts-id-required was also added.
+     The two are kept in sync with the jats-base-atts parameter 
+     entity.
+     This added an attribute list to:
+      - floats-group
+      - sec-meta
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    DEFAULTS FOR ATTRIBUTE LISTS               -->
+<!-- ============================================================= -->
+
+
+<!--                    FLOATS GROUP ATTRIBUTES                    -->
+<!--                    Attributes for the <floats-group> element  -->
+<!ENTITY % floats-group-atts
+            "%jats-common-atts;"                                     >
+
+
+<!--                    SECTION ATTRIBUTES                         -->
+<!--                    Attribute list for Section element         -->
+<!ENTITY % sec-atts
+            "%jats-common-atts;                                       
+             xml:lang   NMTOKEN                            #IMPLIED
+             sec-type   CDATA                              #IMPLIED
+             disp-level CDATA                              #IMPLIED
+             specific-use
+                        CDATA                              #IMPLIED" >
+
+
+<!--                    SECTION METADATA ATTRIBUTES                -->
+<!--                    Attributes for the <sec-meta> element      -->
+<!ENTITY % sec-meta-atts
+            "%jats-common-atts;"                                     >
+
+
+<!-- ============================================================= -->
+<!--                    FLOATS GROUP ELEMENTS                      -->
+<!-- ============================================================= -->
+
+
+<!--                    FLOATS GROUP MODEL                         -->
+<!--                    Model for the container element
+                        <floats-group>, which can be used to hold all
+                        the floating elements such as tables and
+                        figures within an <article>.               -->
+<!ENTITY % floats-group-model
+                        "(%floats-display.class;)*"                  >
+
+
+<!--                    FLOATS GROUP                               -->
+<!--                    This container element is just a group to
+                        hold the floating objects that occur within
+                        an article. Some publishers like to
+                        collect all these floating objects (figures,
+                        tables, text boxes, graphics, etc.) together
+                        at the end  rather than interspersing them
+                        throughout the various parts of the document
+                        where they are referenced.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=floats-group
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=floats-group
+                                                                   -->
+<!ELEMENT  floats-group %floats-group-model;                         >
+<!ATTLIST  floats-group
+             %floats-group-atts;                                     >
+
+
+<!-- ============================================================= -->
+<!--                    SECTION ELEMENTS                           -->
+<!-- ============================================================= -->
+
+
+<!--                    SECTION                                    -->
+<!--                    A headed group of material; the basic
+                        structural unit of the article
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sec
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sec
+                        http://jats.nlm.nih.gov/articleauthoring/tag-library/1.1/index.html?elem=sec
+                                                                   -->
+<!ELEMENT  sec          %sec-model;                                  >
+<!ATTLIST  sec
+             %sec-atts;                                              >
+
+
+<!--                    SECTION METADATA                           -->
+<!--                    In some articles, each section has a different
+                        author or some sections are authored by
+                        different contributors from the enclosing
+                        article. This container element for
+                        section-level metadata is used to capture
+                        information such as those contributors.
+                        Details at:
+                        http://jats.nlm.nih.gov/archiving/tag-library/1.1/index.html?elem=sec-meta
+                        http://jats.nlm.nih.gov/publishing/tag-library/1.1/index.html?elem=sec-meta
+                                                                   -->
+<!ELEMENT  sec-meta     %sec-meta-model;                             >
+<!ATTLIST  sec-meta
+             %sec-meta-atts;                                         >
+
+
+<!-- ================== End Section Class Module ================= -->

--- a/publishing/1.1/JATS-xmlspecchars1.ent
+++ b/publishing/1.1/JATS-xmlspecchars1.ent
@@ -1,0 +1,389 @@
+<!-- ============================================================= -->
+<!--  MODULE:    XML Special Characters Module                     -->
+<!--  VERSION:   ANSI/NISO JATS Version 1.1 (Z39.96-2015)          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.1 20151215//EN"
+     Delivered as file "JATS-xmlspecchars1.ent"                    -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    External Parameter Entities for calling in the    -->
+<!--             special character entities                        -->
+<!--                                                               -->
+<!-- MODULES REQUIRED:                                             -->
+<!--             The standard ISO special character entity sets    -->
+<!--             (see below)                                       -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for these purposes. -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             December 2002                                     -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera Inc. on the NLM  -->
+<!--             Journal Archiving and Interchange DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  7. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  6. JATS became version "1.1d3" and "v1.1 20150301//EN"
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  5. OASIS TABLE NAMESPACE MODIFICATIONS - Added a new module
+     that sets up the namespace URI and namespace prefix for
+     the OASIS tables models.
+   
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://dtd.nlm.nih.gov/3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================= -->
+<!--                    ENTITY SETS FROM INFORMATIVE ANNEX TO      -->
+<!--                       ISO 8879:1986 (SGML)                    -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD ADDED LATIN 1                 -->
+<!ENTITY % ISOlat1 PUBLIC
+"-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+"iso8879/isolat1.ent"                                                >
+
+
+<!--                    ISO STANDARD ADDED LATIN 2                 -->
+<!ENTITY % ISOlat2 PUBLIC
+"-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+"iso8879/isolat2.ent"                                                >
+
+
+<!--                    ISO BOX AND LINE DRAWING                   -->
+<!ENTITY % ISObox       PUBLIC
+"-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+"iso8879/isobox.ent"                                                 >
+
+
+<!--                    ISO STANDARD DIACRITICAL MARKS             -->
+<!ENTITY % ISOdia PUBLIC
+"-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+"iso8879/isodia.ent"                                                 >
+
+
+<!--                    ISO STANDARD NUMERIC AND SPECIAL GRAPHIC   -->
+<!ENTITY % ISOnum PUBLIC
+"-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+"iso8879/isonum.ent"                                                 >
+
+
+<!--                    ISO STANDARD PUBLISHING                    -->
+<!ENTITY % ISOpub PUBLIC
+"-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+"iso8879/isopub.ent"                                                 >
+
+
+<!--                    ISO STANDARD RUSSIAN CYRILLIC              -->
+<!ENTITY % ISOcyr1 PUBLIC
+"-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+"iso8879/isocyr1.ent"                                                >
+
+
+<!--                    ISO STANDARD NON-RUSSIAN CYRILLIC          -->
+<!ENTITY % ISOcyr2 PUBLIC
+"-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+"iso8879/isocyr2.ent"                                                >
+
+
+<!-- ============================================================= -->
+<!--                    ISO 8879 NOT USED BY MATHML                -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD GREEK LETTERS                 -->
+<!ENTITY % ISOgrk1 PUBLIC
+"-//W3C//ENTITIES Greek Letters//EN"
+"xmlchars/isogrk1.ent"                                               >
+
+
+<!--                    ISO STANDARD MONOTONIKO GREEK              -->
+<!ENTITY % ISOgrk2 PUBLIC
+"-//W3C//ENTITIES Monotoniko Greek//EN"
+"xmlchars/isogrk2.ent"                                               >
+
+
+<!--                    ISO STANDARD ALTERNATIVE GREEK SYMBOLS     -->
+<!ENTITY % ISOgrk4 PUBLIC
+"-//W3C//ENTITIES Alternative Greek Symbols//EN"
+"xmlchars/isogrk4.ent"                                               >
+
+
+<!-- ============================================================= -->
+<!--                    ISO TECHNICAL REPORT 9573-13 ENTITY SETS   -->
+<!-- ============================================================= -->
+
+
+<!--                    ISO STANDARD GENERAL TECHNICAL             -->
+<!ENTITY % ISOtech PUBLIC
+"-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+"iso9573-13/isotech.ent"                                             >
+
+
+<!--                    ISO STANDARD GREEK SYMBOLS                 -->
+<!ENTITY % ISOgrk3 PUBLIC
+"-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+"iso9573-13/isogrk3.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (SCRIPT)       -->
+<!ENTITY % ISOmscr PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+"iso9573-13/isomscr.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (ARROW RELATIONS)                       -->
+<!ENTITY % ISOamsa PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+"iso9573-13/isoamsa.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (BINARY OPERATORS)                      -->
+<!ENTITY % ISOamsb PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+"iso9573-13/isoamsb.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (DELIMITERS)                            -->
+<!ENTITY % ISOamsc PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+"iso9573-13/isoamsc.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (NEGATED RELATIONS)                     -->
+<!ENTITY % ISOamsn PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+"iso9573-13/isoamsn.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS (ORDINARY) -->
+<!ENTITY % ISOamso PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+"iso9573-13/isoamso.ent"                                             >
+
+
+<!--                    ISO STANDARD ADDED MATH SYMBOLS
+                           (RELATIONS)                             -->
+<!ENTITY % ISOamsr PUBLIC
+"-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+"iso9573-13/isoamsr.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (FRAKTUR)      -->
+<!ENTITY % ISOmfrk PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+"iso9573-13/isomfrk.ent"                                             >
+
+
+<!--                    ISO STANDARD MATH ALPHABETS (OPEN FACE)    -->
+<!ENTITY % ISOmopf PUBLIC
+"-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+"iso9573-13/isomopf.ent"                                             >
+
+
+<!-- ============================================================= -->
+<!--                    ISO SPECIAL CHARACTER SETS INVOKED         -->
+<!-- ============================================================= -->
+
+
+%ISOlat1;
+%ISOlat2;
+%ISObox;
+%ISOdia;
+%ISOnum;
+%ISOpub;
+%ISOcyr1;
+%ISOcyr2;
+
+%ISOgrk1;
+%ISOgrk2;
+%ISOgrk4;
+
+%ISOtech;
+%ISOgrk3;
+%ISOamsa;
+%ISOamsb;
+%ISOamsc;
+%ISOamsn;
+%ISOamso;
+%ISOamsr;
+%ISOmscr;
+%ISOmfrk;
+%ISOmopf;
+
+
+<!--                    MAINTENANCE NOTE:
+                        Custom special characters are declared
+                        in a separate module %chars.ent;           -->
+
+
+<!-- ============ End of XML Special Characters Module =========== -->

--- a/publishing/1.1/README.txt
+++ b/publishing/1.1/README.txt
@@ -1,0 +1,681 @@
+README FOR THE NISO JATS COMMITTEE DRAFT JOURNAL PUBLISHING DTD
+
+(Publishing (Blue) Version DRAFT NISO JATS 1.1 December 2015)
+(Released post vote making JATS 1.1 an ANSI/NISO standard)
+
+                                     December 2015 v1.1 20151215
+                                               
+======================================================
+
+This README describes:
+
+   1.0 The Four Publishing DTDs
+   2.0 Sample Files for Testing
+   3.0 Modules Needed for each DTD
+       3.1 Modules Used in Publishing XHTML MathML 2.0 DTD
+       3.2 Modules Used in Publishing XHTML MathML 3.0 DTD
+       3.3 Modules Used in Publishing XHTML and OASIS CALS
+             Tables with MathML 2.0 DTD
+       3.4 Modules Used in Publishing XHTML and OASIS CALS
+             Tables with MathML 3.0 DTD
+       3.5 JATS Base Modules (used by all the Publishing DTDs)
+   4.0 Descriptions of All Modules
+       4.1  Modules Specific to the Publishing DTDs
+       4.2  JATS Base Modules: Base Modules
+       4.3  JATS Base Modules: Element Class Modules
+       4.4  JATS Base Modules: Notations and Special Characters
+       4.5  JATS Base Modules: Math Modules 
+       4.6  JATS Base Modules: Table Modules
+    5.0 Catalog Files
+
+
+======================================================
+
+1.0 THE FOUR PUBLISHING DTDS
+
+There are four versions of the Publishing DTD:
+
+ - A version using XHTML tables with MathML 2.0
+
+ - A version using XHTML tables with MathML 3.0
+ 
+ - A version using both XHTML and OASIS CALS table models
+     with MathML 2.0 
+
+ - A version using both XHTML and OASIS CALS table models
+     with MathML 3.0 
+
+All 4 files represent different versions of the ANSI/NISO JATS 
+Journal Publishing DTD. This is the DOCTYPE that covers a 
+journal article and various other non-article journal 
+content such as book and product reviews. These DTDs invoke almost 
+all the modules in the JATS Archiving and Interchange DTD Suite. 
+An institution should choose one of these DTD based on table and 
+MathML requirements. 
+
+======================================================
+
+2.0 SAMPLE FILES FOR TESTING Blue (Publishing)
+
+samplesmall-pub1.xml 
+             - Minimal journal article document 
+               used to test the Publishing DTD (Blue)
+               with XHTML tables and MathML 2.0.
+
+journal.elementa.000011.xml
+journal.elementa.000012.xml
+journal.elementa.000017.xml
+             - Real journal articles shared by their
+               publishers and NLM used to test the 
+               Publishing DTD (Blue)
+               with XHTML tables and MathML 2.0.
+
+samplesmall-pub1-mathml3.xml
+samplesmall-pub1-mathml3-bad.xml
+             - Minimal journal article document 
+               used to test the Publishing DTD (Blue)
+               with XHTML tables and MathML 3.0.
+                  Two sample equations are provided,
+               one of which is valid in MathML 3.0
+               and one of which has a MathML 2.0, sample
+               that is NOT valid in MathML 3.0.
+
+samplepub-oasis-table1.xml
+samplepub-oasis-and-xhtml1.xml
+             - Minimal journal article documents 
+               used to test the Publishing DTD when
+               the OASIS CALS Exchange table model
+               and the XHTML model are both used
+               with MathML 2.0. 
+                  The OASIS table is namespaced with a 
+               hard-coded namespace prefix of "oasis".
+
+samplepub-oasis-and-xhtml1-mathml3.xml and 
+samplepub-oasis-and-xhtml1-mathml3-bad.xml
+             - Minimal journal article document 
+               used to test the Publishing DTD when
+               the OASIS CALS Exchange table model
+               and the XHTML model are both used
+               with MathML 3.0.
+                  The OASIS table is namespaced with a 
+               hard-coded namespace prefix of "oasis".
+                  Two sample equations are provided,
+               one of which is valid in MathML 3.0
+               and one of which has a MathML 2.0, sample
+               that is NOT valid in MathML 3.0.
+ 
+======================================================
+
+3.0 MODULES NEEDED FOR EACH DTD
+ 
+------------------------------------------------------
+
+3.1 Modules Used in the Publishing XHTML MathML 2.0 DTD
+
+ - JATS-journalpublishing1.dtd (XHTML tables with MathML 2.0)
+      - The Publishing DTD using the XHTML table model
+        with MathML 2.0
+
+ - JATS-journalpubcustom-modules1.ent 
+ - JATS-journalpubcustom-classes1.ent
+ - JATS-journalpubcustom-mixes1.ent
+ - JATS-journalpubcustom-models1.ent
+ - JATS-nlmcitation1.ent
+
+ - JATS-XHTMLtablesetup1.ent 
+ - xhtml-table-1.mod    - XHTML DTD module
+ - xhtml-inlstyle-1.mod - XHTML style attribute module
+
+ - JATS-mathmlsetup1.ent
+ - mathml2.dtd
+ - mathml2-qname-1.mod
+   And inside the mathml subdirectory:
+    - mmlalias.ent
+    - mmlextra.ent
+    
+ - and all of the JATS base modules listed in Section 3.5
+
+ 
+------------------------------------------------------
+
+3.2  Modules Used in the Publishing XHTML MathML 3.0 DTD
+
+ - JATS-journalpublishing1-mathml3.dtd (XHTML tables with 
+      MathML 3.0)
+      - The Publishing DTD using the XHTML table model
+        with MathML 3.0
+
+ - JATS-journalpubcustom-modules1.ent 
+ - JATS-journalpubcustom-classes1.ent
+ - JATS-journalpubcustom-mixes1.ent
+ - JATS-journalpubcustom-models1.ent
+ - JATS-nlmcitation1.ent
+
+ - JATS-XHTMLtablesetup1.ent 
+ - xhtml-table-1.mod    - XHTML DTD module
+ - xhtml-inlstyle-1.mod - XHTML style attribute module
+
+ - JATS-mathml3-mathmlsetup1.ent
+ - JATS-mathml3-modules1.ent
+ - mathml3.dtd
+ - mathml3-qname-1.mod
+   And inside the mathml subdirectory:
+    - mmlalias.ent
+    - mmlextra.ent
+    
+ - and all of the JATS base modules listed in Section 3.5
+ 
+ 
+------------------------------------------------------
+
+3.3  Modules Used in the Publishing XHTML and OASIS CALS
+      Tables with MathML 2.0 DTD
+
+ - JATS-journalpublishing-oasis-article1.dtd
+       - An alternative Publishing DTD with one addition: 
+         the OASIS table model is defined in addition to 
+         the XHTML table model. (Both table models are
+         used in this DTD, with the OASIS CALS model given 
+         a hard-coded namespace prefix of "oasis".) This
+         DTD uses MathML 2.0.
+
+ - JATS-journalpub-oasis-custom-modules1.ent
+ - JATS-journalpub-oasis-custom-classes1.ent
+ - JATS-journalpubcustom-mixes1.ent
+ - JATS-journalpubcustom-models1.ent
+ - JATS-nlmcitation1.ent
+
+ - JATS-XHTMLtablesetup1.ent 
+ - xhtml-table-1.mod    - XHTML DTD module
+ - xhtml-inlstyle-1.mod - XHTML style attribute module
+
+ - JATS-oasis-tablesetup1.ent 
+ - JATS-oasis-namespace1.ent 
+ - oasis-exchange.ent   - Basic OASIS CALS table model
+
+ - JATS-mathmlsetup1.ent
+ - mathml2.dtd
+ - mathml2-qname-1.mod
+   And inside the mathml subdirectory:
+    - mmlalias.ent
+    - mmlextra.ent
+    
+ - and all of the JATS base modules listed in Section 3.5
+
+ 
+------------------------------------------------------
+
+3.4  Modules Used in the Publishing XHTML and OASIS CALS
+      Tables with MathML 3.0 DTD
+
+ - JATS-journalpublishing-oasis-article1-mathml3.dtd
+       - An alternative Publishing DTD with one addition: 
+         the OASIS table model is defined in addition to 
+         the XHTML table model. (Both table models are
+         used in this DTD, with the OASIS CALS model given 
+         a hard-coded namespace prefix of "oasis".) This
+         DTD uses MathML 3.0.
+         
+ - JATS-journalpub-oasis-custom-modules1.ent
+ - JATS-journalpub-oasis-custom-classes1.ent
+ - JATS-journalpubcustom-mixes1.ent
+ - JATS-journalpubcustom-models1.ent
+ - JATS-nlmcitation1.ent
+
+ - JATS-XHTMLtablesetup1.ent 
+ - xhtml-table-1.mod    - XHTML DTD module
+ - xhtml-inlstyle-1.mod - XHTML style attribute module
+
+ - JATS-oasis-tablesetup1.ent 
+ - JATS-oasis-namespace1.ent 
+ - oasis-exchange.ent   - Basic OASIS CALS table model
+
+ - JATS-mathml3-mathmlsetup1.ent
+ - JATS-mathml3-modules1.ent
+ - mathml3.dtd
+ - mathml3-qname-1.mod
+   And inside the mathml subdirectory:
+    - mmlalias.ent
+    - mmlextra.ent
+    
+ - and all of the JATS base modules listed in Section 3.5
+
+ 
+------------------------------------------------------
+
+3.5 JATS Base Modules (used by all the Publishing DTDs)
+
+3.5.1 Base Modules
+
+ - JATS-modules1.ent
+ - JATS-common-atts1.ent
+ - JATS-default-classes1.ent
+ - JATS-default-mixes1.ent
+ - JATS-common1.ent
+
+3.5.2 Element Class Modules
+
+ - JATS-articlemeta1.ent
+ - JATS-backmatter1.ent 
+ - JATS-display1.ent   
+ - JATS-format1.ent    
+ - JATS-funding1.ent      
+ - JATS-journalmeta1.ent 
+ - JATS-link1.ent
+ - JATS-list1.ent
+ - JATS-math1.ent
+ - JATS-para1.ent
+ - JATS-phrase1.ent
+ - JATS-references1.ent
+ - JATS-related-object1.ent
+ - JATS-section1.ent 
+
+3.5.3 NISO Access and Indicator Files
+ - JATS-ali-namespace1.ent   
+
+3.5.4 Notations and Special Characters
+
+ - JATS-notat1.ent   
+ - JATS-chars1.ent   
+ - JATS-xmlspecchars1.ent
+
+ - All the MathML special character entity sets:
+
+     (inside the iso8879 subdirectory)
+       isobox.ent
+       isocyr1.ent
+       isocyr2.ent
+       isodia.ent
+       isolat1.ent
+       isolat2.ent
+       isonum.ent
+       isopub.ent
+
+     (inside the iso9573-13 subdirectory)
+       isoamsa.ent
+       isoamsb.ent
+       isoamsc.ent
+       isoamsn.ent
+       isoamso.ent
+       isoamsr.ent
+       isogrk3.ent
+       isomfrk.ent
+       isomopf.ent
+       isomscr.ent
+       isotech.ent
+
+     (inside the xmlchars subdirectory)
+       isogrk1.ent
+       isogrk2.ent
+       isogrk4.ent
+ 
+
+======================================================
+
+4. DESCRIPTIONS of the MODULES
+
+------------------------------------------------------
+4.1 Modules Specific to the Publishing DTDs
+
+JATS-journalpubcustom-modules1.ent 
+             - Customization module for the Publishing XHTML 
+               DTDs. Names all new modules created specifically
+               for the Publishing DTDs (therefore not part of 
+               the base JATS DTD Suite).
+               
+               This module must be called as the first 
+               module in the DTD, just before the Suite 
+               Module of Modules %modules.ent;, which it
+               supplements.
+
+JATS-journalpub-oasis-custom-modules1.ent
+             - Alternate customization module for the
+               DTDS that include OASIS CALS. Names all new 
+               modules created specifically for the Publishing 
+               OASIS-included DTDs (therefore not part of 
+               the base JATS DTD Suite). This module names
+               all the specific modules needed to invoke
+               both the Publishing customizations and the
+               OASIS CALS table modules.
+               
+               This module must be called as the first 
+               module in the DTD, just before the Suite 
+               Module of Modules %modules.ent;, which it
+               supplements.
+
+JATS-journalpubcustom-classes1.ent
+             - Class customizations for the Publishing XHTML 
+               DTDs. Provides the DTD-specific class definitions 
+               for the Publishing DTDs. Used to over-ride the 
+               Suite default classes.
+               
+               Declared in %journalpubcustom-modules.ent;. 
+               It must be invoked before the default classes
+               module.
+
+JATS-journalpub-oasis-custom-classes1.ent
+             - Class customizations for the Publishing XHTML 
+               and OASIS CALS DTDs. This custom classes module
+               replaces the regular journal Publishing custom
+               classes. This modules adds the parameter entities 
+               needed by the OASIS table model to enable OASIS 
+               Exchange CALS table processing.
+               
+               Declared in %journalpub-oasis-custom-modules.ent;. 
+               It must be invoked before the default classes
+               module.
+
+JATS-journalpubcustom-mixes1.ent
+             - The Publishing-DTD-specific mix definitions for  
+               these DTDs. Used to over-ride the Suite
+               default mixes.
+               
+               Declared in %journalpubcustom-modules.ent; 
+               and %journalpub-oasis-custom-modules.ent; 
+               for their respective DTDs.
+               Must be invoked before the default mixes
+               module.
+
+JATS-journalpubcustom-models1.ent
+             - The Publishing-DTD-specific content model 
+               definitions for this DTD. Used to over-ride 
+               the Suite default models.
+               
+               Declared in %journalpubcustom-modules.ent; 
+               and %journalpub-oasis-custom-modules.ent; 
+               for their respective DTDs.
+               Must be invoked before all of the DTD Suite
+               modules since it is used to over-ride them.
+            
+               There are two types of such over-rides. Those 
+               that replace a complete content model are
+               named with a suffix "-model". Those that are 
+               OR-groups of elements (intended to be mixed 
+               with #PCDATA inside a particular model) are 
+               named with an "-elements" suffix.
+
+JATS-nlmcitation1.ent (deprecated)
+             - Defines the highly structured NLM citation model,
+               which was used (historically) to enforce a 
+               slightly loose version of an NLM-structured 
+               bibliographic reference. Sequence is enforced 
+               and interior punctuation is expected to be 
+               generated.
+               
+               This element is now deprecated and should not be
+               used; substitute <element-citation>.
+
+
+------------------------------------------------------
+4.2 JATS Base Modules: Critical Base Modules
+    (Used by all of the DTDs)
+
+JATS-modules1.ent
+               Names the modules in the NISO JATS 
+               DTD Suite.
+                                      
+               Called as the second or third module by any
+               DTD:  after the DTD-specific module of
+               of modules (if any), after the MathML 3.0
+               modules (if any), and before all other modules.
+                 
+               NOTE: May name modules (such as the 
+               OASIS-Exchange module) that are not called 
+               by a particular DTD.
+
+JATS-ali-namespace1.ent  
+               Namespace setup for the NISO Access and
+               Indicators elements (prefix ali:). The
+               elements are defined in the JATS Common 
+               module (described below).
+               [Note: Unlike typical web practice, this
+               URI ends in a slash.]
+
+JATS-common-atts1.ent
+               Defines attributes intended to be used on 
+               ALL elements defined in the NISO JATS, 
+               including table elements for both the 
+               XHTML-inspired and OASIS-inspired table 
+               models, with the exception of <mml:math> 
+               whose namespaces JATS does not control. 
+                                       
+               Must be called after all module-of-modules
+               modules and any namespacing modules, but 
+               before all customization (over-ride) modules.
+
+JATS-default-classes1.ent
+               The class definitions that are common to the
+               NISO JATS DTD Suite. These may be overridden
+               by DTD-specific class declarations.
+
+               Must be invoked before any element-defining
+               modules such as common or the element
+               modules.
+
+JATS-default-mixes1.ent
+               The mix definitions that are common to the
+               NISO JATS DTD Suite. These may be overridden
+               by DTD-specific mix declarations.
+
+               Must be invoked before any element-defining
+               modules such as common or the element
+               modules.
+
+JATS-common1.ent 
+               Defines all elements, attributes, entities
+               used by more than one module.
+                   
+               Called after all module-of-modules modules,
+               namespace modules, and all customization 
+               (over-ride) modules but before all the element
+               class modules. 
+
+JATS-ali-namespace1.ent  
+               Namespace setup for the NISO Access and
+               Indicators elements (prefix ali:). The
+               elements are defined in the JATS Common 
+               module (described just above).
+
+These modules need to be invoked before all other modules 
+in a DTD. Other modules can usually be invoked in any order.
+They are listed below alphabetically.
+
+
+------------------------------------------------------
+4.3 JATS Base Modules: Element Class Modules 
+    (Define the elements and attributes for one class)
+    (Used by all of the DTDs)
+
+JATS-articlemeta1.ent  - Article-level metadata elements 
+JATS-backmatter1.ent   - Article-level back matter elements
+JATS-display1.ent      - Display elements such as Table, Figure, Graphic
+JATS-format1.ent       - Format-related elements such as Bold
+JATS-funding1.ent      - Award, sponsor, and other funding-related metadata
+JATS-journalmeta1.ent  - Journal-level metadata elements
+JATS-link1.ent         - Linking elements such as X(Cross)-Reference
+JATS-list1.ent         - List elements
+JATS-math1.ent         - JATS-defined math elements such as Display Equation
+JATS-para1.ent         - Paragraph-level elements such as Paragraph,
+                         Statement, and Block Quote
+JATS-phrase1.ent       - Phrase-level content-related elements
+JATS-references1.ent   - Bibliographic reference list and the elements
+                         that can be used inside a citation
+JATS-related-object1.ent
+                       - <related-object> is similar to but broader 
+                         than <related-article> for databases, books, 
+                         chapters in books, etc.
+JATS-section1.ent      - Section-level elements
+
+ 
+------------------------------------------------------
+4.4 JATS Base Modules: Notations and Special Characters
+    (Used by all of the DTDs)
+
+JATS-notat1.ent   
+             - Names all Notations used
+
+JATS-chars1.ent   
+             - Defines JATS-specific and custom special
+               characters (as general entities defined
+               as hexadecimal or decimal character
+               entities [Unicode numbers] or by using
+               the <private-char> element).
+
+JATS-xmlspecchars1.ent
+             - Names all the standard special character
+               entity sets to be used by the DTD. The
+               MathML characters sets were used,
+               unchanged, in the same directory
+               structure used for MathML.
+
+All the MathML special character entity sets:
+
+(inside the iso8879 subdirectory)
+  isobox.ent
+  isocyr1.ent
+  isocyr2.ent
+  isodia.ent
+  isolat1.ent
+  isolat2.ent
+  isonum.ent
+  isopub.ent
+
+(inside the iso9573-13 subdirectory)
+  isoamsa.ent
+  isoamsb.ent
+  isoamsc.ent
+  isoamsn.ent
+  isoamso.ent
+  isoamsr.ent
+  isogrk3.ent
+  isomfrk.ent
+  isomopf.ent
+  isomscr.ent
+  isotech.ent
+
+Special character entity sets NOT used in MathML
+(included as part of the DTD for backwards compatibility)  
+
+(inside the xmlchars subdirectory)
+  isogrk1.ent
+  isogrk2.ent
+  isogrk4.ent
+
+
+------------------------------------------------------
+4.5 JATS Base Modules: Modules for MathML 2.0 and MathML 3.0 
+    (Define MathML tagging, used in %math.ent;)
+
+4.5.1 Modules for MathML 2.0
+
+JATS-mathmlsetup1.ent  - DTD Suite module that sets the parameter
+                         entities for the MathML 2.0 modules
+
+The top-level MathML 2.0 modules:
+  mathml2.dtd
+  mathml2-qname-1.mod
+
+And inside the mathml subdirectory:
+  mmlalias.ent
+  mmlextra.ent
+
+4.5.2 Modules for MathML 3.0
+
+JATS-mathml3-mathmlsetup1.ent - DTD Suite module that sets 
+                                the parameter entities for the 
+                                MathML 3.0 modules
+
+JATS-mathml3-modules1.ent 
+                      - DTD Suite module that names the modules 
+                        needed for MathML 3.0
+
+The top-level MathML 3.0 modules:
+  mathml3.dtd
+  mathml3-qname-1.mod
+
+And inside the mathml subdirectory:
+  mmlalias.ent
+  mmlextra.ent
+
+ 
+------------------------------------------------------
+4.6 JATS Base Modules: Table Modules 
+
+4.6.1  XHTML Table Model (Defines XHTML Table Model)
+
+These modules are defined in the Suite and should be invoked
+from the DTD if XHTML table tagging is desired. The XHTML
+table model is the default table model for the JATS Suite.
+
+  JATS-XHTMLtablesetup1.ent 
+                       - JATS module to set up parameter
+                         entities and attributes for
+                         XHTML table processing
+
+  xhtml-table-1.mod    - XHTML DTD module
+  xhtml-inlstyle-1.mod - XHTML style attribute module
+
+4.6.2  OASIS Exchange CALS Table Model
+
+If an organization wishes to use the OASIS Exchange CALS table 
+model instead of OR IN ADDITION TO the XHTML model, the following
+modules are included as well as the XHTML ones:
+
+  JATS-oasis-tablesetup1.ent 
+                       - JATS module to set up parameter
+                         entities and attributes for
+                         OASIS Exchange CALS table processing
+  JATS-oasis-namespace1.ent 
+                       - JATS module that sets up the OASIS 
+                         namespace, by default with the namespace 
+                         prefix of "oasis".
+
+  oasis-exchange.ent   - Basic OASIS CALS table model
+
+
+======================================================
+
+5.0 CATALOG FILES
+
+These files are not part of the JATS Base Modules proper, but 
+are provided as a convenience to implementors.
+
+catalog-jats-v1-1-no-base.xml
+               - XML catalog made according to the
+                 OASIS DTD Entity Resolution XML Catalog V2.1
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd"
+                 with no @xml:base attribute provided
+                 on the group level.
+
+catalog-jats-v1-1-with-base.xml
+               - XML catalog made according to the
+                 OASIS DTD Entity Resolution XML Catalog V2.1
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd"
+                 with a place-holder @xml:base attribute
+                 provided on each group level, for the convenience
+                 of implementors, who will change the @xml:base
+                 to point to their locations.
+
+=============== document end =========================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/publishing/1.1/catalog-jats-v1-1-no-base.xml
+++ b/publishing/1.1/catalog-jats-v1-1-no-base.xml
@@ -1,0 +1,946 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC
+"-//OASIS//DTD Entity Resolution XML Catalog V3.0//EN"
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+<!-- ============================================================= -->
+<!--  MODULE:    An OASIS XML Catalog (not a DTD Suite module)     -->
+<!--             Version of the catalog without @xml:base          -->
+<!--  VERSION:   1.1d3                                             -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To make the connection between PUBLIC identifiers -->
+<!--             for DTD Suite modules and their URIs              -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Scope of Catalog                               -->
+<!--             2) Catalog organization comment                   -->
+<!--             3) How to set up a catalog                        -->
+<!--                  This catalog has been set up deliberately    -->
+<!--                  so that ALL users will need to modify the    -->
+<!--                  catalog before using it.                     -->
+<!--             4) PUBLIC/SYSTEM identifier map                   -->
+<!--                  a. NISO JATS Journal Publishing DTD (Blue)   -->
+<!--                        Blue with XHTML and MathML 3.0         -->
+<!--                        Blue with XHTML and MathML 2.0         -->
+<!--                        Blue with XHTML, CALS, and MathML 3.0  -->
+<!--                        Blue with XHTML, CALS, and MathML 2.0  -->
+<!--                  b. NISO JATS Archiving and Interchange       -->
+<!--                        DTD (Green)                            -->
+<!--                        Green with XHTML and MathML 3.0        -->
+<!--                        Green with XHTML and MathML 2.0        -->
+<!--                        Green with XHTML, CALS, and MathML 3.0 -->
+<!--                        Green with XHTML, CALS, and MathML 2.0 -->
+<!--                  c. NISO JATS Journal Authoring DTD (Pumpkin) -->
+<!--                        Pumpkin with XHTML and MathML 3.0      -->
+<!--                        Pumpkin with XHTML and MathML 2.0      -->
+<!--                  d. JATS DTD Suite common (shared) modules    -->
+<!--                  e. JATS DTD Suite common (shared) modules    -->
+<!--                       from external sources (table models,    -->
+<!--                       MATHML, general entity sets, etc.)      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             June 2002                                         -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal JATS DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+     =============================================================
+
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1 (ANSI/NSIO Z39.96-2015)
+                                   (DAL/BTU) v1.1d3  (2015-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.1 (ANSI/NSIO Z39.96-2015).
+  
+ 15. JATS "1.1d3" and "v1.1d3 20150301" become
+     JATS 1.1 and "v1.1 20151215". No module names were changed.
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  
+ 14. JATS became version "1.1d3" and "v1.1 20150301//EN"
+     BITS became version "2.0" and "v2.0 20150630//EN", and
+        BITS module names all changed to "2"
+
+     =============================================================
+     JATS Version 1.1d2             (DAL/BTU) v1.1d2  (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. Re-arranged catalog entries to make it more obvious which
+     files were needed by which DTDs.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+
+     =============================================================
+     JATS Version 1.1d1             (DAL/BTU) v1.1d1 (2013-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+     
+ 11. Replaced an incorrect formal public identifier for the 
+     Archiving DTD with XTHML and MathML3. Changed"-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD v1.1d1 20130915//EN" 
+     to the fpi: "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1d1 
+     20130915//EN"
+
+ 10. Removed all mentions of BITS files
+
+  9. Removed duplicate declaration of JATS OASIS Table Setup Module
+
+     =============================================================
+     JATS Version 1.1d1 (prelim draft) (DAL/BTU) v1.1d1 (2013-11-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. Major DTD-fork to Add MathML 3.0 as an alternative to 
+     MathML 2.0. They must never be used together, always
+     one must be chosen. This added many more DTDs, as all
+     options needed to be able to choose which Math to use.
+
+  6. Modified comments to make it more obvious which modules are
+     used together and which may be commented out or
+     deleted. No catalog entries ever need to be commented
+     out or deleted.
+
+  5. Changed the filename to include "no-base" in the name.
+
+  4. JATS became version "1.1d1" and "v1.1d1 20130915//EN"
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-09-20)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  3. Replaced OASIS modules to enhance control of OASIS 
+     namespace and namespace prefix (v1.0 20120330//EN").
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become "NISO JATS
+     Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  2. Updated the public identifiers to "v1.0 20120330//EN",
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://jats.nlm.nih.gov/3.0.
+
+  1. Updated public identifiers to "v3.0 20080202//EN"
+     fresh start.                                                   -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================== -->
+<!--                    SCOPE (JATS DTD Suite Version 1.1d1)        -->
+<!-- ============================================================== -->
+
+<!-- This catalog is made up of several groups, each with its own
+     xml:base attribute, for:
+
+       - NISO JATS Journal Publishing DTD (Blue)
+       - The additional modules for the NISO JATS Journal Publishing 
+           DTD (Blue) with OASIS and XHTML tables
+       - NISO JATS Archiving and Interchange DTD (Green)
+       - The additional modules for the NISO JATS Archiving and 
+           Interchange DTD (Green) with OASIS and XHTML tables
+       - NISO JATS Journal Authoring DTD (Pumpkin)
+       - JATS DTD Suite common (shared) modules
+       - JATS DTD Suite common (shared) modules from external 
+            sources (table models, MathML, general entity 
+            sets, etc.)                                         
+
+     To work with relative files (such as in the Oxygen XML Editor), 
+     use this catalog named "no-base", which has no @xml:base 
+     attributes.  To set up a system-level catalog specific to a
+     file system, set an @xml:base attribute on each <group> element 
+     to the appropriate URI, such as a filename or system path.     -->
+     
+<!-- ============================================================== -->
+<!--                    CATALOG ORGANIZATION                        -->
+<!-- ============================================================== -->
+
+<!--  GROUPS AND ENTRIES
+
+     Entries are grouped into logical clusters, organized by the
+     particular DTD variant.
+
+     Each catalog entry associates a PUBLIC identifier with a SYSTEM
+     identifier.
+
+     The @uri SYSTEM identifier is relative (resolved by the
+     application, such as the Oxygen XML editor), and contains the
+     filename of the DTD:
+
+     The XML looks like this:
+
+     <group>
+
+       <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v88.6 20160331//EN"
+               uri="journalpublishing88.dtd"/>
+       ...
+     </group>
+                                                                    -->
+
+
+<!-- ============================================================== -->
+<!--                    HOW TO SET UP                               -->
+<!-- ============================================================== -->
+
+<!-- The OASIS catalog and the NCBI Suite of Modules provide a wide
+     range of flexibility for setting up. Here are two easy ways to
+     do it:
+
+
+     1. WITHOUT an OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory:
+
+            - the journal-publishing package
+            - the archive article package
+            - the journal-authoring package
+            - the book package
+
+        - create your own DTD customization, if you need to,
+          anywhere, using local (relative or absolute) SYSTEM
+          identifiers to reference DTD modules.
+
+        - create a document instance anywhere, and point its
+          SYSTEM identifier to your customized DTD or to the
+          package DTD you have chosen to use, using a local
+          (relative or absolute) SYSTEM identifier.
+
+        The SYSTEM identifiers used in the DTD modules are relative
+        to the directory in which you have placed the DTD package
+        and your customized DTD, and so your editor/processor will
+        find them when reading the DTD.
+
+     2. Using this OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory, or into separate directories.
+          
+             - If you are using tools that work well with relative
+               path locations (e.g., The Oxygen XML Editor), you can
+               use this JATS catalog, named "no-base", that does
+               not use the @xml:base attributes.
+               
+             - If you need to establish an @XML:base attribute,
+               start from the other catalog, named "with-base"/
+
+        - create your own DTD customization, if you need to,
+          anywhere, using PUBLIC identifiers to reference the
+          DTD modules.
+
+        - tell your editor/processor about this OASIS catalog
+          (Note: many apps must be closed and relaunched when
+          a catalog file is first specified AND when it is changed)
+
+        - create a document instance anywhere, and point its
+          SYSTEM or PUBLIC identifier to the DTD you want to use,
+          giving a relative SYSTEM path.
+
+        Your editor/processor will map the PUBLIC identifiers
+        in the DTD to the SYSTEM identifiers specified in
+        this catalog.                                               -->
+
+
+<!-- ============================================================== -->
+<!--                    PUBLIC-SYSTEM IDENTIFIER MAP                -->
+<!-- ============================================================== -->
+
+<!-- ============================================================== -->
+<!--                    JOURNAL PUBLISHING DTD (BLUE)               -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Publishing DTDs (Blue).             -->
+<!--                    If you are not using Publishing (Blue), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Journal Publishing DTDs (Blue)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-models1.ent"/>
+
+<!--                    The following modules are used for all of   -->
+<!--                    the Journal Publishing DTDs (Blue) that use -->
+<!--                    ONLY the XHTML-based Table Model            -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 2.0                -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
+               uri="JATS-journalpublishing1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 3.0                -->
+
+<public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with MathML3 v1.1 20151215//EN"
+               uri="JATS-journalpublishing1-mathml3.dtd"/>
+
+<!--                    The following modules are used only for all -->
+<!--                    Journal Publishing DTDs(Blue) that use the  -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model.                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-journalpub-oasis-custom-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.1 20151215//EN"
+               uri="JATS-journalpub-oasis-custom-classes1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 2.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables v1.1 20151215//EN"
+               uri="JATS-journalpublishing-oasis-article1.dtd"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 3.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables with MathML3 v1.1 20151215//EN"
+               uri="JATS-journalpublishing-oasis-article1-mathml3.dtd"/>
+
+</group>
+
+<!-- ============================================================== -->
+<!--                    ARCHIVING AND INTERCHANGE DTD (GREEN)       -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Archiving and Interchange DTDs      -->
+<!--                    (Green)                                     -->
+<!--                    If you are not using Archiving (Green), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.1 20151215//EN"
+               uri="JATS-archivecustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.1 20151215//EN"
+               uri="JATS-archivecustom-models1.ent"/>
+ 
+<!--                    The following modules are used for all of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.1 20151215//EN" 
+               uri="JATS-archivecustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.1 20151215//EN" 
+               uri="JATS-archivecustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 2.0           -->
+
+ <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN" 
+               uri="JATS-archivearticle1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 3.0           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1 20151215//EN"
+               uri="JATS-archivearticle1-mathml3.dtd"/>
+
+
+<!--                    The following modules are used only for all -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model.         -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables Customize Classes Module v1.1 20151215//EN"
+               uri="JATS-archive-oasis-custom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-archive-oasis-custom-modules1.ent"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 2.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables v1.1 20151215//EN"
+               uri="JATS-archive-oasis-article1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 3.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables with MathML3 v1.1 20151215//EN"
+               uri="JATS-archive-oasis-article1-mathml3.dtd"/>
+              
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    ARTICLE AUTHORING DTD (PUMPKIN)             -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Article Authoring DTD (Pumpkin).            -->
+<!--                    If you are not using Authoring (Pumpkin),   -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Article Authoring DTDs (Pumpkin)        -->
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Classes Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-classes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Mixes Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-mixes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Content and Attribute Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-models1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 2.0   -->
+           
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.1 20151215//EN"
+               uri="JATS-articleauthoring1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 3.0   -->
+            
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.1 20151215//EN"
+               uri="JATS-articleauthoring1-mathml3.dtd"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    JATS DTD SUITE                              -->
+<!--                    MODULAR LIBRARY                             -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!--                    MODULE OF MODULES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+               uri="JATS-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.1 20151215//EN"
+               uri="JATS-mathml3-modules1.ent"/>
+
+
+<!--                    CLASSES AND MIXES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.1 20151215//EN"
+               uri="JATS-default-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.1 20151215//EN"
+               uri="JATS-default-mixes1.ent"/>
+
+
+<!--                    ELEMENT COMMON (SHARED) ELEMENTS/CHARACTERS -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.1 20151215//EN"
+               uri="JATS-common1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.1 20151215//EN"
+               uri="JATS-common-atts1.ent"/>               
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.1 20151215//EN"
+               uri="JATS-notat1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.1 20151215//EN"
+               uri="JATS-xmlspecchars1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.1 20151215//EN"
+               uri="JATS-chars1.ent"/>
+
+
+<!--                    CLASS MODULES                               -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.1 20151215//EN"
+               uri="JATS-articlemeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.1 20151215//EN"
+               uri="JATS-backmatter1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.1 20151215//EN"
+               uri="JATS-display1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.1 20151215//EN"
+               uri="JATS-format1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.1 20151215//EN"
+               uri="JATS-funding1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.1 20151215//EN"
+               uri="JATS-journalmeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.1 20151215//EN"
+               uri="JATS-link1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.1 20151215//EN"
+               uri="JATS-list1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.1 20151215//EN"
+               uri="JATS-math1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+               uri="JATS-nlmcitation1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.1 20151215//EN"
+               uri="JATS-para1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.1 20151215//EN"
+               uri="JATS-phrase1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.1 20151215//EN"
+               uri="JATS-references1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.1 20151215//EN"
+               uri="JATS-related-object1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.1 20151215//EN"
+               uri="JATS-section1.ent"/>
+
+
+<!--                    SET UP XHTML TABLES (OASIS below)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.1 20151215//EN"
+               uri="JATS-XHTMLtablesetup1.ent"/>
+
+<!--                    SET UP MATHML                              -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.1 20151215//EN"
+               uri="JATS-mathmlsetup1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.1 20151215//EN"
+               uri="JATS-mathml3-mathmlsetup1.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    COMMONLY-USED PUBLIC MODELS AND PUBLIC      -->
+<!--                    CHARACTER-ENTITY SETS USED IN THE SUITE     -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" >
+
+<!-- .............................................................. -->
+<!--                    NISO ACCESS AND INDICATOR NAMESPACE         -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS ALI Namespace Module v1.1 20151215//EN"
+               uri="JATS-ali-namespace1.ent"/>
+
+<!-- .............................................................. -->
+<!--                    TABLES: XHTML TABLE MODULES                 -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+               uri="xhtml-table-1.mod"/>
+
+  <public publicId="-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+               uri="xhtml-inlstyle-1.mod"/>
+
+
+<!-- .............................................................. -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS OASIS Table Namespace Module v1.1 20151215//EN"
+               uri="JATS-oasis-namespace1.ent"/>
+
+  <public publicId="-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+               uri="oasis-exchange.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.1 20151215//EN"
+               uri="JATS-oasis-tablesetup1.ent"/>
+ 
+
+<!-- .............................................................. -->
+<!--                    MATHML MODULES                              -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//DTD MathML 2.0//EN"
+               uri="mathml2.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+               uri="mathml2-qname-1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 2.0//EN"
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+  <public publicId="-//W3C//DTD MathML 3.0//EN"
+               uri="mathml3.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN" 
+               uri="mathml3-qname1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 3.0//EN" 
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 3.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+<!-- .............................................................. -->
+<!--                    ISO 8879 ENTITIES                           -->
+<!-- .............................................................. -->
+
+
+  <public publicId="-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+               uri="iso8879/isobox.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+               uri="iso8879/isodia.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+               uri="iso8879/isolat1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+               uri="iso8879/isolat2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+               uri="iso8879/isonum.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+               uri="iso8879/isopub.ent"/>
+
+<!-- .............................................................. -->
+<!--                    ISO 9573-11 ENTITIES                        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+               uri="iso9573-13/isotech.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+               uri="iso9573-13/isogrk3.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+               uri="iso9573-13/isomscr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsa.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+               uri="iso9573-13/isoamsb.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+               uri="iso9573-13/isoamsc.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsn.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+               uri="iso9573-13/isoamso.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+               uri="iso9573-13/isomfrk.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+               uri="iso9573-13/isomopf.ent"/>
+
+<!-- .............................................................. -->
+<!--                    NON-MATHML ENTITIES(backwards compatibility)-->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES Greek Letters//EN"
+               uri="xmlchars/isogrk1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Monotoniko Greek//EN"
+               uri="xmlchars/isogrk2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Alternative Greek Symbols//EN"
+               uri="xmlchars/isogrk4.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    BITS BOOK INTERCHANGE DTD                   -->
+<!--                    The following modules are used only for NLM -->
+<!--                    BITS (Book Interchange Tag Suite)[Chocolate]-->
+<!--                                                                -->
+<!--                    If you are not using BITS (Chocolate), you  -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+<group prefer="public" >
+   
+<!--                    The following modules are used for all of   -->
+<!--                    the BITS DTDs (Chocolate)                   -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD v2.0 20151225//EN"
+               uri="BITS-book2.dtd"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules v2.0 20151225//EN" 
+               uri="BITS-bookcustom-modules2.ent"/>
+ 
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Classes Module v2.0 20151225//EN" 
+               uri="BITS-bookcustom-classes2.ent"/>
+              
+  <public publicId="-//NLM//DTD BITS Book Part Wrapper v2.0 20151225//EN" 
+               uri="BITS-book-part-wrap2.ent" /> 
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    BITS DTDS that                              -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model          -->
+             
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables v2.0 20151225//EN"
+               uri="BITS-book-oasis2.dtd" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules with OASIS and XHTML Tables v2.0 20151225//EN"
+               uri="BITS-book-oasis-custom-modules2.ent" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables Customize Classes Module v2.0 20151225//EN"
+               uri="BITS-book-oasis-custom-classes2.ent" />
+               
+  <public publicId="-//NLM//DTD BITS Book Part OASIS and XTHML Tables Wrapper v2.0 20151225//EN"  
+               uri="BITS-book-part-oasis-wrap2.ent" /> 
+              
+<!--                    The following modules are used for ALL of   -->
+<!--                    the BITS DTDs (Chocolate)                 -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Mixes Module v2.0 20151225//EN"
+               uri="BITS-bookcustom-mixes2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Content and Attributes Module v2.0 20151225//EN" 
+               uri="BITS-bookcustom-models2.ent"/>
+
+
+               
+  <public publicId="-//NLM//DTD BITS Add Attributes Module v2.0 20151225//EN"  
+               uri="BITS-add-attributes2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Book Metadata Elements Module v2.0 20151225//EN"  
+               uri="BITS-bookmeta2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Component Elements v2.0 20151225//EN"  
+               uri="BITS-book-part2.ent"/>
+               
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Common Module v2.0 20151225//EN" 
+               uri="BITS-common2.ent" />  
+ 
+ 
+  <public publicId="-//NLM//DTD BITS Embedded Index Element Module v2.0 20151225//EN"
+               uri="BITS-embedded-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Index Elements Module v2.0 20151225//EN" 
+               uri="BITS-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Table of Contents Module v2.0 20151225//EN"
+               uri="BITS-toc2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS Question and Answer Module v2.0 20151225//EN"  
+               uri="BITS-question-answer2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Table of Contents and Index Navigation Module v2.0 20151225//EN"
+               uri="BITS-toc-index-nav2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS XInclude Setup Module v2.0 20151225//EN" 
+               uri="BITS-xinclude2.ent" /> 
+ 
+</group>
+
+<!-- ================ End WITH Base OASIS XML CATALOG ============= -->
+
+</catalog>

--- a/publishing/1.1/catalog-jats-v1-1-with-base.xml
+++ b/publishing/1.1/catalog-jats-v1-1-with-base.xml
@@ -1,0 +1,951 @@
+<?xml version="1.0"?>
+<!DOCTYPE catalog PUBLIC
+"-//OASIS//DTD Entity Resolution XML Catalog V3.0//EN"
+"http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+<!-- ============================================================= -->
+<!--  MODULE:    An OASIS XML Catalog (not a DTD Suite module)     -->
+<!--             Version of the catalog without @xml:base          -->
+<!--  VERSION:   1.1d3                                             -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    To make the connection between PUBLIC identifiers -->
+<!--             for DTD Suite modules and their URIs              -->
+<!--                                                               -->
+<!-- CONTAINS:   1) Scope of Catalog                               -->
+<!--             2) Catalog organization comment                   -->
+<!--             3) How to set up a catalog                        -->
+<!--                  This catalog has been set up deliberately    -->
+<!--                  so that ALL users will need to modify the    -->
+<!--                  catalog before using it.                     -->
+<!--             4) PUBLIC/SYSTEM identifier map                   -->
+<!--                  a. NISO JATS Journal Publishing DTD (Blue)   -->
+<!--                        Blue with XHTML and MathML 3.0         -->
+<!--                        Blue with XHTML and MathML 2.0         -->
+<!--                        Blue with XHTML, CALS, and MathML 3.0  -->
+<!--                        Blue with XHTML, CALS, and MathML 2.0  -->
+<!--                  b. NISO JATS Archiving and Interchange       -->
+<!--                        DTD (Green)                            -->
+<!--                        Green with XHTML and MathML 3.0        -->
+<!--                        Green with XHTML and MathML 2.0        -->
+<!--                        Green with XHTML, CALS, and MathML 3.0 -->
+<!--                        Green with XHTML, CALS, and MathML 2.0 -->
+<!--                  c. NISO JATS Journal Authoring DTD (Pumpkin) -->
+<!--                        Pumpkin with XHTML and MathML 3.0      -->
+<!--                        Pumpkin with XHTML and MathML 2.0      -->
+<!--                  d. JATS DTD Suite common (shared) modules    -->
+<!--                  e. JATS DTD Suite common (shared) modules    -->
+<!--                       from external sources (table models,    -->
+<!--                       MATHML, general entity sets, etc.)      -->
+<!--                                                               -->
+<!-- TAG SET SPONSOR                                               -->
+<!--             National Center for Biotechnology                 -->
+<!--                Information (NCBI)                             -->
+<!--             National Library of Medicine (NLM)                -->
+<!--                                                               -->
+<!-- CREATED FOR:                                                  -->
+<!--             This module was created for the JATS DTD Suite.   -->
+<!--             Digital archives and publishers may use the       -->
+<!--             DTD as is for markup of journal literature or     -->
+<!--             related material for archiving and transferring   -->
+<!--             such material between archives or create a        -->
+<!--             custom XML DTD from the Suite for                 -->
+<!--             these purposes.                                   -->
+<!--                                                               -->
+<!--             This DTD is in the public domain. An organization -->
+<!--             that wishes to create its own DTD from the suite  -->
+<!--             may do so without permission from NLM.            -->
+<!--                                                               -->
+<!--             The suite has been set up to be extended using a  -->
+<!--             new DTD file and a new DTD-specific customization -->
+<!--             module to redefine the many Parameter Entities.   -->
+<!--             Do not modify the suite directly or redistribute  -->
+<!--             modified versions of the suite.                   -->
+<!--                                                               -->
+<!--             In the interest of maintaining consistency and    -->
+<!--             clarity for potential users, NLM requests:        -->
+<!--                                                               -->
+<!--             1. If you create a DTD from the JATS DTD Suite    -->
+<!--                and intend to stay compatible with the suite,  -->
+<!--                then please include the following statement    -->
+<!--                as a comment in all of your DTD modules:       -->
+<!--                   "Created from, and fully compatible with,   -->
+<!--                    the ANSI/NISO Z39.96 Journal Article Tag   -->
+<!--                    Suite (JATS)."                             -->
+<!--                                                               -->
+<!--             2. If you alter one or more modules of the suite, -->
+<!--                then please rename your version and all its    -->
+<!--                modules to avoid any confusion with the        -->
+<!--                original suite. Also, please include the       -->
+<!--                following statement as a comment in all your   -->
+<!--                DTD modules:                                   -->
+<!--                   "Based in part on, but not fully compatible -->
+<!--                    with, the ANSI/NISO Z39.96 Journal Article -->
+<!--                    Tag Suite (JATS)."                         -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             June 2002                                         -->
+<!--                                                               -->
+<!-- CREATED BY: Mulberry Technologies, Inc. for the NISO Z39.96   -->
+<!--             Working Group. Mulberry Technologies was          -->
+<!--             supported by National Center for Biotechnology    -->
+<!--             Information (NCBI), a center of the US National   -->
+<!--             Library of Medicine (NLM).                        -->
+<!--                                                               -->
+<!--             This module is part of the JATS DTD Suite. The    -->
+<!--             Suite is a continuation of work done by NCBI,     -->
+<!--             Mulberry Technologies, and Inera, Inc. on the NLM -->
+<!--             Journal JATS DTD Suite, which-->
+<!--             was originally released in December, 2002.        -->
+<!--                                                               -->
+<!--             NLM thanks the Harvard University Libraries, both -->
+<!--             for proposing that a draft archiving NLM DTD for  -->
+<!--             life sciences journals be extended to accommodate -->
+<!--             journals in all disciplines and for sponsoring    -->
+<!--             Inera Inc.'s collaboration with other DTD         -->
+<!--             authors in completing NLM Version 1.0. The        -->
+<!--             Andrew W. Mellon Foundation provided support for  -->
+<!--             these important contributions.                    -->
+<!--                                                               -->
+<!--             Suggestions for refinements and enhancements to   -->
+<!--             this DTD should be sent in email to:              -->
+<!--                 jats@ncbi.nlm.nih.gov                         -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+     =============================================================
+
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+    =============================================================
+     JATS Version 1.1 (ANSI/NSIO Z39.96-2015)
+                                   (DAL/BTU) v1.1d3  (2015-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the both the NISO and ANSI membership 
+     to be changed. This version of the NISO JATS was approved 
+     by ANSI and NISO vote, so it supersedes all Committee Drafts
+     and becoming NISO JATS 1.1 (ANSI/NSIO Z39.96-2015).
+  
+ 15. JATS "1.1d3" and "v1.1d3 20150301" become
+     JATS 1.1 and "v1.1 20151215". No module names were changed.
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  
+ 14. JATS became version "1.1d3" and "v1.1 20150301//EN"
+     BITS became version "2.0" and "v2.0 20150630//EN", and
+        BITS module names all changed to "2"
+
+     =============================================================
+     JATS Version 1.1d2             (DAL/BTU) v1.1d2  (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+ 13. Re-arranged catalog entries to make it more obvious which
+     files were needed by which DTDs.
+
+ 12. JATS became version "1.1d2" and "v1.1d2 20140930"
+
+     =============================================================
+     JATS Version 1.1d1             (DAL/BTU) v1.1d1 (2013-12-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1 or 2.0.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+     
+ 11. Replaced an incorrect formal public identifier for the 
+     Archiving DTD with XTHML and MathML3. Changed "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD v1.1d1 20130915//EN" 
+     to the fpi: "-//NLM//DTD JATS 
+     (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1d1 
+     20130915//EN"
+
+ 10. Removed all mentions of BITS files
+
+  9. Removed duplicate declaration of JATS OASIS Table Setup Module
+
+     =============================================================
+     JATS Version 1.1d1 (prelim draft) (DAL/BTU) v1.1d1 (2013-11-15)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. The next
+     official version of NISO JATS will be either 1.1 or 2.0.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  7. Major DTD-fork to Add MathML 3.0 as an alternative to 
+     MathML 2.0. They must never be used together, always
+     one must be chosen. This added many more DTDs, as all
+     options needed to be able to choose which Math to use.
+
+  6. Modified comments to make it more obvious which modules are
+     used together and which may be commented out or
+     deleted. No catalog entries ever need to be commented
+     out or deleted.
+
+  5. Changed the filename to include "no-base" in the name.
+
+  4. JATS became version "1.1d1" and "v1.1d1 20130915//EN"
+
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-09-20)
+   
+     ANSI/NISO Z39.96-2012 (Version 1.0) 
+
+     Details concerning ANSI/NISO Z39.96-2012 JATS-based DTDs,  
+     XSDs, RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.0/
+   
+  3. Replaced OASIS modules to enhance control of OASIS 
+     namespace and namespace prefix (v1.0 20120330//EN").
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become "NISO JATS
+     Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+
+  2. Updated the public identifiers to "v1.0 20120330//EN",
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://jats.nlm.nih.gov/3.0.
+
+  1. Updated public identifiers to "v3.0 20080202//EN"
+     fresh start.                                                   -->
+
+<!-- ============================================================= -->
+<!-- Details concerning 
+     ANSI/NISO Z39.96-2015 JATS-based DTDs, XSDs, 
+     RNGs and supporting documentation are available at
+           http://jats.nlm.nih.gov/1.1/                            -->
+
+<!-- ============================================================== -->
+<!--                    SCOPE (JATS DTD Suite Version 1.1d1)        -->
+<!-- ============================================================== -->
+
+<!-- This catalog is made up of several groups, each with its own
+     xml:base attribute, for:
+
+       - NISO JATS Journal Publishing DTD (Blue)
+       - The additional modules for the NISO JATS Journal Publishing 
+           DTD (Blue) with OASIS and XHTML tables
+       - NISO JATS Archiving and Interchange DTD (Green)
+       - The additional modules for the NISO JATS Archiving and 
+           Interchange DTD (Green) with OASIS and XHTML tables
+       - NISO JATS Journal Authoring DTD (Pumpkin)
+       - JATS DTD Suite common (shared) modules
+       - JATS DTD Suite common (shared) modules from external 
+            sources (table models, MathML, general entity 
+            sets, etc.)                                         
+
+     To work with relative files (such as in the Oxygen XML Editor), 
+     use this catalog named "no-base", which has no @xml:base 
+     attributes.  To set up a system-level catalog specific to a
+     file system, set an @xml:base attribute on each <group> element 
+     to the appropriate URI, such as a filename or system path.     -->
+     
+<!-- ============================================================== -->
+<!--                    CATALOG ORGANIZATION                        -->
+<!-- ============================================================== -->
+
+<!--  GROUPS AND ENTRIES
+
+     Entries are grouped into logical clusters, organized by the
+     particular DTD variant.
+
+     Each catalog entry associates a PUBLIC identifier with a SYSTEM
+     identifier.
+
+     The @uri SYSTEM identifier is relative (resolved by the
+     application, such as the Oxygen XML editor), and contains the
+     filename of the DTD:
+
+     The XML looks like this:
+
+     <group>
+
+       <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v88.6 20160331//EN"
+               uri="journalpublishing88.dtd"/>
+       ...
+     </group>
+                                                                    -->
+
+
+<!-- ============================================================== -->
+<!--                    HOW TO SET UP                               -->
+<!-- ============================================================== -->
+
+<!-- The OASIS catalog and the NCBI Suite of Modules provide a wide
+     range of flexibility for setting up. Here are two easy ways to
+     do it:
+
+
+     1. WITHOUT an OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory:
+
+            - the journal-publishing package
+            - the archive article package
+            - the journal-authoring package
+            - the book package
+
+        - create your own DTD customization, if you need to,
+          anywhere, using local (relative or absolute) SYSTEM
+          identifiers to reference DTD modules.
+
+        - create a document instance anywhere, and point its
+          SYSTEM identifier to your customized DTD or to the
+          package DTD you have chosen to use, using a local
+          (relative or absolute) SYSTEM identifier.
+
+        The SYSTEM identifiers used in the DTD modules are relative
+        to the directory in which you have placed the DTD package
+        and your customized DTD, and so your editor/processor will
+        find them when reading the DTD.
+
+     2. Using this OASIS catalog (DTD components on a local system):
+
+        - unzip the DTD packages you want to use into a single
+          directory, or into separate directories.
+          
+             - If you are using tools that work well with relative
+               path locations (e.g., The Oxygen XML Editor), you can
+               use this JATS catalog, named "no-base", that does
+               not use the @xml:base attributes.
+               
+             - If you need to establish an @XML:base attribute,
+               start from the other catalog, named "with-base"/
+
+        - create your own DTD customization, if you need to,
+          anywhere, using PUBLIC identifiers to reference the
+          DTD modules.
+
+        - tell your editor/processor about this OASIS catalog
+          (Note: many apps must be closed and relaunched when
+          a catalog file is first specified AND when it is changed)
+
+        - create a document instance anywhere, and point its
+          SYSTEM or PUBLIC identifier to the DTD you want to use,
+          giving a relative SYSTEM path.
+
+        Your editor/processor will map the PUBLIC identifiers
+        in the DTD to the SYSTEM identifiers specified in
+        this catalog.                                               -->
+
+
+<!-- ============================================================== -->
+<!--                    PUBLIC-SYSTEM IDENTIFIER MAP                -->
+<!-- ============================================================== -->
+
+<!-- ============================================================== -->
+<!--                    JOURNAL PUBLISHING DTD (BLUE)               -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Publishing DTDs (Blue).             -->
+<!--                    If you are not using Publishing (Blue), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Journal Publishing DTDs (Blue)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Mixes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Content and Attributes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-models1.ent"/>
+
+<!--                    The following modules are used for all of   -->
+<!--                    the Journal Publishing DTDs (Blue) that use -->
+<!--                    ONLY the XHTML-based Table Model            -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD Customize Classes Module v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-journalpubcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 2.0                -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN"
+               uri="JATS-journalpublishing1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue), that uses    -->
+<!--                    XHTML tables with MathML 3.0                -->
+
+<public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with MathML3 v1.1 20151215//EN"
+               uri="JATS-journalpublishing1-mathml3.dtd"/>
+
+<!--                    The following modules are used only for all -->
+<!--                    Journal Publishing DTDs(Blue) that use the  -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model.                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-journalpub-oasis-custom-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables Customize Classes v1.1 20151215//EN"
+               uri="JATS-journalpub-oasis-custom-classes1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 2.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables v1.1 20151215//EN"
+               uri="JATS-journalpublishing-oasis-article1.dtd"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Journal Publishing DTD (Blue) that uses the -->
+<!--                    OASIS table model (namespace prefix "oasis")-->
+<!--                    and the XHTML table model with MathML 3.0   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD with OASIS Tables with MathML3 v1.1 20151215//EN"
+               uri="JATS-journalpublishing-oasis-article1-mathml3.dtd"/>
+
+</group>
+
+<!-- ============================================================== -->
+<!--                    ARCHIVING AND INTERCHANGE DTD (GREEN)       -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Journal Archiving and Interchange DTDs      -->
+<!--                    (Green)                                     -->
+<!--                    If you are not using Archiving (Green), you -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Mixes Module v1.1 20151215//EN"
+               uri="JATS-archivecustom-mixes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Content and Attributes Module v1.1 20151215//EN"
+               uri="JATS-archivecustom-models1.ent"/>
+ 
+<!--                    The following modules are used for all of   -->
+<!--                    the Archiving and Interchange DTDs (Green)  -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD Customize Classes Module v1.1 20151215//EN" 
+               uri="JATS-archivecustom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving DTD-Specific Modules v1.1 20151215//EN" 
+               uri="JATS-archivecustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 2.0           -->
+
+ <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN" 
+               uri="JATS-archivearticle1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green), that-->
+<!--                    uses XHTML tables with MathML 3.0           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with MathML3 v1.1 20151215//EN"
+               uri="JATS-archivearticle1-mathml3.dtd"/>
+
+
+<!--                    The following modules are used only for all -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model.         -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables Customize Classes Module v1.1 20151215//EN"
+               uri="JATS-archive-oasis-custom-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-archive-oasis-custom-modules1.ent"/>
+
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 2.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables v1.1 20151215//EN"
+               uri="JATS-archive-oasis-article1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    Archiving and Interchange DTDs (Green) that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model with     -->
+<!--                    MathML 3.0                                  -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD with OASIS Tables with MathML3 v1.1 20151215//EN"
+               uri="JATS-archive-oasis-article1-mathml3.dtd"/>
+              
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    ARTICLE AUTHORING DTD (PUMPKIN)             -->
+<!--                    The following modules are used only for JATS-->
+<!--                    Article Authoring DTD (Pumpkin).            -->
+<!--                    If you are not using Authoring (Pumpkin),   -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    The following modules are used for ALL of   -->
+<!--                    the Article Authoring DTDs (Pumpkin)        -->
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Classes Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-classes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Mixes Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-mixes1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD Over-ride Content and Attribute Module v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-models1.ent"/>
+
+  <public publicId= "-//NLM//DTD JATS (Z39.96) Article Authoring DTD-Specific Modules v1.1 20151215//EN"
+               uri="JATS-articleauthcustom-modules1.ent"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 2.0   -->
+           
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.1 20151215//EN"
+               uri="JATS-articleauthoring1.dtd"/>
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    the Article Authoring DTDs (Pumpkin) that   -->
+<!--                    use the XHTML table model with MathML 3.0   -->
+            
+  <public publicId="-//NLM//DTD JATS (Z39.96) Article Authoring DTD v1.1 20151215//EN"
+               uri="JATS-articleauthoring1-mathml3.dtd"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    JATS DTD SUITE                              -->
+<!--                    MODULAR LIBRARY                             -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!--                    MODULE OF MODULES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Module of Modules v1.1 20151215//EN"
+               uri="JATS-modules1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS MathML 3.0 Modules v1.1 20151215//EN"
+               uri="JATS-mathml3-modules1.ent"/>
+
+
+<!--                    CLASSES AND MIXES                           -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Classes Module v1.1 20151215//EN"
+               uri="JATS-default-classes1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Default Element Mixes Module v1.1 20151215//EN"
+               uri="JATS-default-mixes1.ent"/>
+
+
+<!--                    ELEMENT COMMON (SHARED) ELEMENTS/CHARACTERS -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common (Shared) Elements Module v1.1 20151215//EN"
+               uri="JATS-common1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Common Attributes (for all elements) v1.1 20151215//EN"
+               uri="JATS-common-atts1.ent"/>               
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Notation Declarations v1.1 20151215//EN"
+               uri="JATS-notat1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XML Special Characters Module v1.1 20151215//EN"
+               uri="JATS-xmlspecchars1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Custom Special Characters Module v1.1 20151215//EN"
+               uri="JATS-chars1.ent"/>
+
+
+<!--                    CLASS MODULES                               -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Article Metadata Elements v1.1 20151215//EN"
+               uri="JATS-articlemeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Back Matter Elements v1.1 20151215//EN"
+               uri="JATS-backmatter1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Display Class Elements v1.1 20151215//EN"
+               uri="JATS-display1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Formatting Element Classes v1.1 20151215//EN"
+               uri="JATS-format1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Funding Elements v1.1 20151215//EN"
+               uri="JATS-funding1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Journal Metadata Elements v1.1 20151215//EN"
+               uri="JATS-journalmeta1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Link Class Elements v1.1 20151215//EN"
+               uri="JATS-link1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite List Class Elements v1.1 20151215//EN"
+               uri="JATS-list1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Math Class Elements v1.1 20151215//EN"
+               uri="JATS-math1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) NLM Citation v1.1 20151215//EN"
+               uri="JATS-nlmcitation1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Paragraph-Like Elements v1.1 20151215//EN"
+               uri="JATS-para1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Subject Phrase Class Elements v1.1 20151215//EN"
+               uri="JATS-phrase1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Bibliographic Reference (Citation) Class Elements v1.1 20151215//EN"
+               uri="JATS-references1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Related Object Element v1.1 20151215//EN"
+               uri="JATS-related-object1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite Section Class Elements v1.1 20151215//EN"
+               uri="JATS-section1.ent"/>
+
+
+<!--                    SET UP XHTML TABLES (OASIS below)          -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite XHTML Table Setup Module v1.1 20151215//EN"
+               uri="JATS-XHTMLtablesetup1.ent"/>
+
+<!--                    SET UP MATHML                              -->
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML Setup Module v1.1 20151215//EN"
+               uri="JATS-mathmlsetup1.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) JATS DTD Suite MathML 3.0 Setup Module v1.1 20151215//EN"
+               uri="JATS-mathml3-mathmlsetup1.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    COMMONLY-USED PUBLIC MODELS AND PUBLIC      -->
+<!--                    CHARACTER-ENTITY SETS USED IN THE SUITE     -->
+<!--                    The following group is used by all of       -->
+<!--                    the JATS DTDS.                              -->
+<!--                    DO NOT DELETE OR COMMENT OUT THIS GROUP!    -->
+<!-- ============================================================== -->
+
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+
+<!-- .............................................................. -->
+<!--                    NISO ACCESS AND INDICATOR NAMESPACE         -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS ALI Namespace Module v1.1 20151215//EN"
+               uri="JATS-ali-namespace1.ent"/>
+
+<!-- .............................................................. -->
+<!--                    TABLES: XHTML TABLE MODULES                 -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+               uri="xhtml-table-1.mod"/>
+
+  <public publicId="-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+               uri="xhtml-inlstyle-1.mod"/>
+
+
+<!-- .............................................................. -->
+<!--                    TABLES: OASIS EXCHANGE TABLE MODULES        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//NLM//DTD JATS OASIS Table Namespace Module v1.1 20151215//EN"
+               uri="JATS-oasis-namespace1.ent"/>
+
+  <public publicId="-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+               uri="oasis-exchange.ent"/>
+
+  <public publicId="-//NLM//DTD JATS (Z39.96) Namespaced OASIS XML Table Setup Module v1.1 20151215//EN"
+               uri="JATS-oasis-tablesetup1.ent"/>
+ 
+
+<!-- .............................................................. -->
+<!--                    MATHML MODULES                              -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//DTD MathML 2.0//EN"
+               uri="mathml2.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+               uri="mathml2-qname-1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 2.0//EN"
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+  <public publicId="-//W3C//DTD MathML 3.0//EN"
+               uri="mathml3.dtd"/>
+  <public publicId="-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN" 
+               uri="mathml3-qname1.mod"/>
+  <public publicId="-//W3C//ENTITIES Extra for MathML 3.0//EN" 
+               uri="mathml/mmlextra.ent"/>
+  <public publicId="-//W3C//ENTITIES Aliases for MathML 3.0//EN"
+               uri="mathml/mmlalias.ent"/>
+
+
+<!-- .............................................................. -->
+<!--                    ISO 8879 ENTITIES                           -->
+<!-- .............................................................. -->
+
+
+  <public publicId="-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+               uri="iso8879/isobox.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+               uri="iso8879/isocyr2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+               uri="iso8879/isodia.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+               uri="iso8879/isolat1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+               uri="iso8879/isolat2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+               uri="iso8879/isonum.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+               uri="iso8879/isopub.ent"/>
+
+<!-- .............................................................. -->
+<!--                    ISO 9573-11 ENTITIES                        -->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+               uri="iso9573-13/isotech.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+               uri="iso9573-13/isogrk3.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+               uri="iso9573-13/isomscr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsa.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+               uri="iso9573-13/isoamsb.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+               uri="iso9573-13/isoamsc.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsn.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+               uri="iso9573-13/isoamso.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+               uri="iso9573-13/isoamsr.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+               uri="iso9573-13/isomfrk.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+               uri="iso9573-13/isomopf.ent"/>
+
+<!-- .............................................................. -->
+<!--                    NON-MATHML ENTITIES(backwards compatibility)-->
+<!-- .............................................................. -->
+
+  <public publicId="-//W3C//ENTITIES Greek Letters//EN"
+               uri="xmlchars/isogrk1.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Monotoniko Greek//EN"
+               uri="xmlchars/isogrk2.ent"/>
+
+  <public publicId="-//W3C//ENTITIES Alternative Greek Symbols//EN"
+               uri="xmlchars/isogrk4.ent"/>
+
+</group>
+
+
+<!-- ============================================================== -->
+<!--                    BITS BOOK INTERCHANGE DTD                   -->
+<!--                    The following modules are used only for NLM -->
+<!--                    BITS (Book Interchange Tag Suite)[Chocolate]-->
+<!--                                                                -->
+<!--                    If you are not using BITS (Chocolate), you  -->
+<!--                    may delete the group below, or leave it     -->
+<!--                    here as these public definitions do no harm.-->
+<!-- ============================================================== -->
+<group prefer="public" 
+       xml:base="put a real base here, such as 'file:///C:/MyWork/OurTasks/DTDs-for-JATS/'">
+   
+<!--                    The following modules are used for all of   -->
+<!--                    the BITS DTDs (Chocolate)                   -->
+<!--                    that use ONLY the XHTML-based Table Model   -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD v2.0 20151225//EN"
+               uri="BITS-book2.dtd"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules v2.0 20151225//EN" 
+               uri="BITS-bookcustom-modules2.ent"/>
+ 
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Classes Module v2.0 20151225//EN" 
+               uri="BITS-bookcustom-classes2.ent"/>
+              
+  <public publicId="-//NLM//DTD BITS Book Part Wrapper v2.0 20151225//EN" 
+               uri="BITS-book-part-wrap2.ent" /> 
+
+<!--                    The following modules are used ONLY for the -->
+<!--                    BITS DTDs that -->
+<!--                    use the OASIS table model (namespace prefix -->
+<!--                    "oasis") and the XHTML table model          -->
+             
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables v2.0 20151225//EN"
+               uri="BITS-book-oasis2.dtd" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD-Specific Modules with OASIS and XHTML Tables v2.0 20151225//EN"
+               uri="BITS-book-oasis-custom-modules2.ent" />
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD with OASIS and XHTML Tables Customize Classes Module v2.0 20151225//EN"
+               uri="BITS-book-oasis-custom-classes2.ent" />
+               
+  <public publicId="-//NLM//DTD BITS Book Part OASIS and XTHML Tables Wrapper v2.0 20151225//EN"  
+               uri="BITS-book-part-oasis-wrap2.ent" /> 
+              
+<!--                    The following modules are used for ALL of   -->
+<!--                    the BITS DTDs (Chocolate)                 -->
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Mixes Module v2.0 20151225//EN"
+               uri="BITS-bookcustom-mixes2.ent"/>
+
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Customize Content and Attributes Module v2.0 20151225//EN" 
+               uri="BITS-bookcustom-models2.ent"/>
+
+
+               
+  <public publicId="-//NLM//DTD BITS Add Attributes Module v2.0 20151225//EN"  
+               uri="BITS-add-attributes2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Book Metadata Elements Module v2.0 20151225//EN"  
+               uri="BITS-bookmeta2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Book Component Elements v2.0 20151225//EN"  
+               uri="BITS-book-part2.ent"/> 
+                
+  <public publicId="-//NLM//DTD BITS Book Interchange DTD Common Module v2.0 20151225//EN" 
+               uri="BITS-common2.ent" /> 
+ 
+  <public publicId="-//NLM//DTD BITS Embedded Index Element Module v2.0 20151225//EN"
+               uri="BITS-embedded-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Index Elements Module v2.0 20151225//EN" 
+               uri="BITS-index2.ent"/> 
+
+  <public publicId="-//NLM//DTD BITS Structural Table of Contents Module v2.0 20151225//EN"
+               uri="BITS-toc2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS Question and Answer Module v2.0 20151225//EN"  
+               uri="BITS-question-answer2.ent"  /> 
+
+  <public publicId="-//NLM//DTD BITS Table of Contents and Index Navigation Module v2.0 20151225//EN"
+               uri="BITS-toc-index-nav2.ent"/> 
+               
+  <public publicId="-//NLM//DTD BITS XInclude Setup Module v2.0 20151225//EN" 
+               uri="BITS-xinclude2.ent" /> 
+ 
+</group>
+
+<!-- ================ End WITH Base OASIS XML CATALOG ============= -->
+
+</catalog>

--- a/publishing/1.1/iso8879/isobox.ent
+++ b/publishing/1.1/iso8879/isobox.ent
@@ -1,0 +1,61 @@
+
+<!--
+     File isobox.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY boxDL            "&#x02557;" ><!--lower left quadrant -->
+<!ENTITY boxDl            "&#x02556;" ><!--lower left quadrant -->
+<!ENTITY boxdL            "&#x02555;" ><!--lower left quadrant -->
+<!ENTITY boxdl            "&#x02510;" ><!--lower left quadrant -->
+<!ENTITY boxDR            "&#x02554;" ><!--lower right quadrant -->
+<!ENTITY boxDr            "&#x02553;" ><!--lower right quadrant -->
+<!ENTITY boxdR            "&#x02552;" ><!--lower right quadrant -->
+<!ENTITY boxdr            "&#x0250C;" ><!--lower right quadrant -->
+<!ENTITY boxH             "&#x02550;" ><!--horizontal line -->
+<!ENTITY boxh             "&#x02500;" ><!--horizontal line  -->
+<!ENTITY boxHD            "&#x02566;" ><!--lower left and right quadrants -->
+<!ENTITY boxHd            "&#x02564;" ><!--lower left and right quadrants -->
+<!ENTITY boxhD            "&#x02565;" ><!--lower left and right quadrants -->
+<!ENTITY boxhd            "&#x0252C;" ><!--lower left and right quadrants -->
+<!ENTITY boxHU            "&#x02569;" ><!--upper left and right quadrants -->
+<!ENTITY boxHu            "&#x02567;" ><!--upper left and right quadrants -->
+<!ENTITY boxhU            "&#x02568;" ><!--upper left and right quadrants -->
+<!ENTITY boxhu            "&#x02534;" ><!--upper left and right quadrants -->
+<!ENTITY boxUL            "&#x0255D;" ><!--upper left quadrant -->
+<!ENTITY boxUl            "&#x0255C;" ><!--upper left quadrant -->
+<!ENTITY boxuL            "&#x0255B;" ><!--upper left quadrant -->
+<!ENTITY boxul            "&#x02518;" ><!--upper left quadrant -->
+<!ENTITY boxUR            "&#x0255A;" ><!--upper right quadrant -->
+<!ENTITY boxUr            "&#x02559;" ><!--upper right quadrant -->
+<!ENTITY boxuR            "&#x02558;" ><!--upper right quadrant -->
+<!ENTITY boxur            "&#x02514;" ><!--upper right quadrant -->
+<!ENTITY boxV             "&#x02551;" ><!--vertical line -->
+<!ENTITY boxv             "&#x02502;" ><!--vertical line -->
+<!ENTITY boxVH            "&#x0256C;" ><!--all four quadrants -->
+<!ENTITY boxVh            "&#x0256B;" ><!--all four quadrants -->
+<!ENTITY boxvH            "&#x0256A;" ><!--all four quadrants -->
+<!ENTITY boxvh            "&#x0253C;" ><!--all four quadrants -->
+<!ENTITY boxVL            "&#x02563;" ><!--upper and lower left quadrants -->
+<!ENTITY boxVl            "&#x02562;" ><!--upper and lower left quadrants -->
+<!ENTITY boxvL            "&#x02561;" ><!--upper and lower left quadrants -->
+<!ENTITY boxvl            "&#x02524;" ><!--upper and lower left quadrants -->
+<!ENTITY boxVR            "&#x02560;" ><!--upper and lower right quadrants -->
+<!ENTITY boxVr            "&#x0255F;" ><!--upper and lower right quadrants -->
+<!ENTITY boxvR            "&#x0255E;" ><!--upper and lower right quadrants -->
+<!ENTITY boxvr            "&#x0251C;" ><!--upper and lower right quadrants -->

--- a/publishing/1.1/iso8879/isocyr1.ent
+++ b/publishing/1.1/iso8879/isocyr1.ent
@@ -1,0 +1,88 @@
+
+<!--
+     File isocyr1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Acy              "&#x00410;" ><!--=capital A, Cyrillic -->
+<!ENTITY acy              "&#x00430;" ><!--=small a, Cyrillic -->
+<!ENTITY Bcy              "&#x00411;" ><!--=capital BE, Cyrillic -->
+<!ENTITY bcy              "&#x00431;" ><!--=small be, Cyrillic -->
+<!ENTITY CHcy             "&#x00427;" ><!--=capital CHE, Cyrillic -->
+<!ENTITY chcy             "&#x00447;" ><!--=small che, Cyrillic -->
+<!ENTITY Dcy              "&#x00414;" ><!--=capital DE, Cyrillic -->
+<!ENTITY dcy              "&#x00434;" ><!--=small de, Cyrillic -->
+<!ENTITY Ecy              "&#x0042D;" ><!--=capital E, Cyrillic -->
+<!ENTITY ecy              "&#x0044D;" ><!--=small e, Cyrillic -->
+<!ENTITY Fcy              "&#x00424;" ><!--=capital EF, Cyrillic -->
+<!ENTITY fcy              "&#x00444;" ><!--=small ef, Cyrillic -->
+<!ENTITY Gcy              "&#x00413;" ><!--=capital GHE, Cyrillic -->
+<!ENTITY gcy              "&#x00433;" ><!--=small ghe, Cyrillic -->
+<!ENTITY HARDcy           "&#x0042A;" ><!--=capital HARD sign, Cyrillic -->
+<!ENTITY hardcy           "&#x0044A;" ><!--=small hard sign, Cyrillic -->
+<!ENTITY Icy              "&#x00418;" ><!--=capital I, Cyrillic -->
+<!ENTITY icy              "&#x00438;" ><!--=small i, Cyrillic -->
+<!ENTITY IEcy             "&#x00415;" ><!--=capital IE, Cyrillic -->
+<!ENTITY iecy             "&#x00435;" ><!--=small ie, Cyrillic -->
+<!ENTITY IOcy             "&#x00401;" ><!--=capital IO, Russian -->
+<!ENTITY iocy             "&#x00451;" ><!--=small io, Russian -->
+<!ENTITY Jcy              "&#x00419;" ><!--=capital short I, Cyrillic -->
+<!ENTITY jcy              "&#x00439;" ><!--=small short i, Cyrillic -->
+<!ENTITY Kcy              "&#x0041A;" ><!--=capital KA, Cyrillic -->
+<!ENTITY kcy              "&#x0043A;" ><!--=small ka, Cyrillic -->
+<!ENTITY KHcy             "&#x00425;" ><!--=capital HA, Cyrillic -->
+<!ENTITY khcy             "&#x00445;" ><!--=small ha, Cyrillic -->
+<!ENTITY Lcy              "&#x0041B;" ><!--=capital EL, Cyrillic -->
+<!ENTITY lcy              "&#x0043B;" ><!--=small el, Cyrillic -->
+<!ENTITY Mcy              "&#x0041C;" ><!--=capital EM, Cyrillic -->
+<!ENTITY mcy              "&#x0043C;" ><!--=small em, Cyrillic -->
+<!ENTITY Ncy              "&#x0041D;" ><!--=capital EN, Cyrillic -->
+<!ENTITY ncy              "&#x0043D;" ><!--=small en, Cyrillic -->
+<!ENTITY numero           "&#x02116;" ><!--=numero sign -->
+<!ENTITY Ocy              "&#x0041E;" ><!--=capital O, Cyrillic -->
+<!ENTITY ocy              "&#x0043E;" ><!--=small o, Cyrillic -->
+<!ENTITY Pcy              "&#x0041F;" ><!--=capital PE, Cyrillic -->
+<!ENTITY pcy              "&#x0043F;" ><!--=small pe, Cyrillic -->
+<!ENTITY Rcy              "&#x00420;" ><!--=capital ER, Cyrillic -->
+<!ENTITY rcy              "&#x00440;" ><!--=small er, Cyrillic -->
+<!ENTITY Scy              "&#x00421;" ><!--=capital ES, Cyrillic -->
+<!ENTITY scy              "&#x00441;" ><!--=small es, Cyrillic -->
+<!ENTITY SHCHcy           "&#x00429;" ><!--=capital SHCHA, Cyrillic -->
+<!ENTITY shchcy           "&#x00449;" ><!--=small shcha, Cyrillic -->
+<!ENTITY SHcy             "&#x00428;" ><!--=capital SHA, Cyrillic -->
+<!ENTITY shcy             "&#x00448;" ><!--=small sha, Cyrillic -->
+<!ENTITY SOFTcy           "&#x0042C;" ><!--=capital SOFT sign, Cyrillic -->
+<!ENTITY softcy           "&#x0044C;" ><!--=small soft sign, Cyrillic -->
+<!ENTITY Tcy              "&#x00422;" ><!--=capital TE, Cyrillic -->
+<!ENTITY tcy              "&#x00442;" ><!--=small te, Cyrillic -->
+<!ENTITY TScy             "&#x00426;" ><!--=capital TSE, Cyrillic -->
+<!ENTITY tscy             "&#x00446;" ><!--=small tse, Cyrillic -->
+<!ENTITY Ucy              "&#x00423;" ><!--=capital U, Cyrillic -->
+<!ENTITY ucy              "&#x00443;" ><!--=small u, Cyrillic -->
+<!ENTITY Vcy              "&#x00412;" ><!--=capital VE, Cyrillic -->
+<!ENTITY vcy              "&#x00432;" ><!--=small ve, Cyrillic -->
+<!ENTITY YAcy             "&#x0042F;" ><!--=capital YA, Cyrillic -->
+<!ENTITY yacy             "&#x0044F;" ><!--=small ya, Cyrillic -->
+<!ENTITY Ycy              "&#x0042B;" ><!--=capital YERU, Cyrillic -->
+<!ENTITY ycy              "&#x0044B;" ><!--=small yeru, Cyrillic -->
+<!ENTITY YUcy             "&#x0042E;" ><!--=capital YU, Cyrillic -->
+<!ENTITY yucy             "&#x0044E;" ><!--=small yu, Cyrillic -->
+<!ENTITY Zcy              "&#x00417;" ><!--=capital ZE, Cyrillic -->
+<!ENTITY zcy              "&#x00437;" ><!--=small ze, Cyrillic -->
+<!ENTITY ZHcy             "&#x00416;" ><!--=capital ZHE, Cyrillic -->
+<!ENTITY zhcy             "&#x00436;" ><!--=small zhe, Cyrillic -->

--- a/publishing/1.1/iso8879/isocyr2.ent
+++ b/publishing/1.1/iso8879/isocyr2.ent
@@ -1,0 +1,47 @@
+
+<!--
+     File isocyr2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY DJcy             "&#x00402;" ><!--=capital DJE, Serbian -->
+<!ENTITY djcy             "&#x00452;" ><!--=small dje, Serbian -->
+<!ENTITY DScy             "&#x00405;" ><!--=capital DSE, Macedonian -->
+<!ENTITY dscy             "&#x00455;" ><!--=small dse, Macedonian -->
+<!ENTITY DZcy             "&#x0040F;" ><!--=capital dze, Serbian -->
+<!ENTITY dzcy             "&#x0045F;" ><!--=small dze, Serbian -->
+<!ENTITY GJcy             "&#x00403;" ><!--=capital GJE Macedonian -->
+<!ENTITY gjcy             "&#x00453;" ><!--=small gje, Macedonian -->
+<!ENTITY Iukcy            "&#x00406;" ><!--=capital I, Ukrainian -->
+<!ENTITY iukcy            "&#x00456;" ><!--=small i, Ukrainian -->
+<!ENTITY Jsercy           "&#x00408;" ><!--=capital JE, Serbian -->
+<!ENTITY jsercy           "&#x00458;" ><!--=small je, Serbian -->
+<!ENTITY Jukcy            "&#x00404;" ><!--=capital JE, Ukrainian -->
+<!ENTITY jukcy            "&#x00454;" ><!--=small je, Ukrainian -->
+<!ENTITY KJcy             "&#x0040C;" ><!--=capital KJE, Macedonian -->
+<!ENTITY kjcy             "&#x0045C;" ><!--=small kje Macedonian -->
+<!ENTITY LJcy             "&#x00409;" ><!--=capital LJE, Serbian -->
+<!ENTITY ljcy             "&#x00459;" ><!--=small lje, Serbian -->
+<!ENTITY NJcy             "&#x0040A;" ><!--=capital NJE, Serbian -->
+<!ENTITY njcy             "&#x0045A;" ><!--=small nje, Serbian -->
+<!ENTITY TSHcy            "&#x0040B;" ><!--=capital TSHE, Serbian -->
+<!ENTITY tshcy            "&#x0045B;" ><!--=small tshe, Serbian -->
+<!ENTITY Ubrcy            "&#x0040E;" ><!--=capital U, Byelorussian -->
+<!ENTITY ubrcy            "&#x0045E;" ><!--=small u, Byelorussian -->
+<!ENTITY YIcy             "&#x00407;" ><!--=capital YI, Ukrainian -->
+<!ENTITY yicy             "&#x00457;" ><!--=small yi, Ukrainian -->

--- a/publishing/1.1/iso8879/isodia.ent
+++ b/publishing/1.1/iso8879/isodia.ent
@@ -1,0 +1,35 @@
+
+<!--
+     File isodia.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY acute            "&#x000B4;" ><!--=acute accent -->
+<!ENTITY breve            "&#x002D8;" ><!--=breve -->
+<!ENTITY caron            "&#x002C7;" ><!--=caron -->
+<!ENTITY cedil            "&#x000B8;" ><!--=cedilla -->
+<!ENTITY circ             "&#x002C6;" ><!--circumflex accent -->
+<!ENTITY dblac            "&#x002DD;" ><!--=double acute accent -->
+<!ENTITY die              "&#x000A8;" ><!--=dieresis -->
+<!ENTITY dot              "&#x002D9;" ><!--=dot above -->
+<!ENTITY grave            "&#x00060;" ><!--=grave accent -->
+<!ENTITY macr             "&#x000AF;" ><!--=macron -->
+<!ENTITY ogon             "&#x002DB;" ><!--=ogonek -->
+<!ENTITY ring             "&#x002DA;" ><!--=ring -->
+<!ENTITY tilde            "&#x002DC;" ><!--=tilde -->
+<!ENTITY uml              "&#x000A8;" ><!--=umlaut mark -->

--- a/publishing/1.1/iso8879/isolat1.ent
+++ b/publishing/1.1/iso8879/isolat1.ent
@@ -1,0 +1,83 @@
+
+<!--
+     File isolat1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Aacute           "&#x000C1;" ><!--=capital A, acute accent -->
+<!ENTITY aacute           "&#x000E1;" ><!--=small a, acute accent -->
+<!ENTITY Acirc            "&#x000C2;" ><!--=capital A, circumflex accent -->
+<!ENTITY acirc            "&#x000E2;" ><!--=small a, circumflex accent -->
+<!ENTITY AElig            "&#x000C6;" ><!--=capital AE diphthong (ligature) -->
+<!ENTITY aelig            "&#x000E6;" ><!--=small ae diphthong (ligature) -->
+<!ENTITY Agrave           "&#x000C0;" ><!--=capital A, grave accent -->
+<!ENTITY agrave           "&#x000E0;" ><!--=small a, grave accent -->
+<!ENTITY Aring            "&#x000C5;" ><!--=capital A, ring -->
+<!ENTITY aring            "&#x000E5;" ><!--=small a, ring -->
+<!ENTITY Atilde           "&#x000C3;" ><!--=capital A, tilde -->
+<!ENTITY atilde           "&#x000E3;" ><!--=small a, tilde -->
+<!ENTITY Auml             "&#x000C4;" ><!--=capital A, dieresis or umlaut mark -->
+<!ENTITY auml             "&#x000E4;" ><!--=small a, dieresis or umlaut mark -->
+<!ENTITY Ccedil           "&#x000C7;" ><!--=capital C, cedilla -->
+<!ENTITY ccedil           "&#x000E7;" ><!--=small c, cedilla -->
+<!ENTITY Eacute           "&#x000C9;" ><!--=capital E, acute accent -->
+<!ENTITY eacute           "&#x000E9;" ><!--=small e, acute accent -->
+<!ENTITY Ecirc            "&#x000CA;" ><!--=capital E, circumflex accent -->
+<!ENTITY ecirc            "&#x000EA;" ><!--=small e, circumflex accent -->
+<!ENTITY Egrave           "&#x000C8;" ><!--=capital E, grave accent -->
+<!ENTITY egrave           "&#x000E8;" ><!--=small e, grave accent -->
+<!ENTITY ETH              "&#x000D0;" ><!--=capital Eth, Icelandic -->
+<!ENTITY eth              "&#x000F0;" ><!--=small eth, Icelandic -->
+<!ENTITY Euml             "&#x000CB;" ><!--=capital E, dieresis or umlaut mark -->
+<!ENTITY euml             "&#x000EB;" ><!--=small e, dieresis or umlaut mark -->
+<!ENTITY Iacute           "&#x000CD;" ><!--=capital I, acute accent -->
+<!ENTITY iacute           "&#x000ED;" ><!--=small i, acute accent -->
+<!ENTITY Icirc            "&#x000CE;" ><!--=capital I, circumflex accent -->
+<!ENTITY icirc            "&#x000EE;" ><!--=small i, circumflex accent -->
+<!ENTITY Igrave           "&#x000CC;" ><!--=capital I, grave accent -->
+<!ENTITY igrave           "&#x000EC;" ><!--=small i, grave accent -->
+<!ENTITY Iuml             "&#x000CF;" ><!--=capital I, dieresis or umlaut mark -->
+<!ENTITY iuml             "&#x000EF;" ><!--=small i, dieresis or umlaut mark -->
+<!ENTITY Ntilde           "&#x000D1;" ><!--=capital N, tilde -->
+<!ENTITY ntilde           "&#x000F1;" ><!--=small n, tilde -->
+<!ENTITY Oacute           "&#x000D3;" ><!--=capital O, acute accent -->
+<!ENTITY oacute           "&#x000F3;" ><!--=small o, acute accent -->
+<!ENTITY Ocirc            "&#x000D4;" ><!--=capital O, circumflex accent -->
+<!ENTITY ocirc            "&#x000F4;" ><!--=small o, circumflex accent -->
+<!ENTITY Ograve           "&#x000D2;" ><!--=capital O, grave accent -->
+<!ENTITY ograve           "&#x000F2;" ><!--=small o, grave accent -->
+<!ENTITY Oslash           "&#x000D8;" ><!--=capital O, slash -->
+<!ENTITY oslash           "&#x000F8;" ><!--latin small letter o with stroke -->
+<!ENTITY Otilde           "&#x000D5;" ><!--=capital O, tilde -->
+<!ENTITY otilde           "&#x000F5;" ><!--=small o, tilde -->
+<!ENTITY Ouml             "&#x000D6;" ><!--=capital O, dieresis or umlaut mark -->
+<!ENTITY ouml             "&#x000F6;" ><!--=small o, dieresis or umlaut mark -->
+<!ENTITY szlig            "&#x000DF;" ><!--=small sharp s, German (sz ligature) -->
+<!ENTITY THORN            "&#x000DE;" ><!--=capital THORN, Icelandic -->
+<!ENTITY thorn            "&#x000FE;" ><!--=small thorn, Icelandic -->
+<!ENTITY Uacute           "&#x000DA;" ><!--=capital U, acute accent -->
+<!ENTITY uacute           "&#x000FA;" ><!--=small u, acute accent -->
+<!ENTITY Ucirc            "&#x000DB;" ><!--=capital U, circumflex accent -->
+<!ENTITY ucirc            "&#x000FB;" ><!--=small u, circumflex accent -->
+<!ENTITY Ugrave           "&#x000D9;" ><!--=capital U, grave accent -->
+<!ENTITY ugrave           "&#x000F9;" ><!--=small u, grave accent -->
+<!ENTITY Uuml             "&#x000DC;" ><!--=capital U, dieresis or umlaut mark -->
+<!ENTITY uuml             "&#x000FC;" ><!--=small u, dieresis or umlaut mark -->
+<!ENTITY Yacute           "&#x000DD;" ><!--=capital Y, acute accent -->
+<!ENTITY yacute           "&#x000FD;" ><!--=small y, acute accent -->
+<!ENTITY yuml             "&#x000FF;" ><!--=small y, dieresis or umlaut mark -->

--- a/publishing/1.1/iso8879/isolat2.ent
+++ b/publishing/1.1/iso8879/isolat2.ent
@@ -1,0 +1,142 @@
+
+<!--
+     File isolat2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Abreve           "&#x00102;" ><!--=capital A, breve -->
+<!ENTITY abreve           "&#x00103;" ><!--=small a, breve -->
+<!ENTITY Amacr            "&#x00100;" ><!--=capital A, macron -->
+<!ENTITY amacr            "&#x00101;" ><!--=small a, macron -->
+<!ENTITY Aogon            "&#x00104;" ><!--=capital A, ogonek -->
+<!ENTITY aogon            "&#x00105;" ><!--=small a, ogonek -->
+<!ENTITY Cacute           "&#x00106;" ><!--=capital C, acute accent -->
+<!ENTITY cacute           "&#x00107;" ><!--=small c, acute accent -->
+<!ENTITY Ccaron           "&#x0010C;" ><!--=capital C, caron -->
+<!ENTITY ccaron           "&#x0010D;" ><!--=small c, caron -->
+<!ENTITY Ccirc            "&#x00108;" ><!--=capital C, circumflex accent -->
+<!ENTITY ccirc            "&#x00109;" ><!--=small c, circumflex accent -->
+<!ENTITY Cdot             "&#x0010A;" ><!--=capital C, dot above -->
+<!ENTITY cdot             "&#x0010B;" ><!--=small c, dot above -->
+<!ENTITY Dcaron           "&#x0010E;" ><!--=capital D, caron -->
+<!ENTITY dcaron           "&#x0010F;" ><!--=small d, caron -->
+<!ENTITY Dstrok           "&#x00110;" ><!--=capital D, stroke -->
+<!ENTITY dstrok           "&#x00111;" ><!--=small d, stroke -->
+<!ENTITY Ecaron           "&#x0011A;" ><!--=capital E, caron -->
+<!ENTITY ecaron           "&#x0011B;" ><!--=small e, caron -->
+<!ENTITY Edot             "&#x00116;" ><!--=capital E, dot above -->
+<!ENTITY edot             "&#x00117;" ><!--=small e, dot above -->
+<!ENTITY Emacr            "&#x00112;" ><!--=capital E, macron -->
+<!ENTITY emacr            "&#x00113;" ><!--=small e, macron -->
+<!ENTITY ENG              "&#x0014A;" ><!--=capital ENG, Lapp -->
+<!ENTITY eng              "&#x0014B;" ><!--=small eng, Lapp -->
+<!ENTITY Eogon            "&#x00118;" ><!--=capital E, ogonek -->
+<!ENTITY eogon            "&#x00119;" ><!--=small e, ogonek -->
+<!ENTITY gacute           "&#x001F5;" ><!--=small g, acute accent -->
+<!ENTITY Gbreve           "&#x0011E;" ><!--=capital G, breve -->
+<!ENTITY gbreve           "&#x0011F;" ><!--=small g, breve -->
+<!ENTITY Gcedil           "&#x00122;" ><!--=capital G, cedilla -->
+<!ENTITY Gcirc            "&#x0011C;" ><!--=capital G, circumflex accent -->
+<!ENTITY gcirc            "&#x0011D;" ><!--=small g, circumflex accent -->
+<!ENTITY Gdot             "&#x00120;" ><!--=capital G, dot above -->
+<!ENTITY gdot             "&#x00121;" ><!--=small g, dot above -->
+<!ENTITY Hcirc            "&#x00124;" ><!--=capital H, circumflex accent -->
+<!ENTITY hcirc            "&#x00125;" ><!--=small h, circumflex accent -->
+<!ENTITY Hstrok           "&#x00126;" ><!--=capital H, stroke -->
+<!ENTITY hstrok           "&#x00127;" ><!--=small h, stroke -->
+<!ENTITY Idot             "&#x00130;" ><!--=capital I, dot above -->
+<!ENTITY IJlig            "&#x00132;" ><!--=capital IJ ligature -->
+<!ENTITY ijlig            "&#x00133;" ><!--=small ij ligature -->
+<!ENTITY Imacr            "&#x0012A;" ><!--=capital I, macron -->
+<!ENTITY imacr            "&#x0012B;" ><!--=small i, macron -->
+<!ENTITY inodot           "&#x00131;" ><!--=small i without dot -->
+<!ENTITY Iogon            "&#x0012E;" ><!--=capital I, ogonek -->
+<!ENTITY iogon            "&#x0012F;" ><!--=small i, ogonek -->
+<!ENTITY Itilde           "&#x00128;" ><!--=capital I, tilde -->
+<!ENTITY itilde           "&#x00129;" ><!--=small i, tilde -->
+<!ENTITY Jcirc            "&#x00134;" ><!--=capital J, circumflex accent -->
+<!ENTITY jcirc            "&#x00135;" ><!--=small j, circumflex accent -->
+<!ENTITY Kcedil           "&#x00136;" ><!--=capital K, cedilla -->
+<!ENTITY kcedil           "&#x00137;" ><!--=small k, cedilla -->
+<!ENTITY kgreen           "&#x00138;" ><!--=small k, Greenlandic -->
+<!ENTITY Lacute           "&#x00139;" ><!--=capital L, acute accent -->
+<!ENTITY lacute           "&#x0013A;" ><!--=small l, acute accent -->
+<!ENTITY Lcaron           "&#x0013D;" ><!--=capital L, caron -->
+<!ENTITY lcaron           "&#x0013E;" ><!--=small l, caron -->
+<!ENTITY Lcedil           "&#x0013B;" ><!--=capital L, cedilla -->
+<!ENTITY lcedil           "&#x0013C;" ><!--=small l, cedilla -->
+<!ENTITY Lmidot           "&#x0013F;" ><!--=capital L, middle dot -->
+<!ENTITY lmidot           "&#x00140;" ><!--=small l, middle dot -->
+<!ENTITY Lstrok           "&#x00141;" ><!--=capital L, stroke -->
+<!ENTITY lstrok           "&#x00142;" ><!--=small l, stroke -->
+<!ENTITY Nacute           "&#x00143;" ><!--=capital N, acute accent -->
+<!ENTITY nacute           "&#x00144;" ><!--=small n, acute accent -->
+<!ENTITY napos            "&#x00149;" ><!--=small n, apostrophe -->
+<!ENTITY Ncaron           "&#x00147;" ><!--=capital N, caron -->
+<!ENTITY ncaron           "&#x00148;" ><!--=small n, caron -->
+<!ENTITY Ncedil           "&#x00145;" ><!--=capital N, cedilla -->
+<!ENTITY ncedil           "&#x00146;" ><!--=small n, cedilla -->
+<!ENTITY Odblac           "&#x00150;" ><!--=capital O, double acute accent -->
+<!ENTITY odblac           "&#x00151;" ><!--=small o, double acute accent -->
+<!ENTITY OElig            "&#x00152;" ><!--=capital OE ligature -->
+<!ENTITY oelig            "&#x00153;" ><!--=small oe ligature -->
+<!ENTITY Omacr            "&#x0014C;" ><!--=capital O, macron -->
+<!ENTITY omacr            "&#x0014D;" ><!--=small o, macron -->
+<!ENTITY Racute           "&#x00154;" ><!--=capital R, acute accent -->
+<!ENTITY racute           "&#x00155;" ><!--=small r, acute accent -->
+<!ENTITY Rcaron           "&#x00158;" ><!--=capital R, caron -->
+<!ENTITY rcaron           "&#x00159;" ><!--=small r, caron -->
+<!ENTITY Rcedil           "&#x00156;" ><!--=capital R, cedilla -->
+<!ENTITY rcedil           "&#x00157;" ><!--=small r, cedilla -->
+<!ENTITY Sacute           "&#x0015A;" ><!--=capital S, acute accent -->
+<!ENTITY sacute           "&#x0015B;" ><!--=small s, acute accent -->
+<!ENTITY Scaron           "&#x00160;" ><!--=capital S, caron -->
+<!ENTITY scaron           "&#x00161;" ><!--=small s, caron -->
+<!ENTITY Scedil           "&#x0015E;" ><!--=capital S, cedilla -->
+<!ENTITY scedil           "&#x0015F;" ><!--=small s, cedilla -->
+<!ENTITY Scirc            "&#x0015C;" ><!--=capital S, circumflex accent -->
+<!ENTITY scirc            "&#x0015D;" ><!--=small s, circumflex accent -->
+<!ENTITY Tcaron           "&#x00164;" ><!--=capital T, caron -->
+<!ENTITY tcaron           "&#x00165;" ><!--=small t, caron -->
+<!ENTITY Tcedil           "&#x00162;" ><!--=capital T, cedilla -->
+<!ENTITY tcedil           "&#x00163;" ><!--=small t, cedilla -->
+<!ENTITY Tstrok           "&#x00166;" ><!--=capital T, stroke -->
+<!ENTITY tstrok           "&#x00167;" ><!--=small t, stroke -->
+<!ENTITY Ubreve           "&#x0016C;" ><!--=capital U, breve -->
+<!ENTITY ubreve           "&#x0016D;" ><!--=small u, breve -->
+<!ENTITY Udblac           "&#x00170;" ><!--=capital U, double acute accent -->
+<!ENTITY udblac           "&#x00171;" ><!--=small u, double acute accent -->
+<!ENTITY Umacr            "&#x0016A;" ><!--=capital U, macron -->
+<!ENTITY umacr            "&#x0016B;" ><!--=small u, macron -->
+<!ENTITY Uogon            "&#x00172;" ><!--=capital U, ogonek -->
+<!ENTITY uogon            "&#x00173;" ><!--=small u, ogonek -->
+<!ENTITY Uring            "&#x0016E;" ><!--=capital U, ring -->
+<!ENTITY uring            "&#x0016F;" ><!--=small u, ring -->
+<!ENTITY Utilde           "&#x00168;" ><!--=capital U, tilde -->
+<!ENTITY utilde           "&#x00169;" ><!--=small u, tilde -->
+<!ENTITY Wcirc            "&#x00174;" ><!--=capital W, circumflex accent -->
+<!ENTITY wcirc            "&#x00175;" ><!--=small w, circumflex accent -->
+<!ENTITY Ycirc            "&#x00176;" ><!--=capital Y, circumflex accent -->
+<!ENTITY ycirc            "&#x00177;" ><!--=small y, circumflex accent -->
+<!ENTITY Yuml             "&#x00178;" ><!--=capital Y, dieresis or umlaut mark -->
+<!ENTITY Zacute           "&#x00179;" ><!--=capital Z, acute accent -->
+<!ENTITY zacute           "&#x0017A;" ><!--=small z, acute accent -->
+<!ENTITY Zcaron           "&#x0017D;" ><!--=capital Z, caron -->
+<!ENTITY zcaron           "&#x0017E;" ><!--=small z, caron -->
+<!ENTITY Zdot             "&#x0017B;" ><!--=capital Z, dot above -->
+<!ENTITY zdot             "&#x0017C;" ><!--=small z, dot above -->

--- a/publishing/1.1/iso8879/isonum.ent
+++ b/publishing/1.1/iso8879/isonum.ent
@@ -1,0 +1,97 @@
+
+<!--
+     File isonum.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY amp              "&#38;#38;" ><!--=ampersand -->
+<!ENTITY apos             "&#x00027;" ><!--=apostrophe -->
+<!ENTITY ast              "&#x0002A;" ><!--/ast B: =asterisk -->
+<!ENTITY brvbar           "&#x000A6;" ><!--=broken (vertical) bar -->
+<!ENTITY bsol             "&#x0005C;" ><!--/backslash =reverse solidus -->
+<!ENTITY cent             "&#x000A2;" ><!--=cent sign -->
+<!ENTITY colon            "&#x0003A;" ><!--/colon P: -->
+<!ENTITY comma            "&#x0002C;" ><!--P: =comma -->
+<!ENTITY commat           "&#x00040;" ><!--=commercial at -->
+<!ENTITY copy             "&#x000A9;" ><!--=copyright sign -->
+<!ENTITY curren           "&#x000A4;" ><!--=general currency sign -->
+<!ENTITY darr             "&#x02193;" ><!--/downarrow A: =downward arrow -->
+<!ENTITY deg              "&#x000B0;" ><!--=degree sign -->
+<!ENTITY divide           "&#x000F7;" ><!--/div B: =divide sign -->
+<!ENTITY dollar           "&#x00024;" ><!--=dollar sign -->
+<!ENTITY equals           "&#x0003D;" ><!--=equals sign R: -->
+<!ENTITY excl             "&#x00021;" ><!--=exclamation mark -->
+<!ENTITY frac12           "&#x000BD;" ><!--=fraction one-half -->
+<!ENTITY frac14           "&#x000BC;" ><!--=fraction one-quarter -->
+<!ENTITY frac18           "&#x0215B;" ><!--=fraction one-eighth -->
+<!ENTITY frac34           "&#x000BE;" ><!--=fraction three-quarters -->
+<!ENTITY frac38           "&#x0215C;" ><!--=fraction three-eighths -->
+<!ENTITY frac58           "&#x0215D;" ><!--=fraction five-eighths -->
+<!ENTITY frac78           "&#x0215E;" ><!--=fraction seven-eighths -->
+<!ENTITY gt               "&#x0003E;" ><!--=greater-than sign R: -->
+<!ENTITY half             "&#x000BD;" ><!--=fraction one-half -->
+<!ENTITY horbar           "&#x02015;" ><!--=horizontal bar -->
+<!ENTITY hyphen           "&#x02010;" ><!--=hyphen -->
+<!ENTITY iexcl            "&#x000A1;" ><!--=inverted exclamation mark -->
+<!ENTITY iquest           "&#x000BF;" ><!--=inverted question mark -->
+<!ENTITY laquo            "&#x000AB;" ><!--=angle quotation mark, left -->
+<!ENTITY larr             "&#x02190;" ><!--/leftarrow /gets A: =leftward arrow -->
+<!ENTITY lcub             "&#x0007B;" ><!--/lbrace O: =left curly bracket -->
+<!ENTITY ldquo            "&#x0201C;" ><!--=double quotation mark, left -->
+<!ENTITY lowbar           "&#x0005F;" ><!--=low line -->
+<!ENTITY lpar             "&#x00028;" ><!--O: =left parenthesis -->
+<!ENTITY lsqb             "&#x0005B;" ><!--/lbrack O: =left square bracket -->
+<!ENTITY lsquo            "&#x02018;" ><!--=single quotation mark, left -->
+<!ENTITY lt               "&#38;#60;" ><!--=less-than sign R: -->
+<!ENTITY micro            "&#x000B5;" ><!--=micro sign -->
+<!ENTITY middot           "&#x000B7;" ><!--/centerdot B: =middle dot -->
+<!ENTITY nbsp             "&#x000A0;" ><!--=no break (required) space -->
+<!ENTITY not              "&#x000AC;" ><!--/neg /lnot =not sign -->
+<!ENTITY num              "&#x00023;" ><!--=number sign -->
+<!ENTITY ohm              "&#x02126;" ><!--=ohm sign -->
+<!ENTITY ordf             "&#x000AA;" ><!--=ordinal indicator, feminine -->
+<!ENTITY ordm             "&#x000BA;" ><!--=ordinal indicator, masculine -->
+<!ENTITY para             "&#x000B6;" ><!--=pilcrow (paragraph sign) -->
+<!ENTITY percnt           "&#x00025;" ><!--=percent sign -->
+<!ENTITY period           "&#x0002E;" ><!--=full stop, period -->
+<!ENTITY plus             "&#x0002B;" ><!--=plus sign B: -->
+<!ENTITY plusmn           "&#x000B1;" ><!--/pm B: =plus-or-minus sign -->
+<!ENTITY pound            "&#x000A3;" ><!--=pound sign -->
+<!ENTITY quest            "&#x0003F;" ><!--=question mark -->
+<!ENTITY quot             "&#x00022;" ><!--=quotation mark -->
+<!ENTITY raquo            "&#x000BB;" ><!--=angle quotation mark, right -->
+<!ENTITY rarr             "&#x02192;" ><!--/rightarrow /to A: =rightward arrow -->
+<!ENTITY rcub             "&#x0007D;" ><!--/rbrace C: =right curly bracket -->
+<!ENTITY rdquo            "&#x0201D;" ><!--=double quotation mark, right -->
+<!ENTITY reg              "&#x000AE;" ><!--/circledR =registered sign -->
+<!ENTITY rpar             "&#x00029;" ><!--C: =right parenthesis -->
+<!ENTITY rsqb             "&#x0005D;" ><!--/rbrack C: =right square bracket -->
+<!ENTITY rsquo            "&#x02019;" ><!--=single quotation mark, right -->
+<!ENTITY sect             "&#x000A7;" ><!--=section sign -->
+<!ENTITY semi             "&#x0003B;" ><!--=semicolon P: -->
+<!ENTITY shy              "&#x000AD;" ><!--=soft hyphen -->
+<!ENTITY sol              "&#x0002F;" ><!--=solidus -->
+<!ENTITY sung             "&#x0266A;" ><!--=music note (sung text sign) -->
+<!ENTITY sup1             "&#x000B9;" ><!--=superscript one -->
+<!ENTITY sup2             "&#x000B2;" ><!--=superscript two -->
+<!ENTITY sup3             "&#x000B3;" ><!--=superscript three -->
+<!ENTITY times            "&#x000D7;" ><!--/times B: =multiply sign -->
+<!ENTITY trade            "&#x02122;" ><!--=trade mark sign -->
+<!ENTITY uarr             "&#x02191;" ><!--/uparrow A: =upward arrow -->
+<!ENTITY verbar           "&#x0007C;" ><!--/vert =vertical bar -->
+<!ENTITY yen              "&#x000A5;" ><!--/yen =yen sign -->

--- a/publishing/1.1/iso8879/isopub.ent
+++ b/publishing/1.1/iso8879/isopub.ent
@@ -1,0 +1,105 @@
+
+<!--
+     File isopub.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY blank            "&#x02423;" ><!--=significant blank symbol -->
+<!ENTITY blk12            "&#x02592;" ><!--=50% shaded block -->
+<!ENTITY blk14            "&#x02591;" ><!--=25% shaded block -->
+<!ENTITY blk34            "&#x02593;" ><!--=75% shaded block -->
+<!ENTITY block            "&#x02588;" ><!--=full block -->
+<!ENTITY bull             "&#x02022;" ><!--/bullet B: =round bullet, filled -->
+<!ENTITY caret            "&#x02041;" ><!--=caret (insertion mark) -->
+<!ENTITY check            "&#x02713;" ><!--/checkmark =tick, check mark -->
+<!ENTITY cir              "&#x025CB;" ><!--/circ B: =circle, open -->
+<!ENTITY clubs            "&#x02663;" ><!--/clubsuit =club suit symbol  -->
+<!ENTITY copysr           "&#x02117;" ><!--=sound recording copyright sign -->
+<!ENTITY cross            "&#x02717;" ><!--=ballot cross -->
+<!ENTITY Dagger           "&#x02021;" ><!--/ddagger B: =double dagger -->
+<!ENTITY dagger           "&#x02020;" ><!--/dagger B: =dagger -->
+<!ENTITY dash             "&#x02010;" ><!--=hyphen (true graphic) -->
+<!ENTITY diams            "&#x02666;" ><!--/diamondsuit =diamond suit symbol  -->
+<!ENTITY dlcrop           "&#x0230D;" ><!--downward left crop mark  -->
+<!ENTITY drcrop           "&#x0230C;" ><!--downward right crop mark  -->
+<!ENTITY dtri             "&#x025BF;" ><!--/triangledown =down triangle, open -->
+<!ENTITY dtrif            "&#x025BE;" ><!--/blacktriangledown =dn tri, filled -->
+<!ENTITY emsp             "&#x02003;" ><!--=em space -->
+<!ENTITY emsp13           "&#x02004;" ><!--=1/3-em space -->
+<!ENTITY emsp14           "&#x02005;" ><!--=1/4-em space -->
+<!ENTITY ensp             "&#x02002;" ><!--=en space (1/2-em) -->
+<!ENTITY female           "&#x02640;" ><!--=female symbol -->
+<!ENTITY ffilig           "&#x0FB03;" ><!--small ffi ligature -->
+<!ENTITY fflig            "&#x0FB00;" ><!--small ff ligature -->
+<!ENTITY ffllig           "&#x0FB04;" ><!--small ffl ligature -->
+<!ENTITY filig            "&#x0FB01;" ><!--small fi ligature -->
+<!ENTITY flat             "&#x0266D;" ><!--/flat =musical flat -->
+<!ENTITY fllig            "&#x0FB02;" ><!--small fl ligature -->
+<!ENTITY frac13           "&#x02153;" ><!--=fraction one-third -->
+<!ENTITY frac15           "&#x02155;" ><!--=fraction one-fifth -->
+<!ENTITY frac16           "&#x02159;" ><!--=fraction one-sixth -->
+<!ENTITY frac23           "&#x02154;" ><!--=fraction two-thirds -->
+<!ENTITY frac25           "&#x02156;" ><!--=fraction two-fifths -->
+<!ENTITY frac35           "&#x02157;" ><!--=fraction three-fifths -->
+<!ENTITY frac45           "&#x02158;" ><!--=fraction four-fifths -->
+<!ENTITY frac56           "&#x0215A;" ><!--=fraction five-sixths -->
+<!ENTITY hairsp           "&#x0200A;" ><!--=hair space -->
+<!ENTITY hearts           "&#x02665;" ><!--/heartsuit =heart suit symbol -->
+<!ENTITY hellip           "&#x02026;" ><!--=ellipsis (horizontal) -->
+<!ENTITY hybull           "&#x02043;" ><!--rectangle, filled (hyphen bullet) -->
+<!ENTITY incare           "&#x02105;" ><!--=in-care-of symbol -->
+<!ENTITY ldquor           "&#x0201E;" ><!--=rising dbl quote, left (low) -->
+<!ENTITY lhblk            "&#x02584;" ><!--=lower half block -->
+<!ENTITY loz              "&#x025CA;" ><!--/lozenge - lozenge or total mark -->
+<!ENTITY lozf             "&#x029EB;" ><!--/blacklozenge - lozenge, filled -->
+<!ENTITY lsquor           "&#x0201A;" ><!--=rising single quote, left (low) -->
+<!ENTITY ltri             "&#x025C3;" ><!--/triangleleft B: l triangle, open -->
+<!ENTITY ltrif            "&#x025C2;" ><!--/blacktriangleleft R: =l tri, filled -->
+<!ENTITY male             "&#x02642;" ><!--=male symbol -->
+<!ENTITY malt             "&#x02720;" ><!--/maltese =maltese cross -->
+<!ENTITY marker           "&#x025AE;" ><!--=histogram marker -->
+<!ENTITY mdash            "&#x02014;" ><!--=em dash  -->
+<!ENTITY mldr             "&#x02026;" ><!--em leader -->
+<!ENTITY natur            "&#x0266E;" ><!--/natural - music natural -->
+<!ENTITY ndash            "&#x02013;" ><!--=en dash -->
+<!ENTITY nldr             "&#x02025;" ><!--=double baseline dot (en leader) -->
+<!ENTITY numsp            "&#x02007;" ><!--=digit space (width of a number) -->
+<!ENTITY phone            "&#x0260E;" ><!--=telephone symbol  -->
+<!ENTITY puncsp           "&#x02008;" ><!--=punctuation space (width of comma) -->
+<!ENTITY rdquor           "&#x0201D;" ><!--rising dbl quote, right (high) -->
+<!ENTITY rect             "&#x025AD;" ><!--=rectangle, open -->
+<!ENTITY rsquor           "&#x02019;" ><!--rising single quote, right (high) -->
+<!ENTITY rtri             "&#x025B9;" ><!--/triangleright B: r triangle, open -->
+<!ENTITY rtrif            "&#x025B8;" ><!--/blacktriangleright R: =r tri, filled -->
+<!ENTITY rx               "&#x0211E;" ><!--pharmaceutical prescription (Rx) -->
+<!ENTITY sext             "&#x02736;" ><!--sextile (6-pointed star) -->
+<!ENTITY sharp            "&#x0266F;" ><!--/sharp =musical sharp -->
+<!ENTITY spades           "&#x02660;" ><!--/spadesuit =spades suit symbol  -->
+<!ENTITY squ              "&#x025A1;" ><!--=square, open -->
+<!ENTITY squf             "&#x025AA;" ><!--/blacksquare =sq bullet, filled -->
+<!ENTITY star             "&#x02606;" ><!--=star, open -->
+<!ENTITY starf            "&#x02605;" ><!--/bigstar - star, filled  -->
+<!ENTITY target           "&#x02316;" ><!--register mark or target -->
+<!ENTITY telrec           "&#x02315;" ><!--=telephone recorder symbol -->
+<!ENTITY thinsp           "&#x02009;" ><!--=thin space (1/6-em) -->
+<!ENTITY uhblk            "&#x02580;" ><!--=upper half block -->
+<!ENTITY ulcrop           "&#x0230F;" ><!--upward left crop mark  -->
+<!ENTITY urcrop           "&#x0230E;" ><!--upward right crop mark  -->
+<!ENTITY utri             "&#x025B5;" ><!--/triangle =up triangle, open -->
+<!ENTITY utrif            "&#x025B4;" ><!--/blacktriangle =up tri, filled -->
+<!ENTITY vellip           "&#x022EE;" ><!--vertical ellipsis -->

--- a/publishing/1.1/iso9573-13/isoamsa.ent
+++ b/publishing/1.1/iso9573-13/isoamsa.ent
@@ -1,0 +1,167 @@
+
+<!--
+     File isoamsa.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY angzarr          "&#x0237C;" ><!--angle with down zig-zag arrow -->
+<!ENTITY cirmid           "&#x02AEF;" ><!--circle, mid below -->
+<!ENTITY cudarrl          "&#x02938;" ><!--left, curved, down arrow -->
+<!ENTITY cudarrr          "&#x02935;" ><!--right, curved, down arrow -->
+<!ENTITY cularr           "&#x021B6;" ><!--/curvearrowleft A: left curved arrow -->
+<!ENTITY cularrp          "&#x0293D;" ><!--curved left arrow with plus -->
+<!ENTITY curarr           "&#x021B7;" ><!--/curvearrowright A: rt curved arrow -->
+<!ENTITY curarrm          "&#x0293C;" ><!--curved right arrow with minus -->
+<!ENTITY Darr             "&#x021A1;" ><!--down two-headed arrow -->
+<!ENTITY dArr             "&#x021D3;" ><!--/Downarrow A: down dbl arrow -->
+<!ENTITY ddarr            "&#x021CA;" ><!--/downdownarrows A: two down arrows -->
+<!ENTITY DDotrahd         "&#x02911;" ><!--right arrow with dotted stem -->
+<!ENTITY dfisht           "&#x0297F;" ><!--down fish tail -->
+<!ENTITY dHar             "&#x02965;" ><!--down harpoon-left, down harpoon-right -->
+<!ENTITY dharl            "&#x021C3;" ><!--/downharpoonleft A: dn harpoon-left -->
+<!ENTITY dharr            "&#x021C2;" ><!--/downharpoonright A: down harpoon-rt -->
+<!ENTITY duarr            "&#x021F5;" ><!--down arrow, up arrow -->
+<!ENTITY duhar            "&#x0296F;" ><!--down harp, up harp -->
+<!ENTITY dzigrarr         "&#x027FF;" ><!--right long zig-zag arrow -->
+<!ENTITY erarr            "&#x02971;" ><!--equal, right arrow below -->
+<!ENTITY hArr             "&#x021D4;" ><!--/Leftrightarrow A: l&r dbl arrow -->
+<!ENTITY harr             "&#x02194;" ><!--/leftrightarrow A: l&r arrow -->
+<!ENTITY harrcir          "&#x02948;" ><!--left and right arrow with a circle -->
+<!ENTITY harrw            "&#x021AD;" ><!--/leftrightsquigarrow A: l&r arr-wavy -->
+<!ENTITY hoarr            "&#x021FF;" ><!--horizontal open arrow -->
+<!ENTITY imof             "&#x022B7;" ><!--image of -->
+<!ENTITY lAarr            "&#x021DA;" ><!--/Lleftarrow A: left triple arrow -->
+<!ENTITY Larr             "&#x0219E;" ><!--/twoheadleftarrow A: -->
+<!ENTITY larrbfs          "&#x0291F;" ><!--left arrow-bar, filled square -->
+<!ENTITY larrfs           "&#x0291D;" ><!--left arrow, filled square -->
+<!ENTITY larrhk           "&#x021A9;" ><!--/hookleftarrow A: left arrow-hooked -->
+<!ENTITY larrlp           "&#x021AB;" ><!--/looparrowleft A: left arrow-looped -->
+<!ENTITY larrpl           "&#x02939;" ><!--left arrow, plus -->
+<!ENTITY larrsim          "&#x02973;" ><!--left arrow, similar -->
+<!ENTITY larrtl           "&#x021A2;" ><!--/leftarrowtail A: left arrow-tailed -->
+<!ENTITY lAtail           "&#x0291B;" ><!--left double arrow-tail -->
+<!ENTITY latail           "&#x02919;" ><!--left arrow-tail -->
+<!ENTITY lBarr            "&#x0290E;" ><!--left doubly broken arrow -->
+<!ENTITY lbarr            "&#x0290C;" ><!--left broken arrow -->
+<!ENTITY ldca             "&#x02936;" ><!--left down curved arrow -->
+<!ENTITY ldrdhar          "&#x02967;" ><!--left harpoon-down over right harpoon-down -->
+<!ENTITY ldrushar         "&#x0294B;" ><!--left-down-right-up harpoon -->
+<!ENTITY ldsh             "&#x021B2;" ><!--left down angled arrow -->
+<!ENTITY lfisht           "&#x0297C;" ><!--left fish tail -->
+<!ENTITY lHar             "&#x02962;" ><!--left harpoon-up over left harpoon-down -->
+<!ENTITY lhard            "&#x021BD;" ><!--/leftharpoondown A: l harpoon-down -->
+<!ENTITY lharu            "&#x021BC;" ><!--/leftharpoonup A: left harpoon-up -->
+<!ENTITY lharul           "&#x0296A;" ><!--left harpoon-up over long dash -->
+<!ENTITY llarr            "&#x021C7;" ><!--/leftleftarrows A: two left arrows -->
+<!ENTITY llhard           "&#x0296B;" ><!--left harpoon-down below long dash -->
+<!ENTITY loarr            "&#x021FD;" ><!--left open arrow -->
+<!ENTITY lrarr            "&#x021C6;" ><!--/leftrightarrows A: l arr over r arr -->
+<!ENTITY lrhar            "&#x021CB;" ><!--/leftrightharpoons A: l harp over r -->
+<!ENTITY lrhard           "&#x0296D;" ><!--right harpoon-down below long dash -->
+<!ENTITY lsh              "&#x021B0;" ><!--/Lsh A: -->
+<!ENTITY lurdshar         "&#x0294A;" ><!--left-up-right-down harpoon -->
+<!ENTITY luruhar          "&#x02966;" ><!--left harpoon-up over right harpoon-up -->
+<!ENTITY Map              "&#x02905;" ><!--twoheaded mapsto -->
+<!ENTITY map              "&#x021A6;" ><!--/mapsto A: -->
+<!ENTITY midcir           "&#x02AF0;" ><!--mid, circle below  -->
+<!ENTITY mumap            "&#x022B8;" ><!--/multimap A: -->
+<!ENTITY nearhk           "&#x02924;" ><!--NE arrow-hooked -->
+<!ENTITY neArr            "&#x021D7;" ><!--NE pointing dbl arrow -->
+<!ENTITY nearr            "&#x02197;" ><!--/nearrow A: NE pointing arrow -->
+<!ENTITY nesear           "&#x02928;" ><!--/toea A: NE & SE arrows -->
+<!ENTITY nhArr            "&#x021CE;" ><!--/nLeftrightarrow A: not l&r dbl arr -->
+<!ENTITY nharr            "&#x021AE;" ><!--/nleftrightarrow A: not l&r arrow -->
+<!ENTITY nlArr            "&#x021CD;" ><!--/nLeftarrow A: not implied by -->
+<!ENTITY nlarr            "&#x0219A;" ><!--/nleftarrow A: not left arrow -->
+<!ENTITY nrArr            "&#x021CF;" ><!--/nRightarrow A: not implies -->
+<!ENTITY nrarr            "&#x0219B;" ><!--/nrightarrow A: not right arrow -->
+<!ENTITY nrarrc           "&#x02933;&#x00338;" ><!--not right arrow-curved -->
+<!ENTITY nrarrw           "&#x0219D;&#x00338;" ><!--not right arrow-wavy -->
+<!ENTITY nvHarr           "&#x02904;" ><!--not, vert, left and right double arrow  -->
+<!ENTITY nvlArr           "&#x02902;" ><!--not, vert, left double arrow -->
+<!ENTITY nvrArr           "&#x02903;" ><!--not, vert, right double arrow -->
+<!ENTITY nwarhk           "&#x02923;" ><!--NW arrow-hooked -->
+<!ENTITY nwArr            "&#x021D6;" ><!--NW pointing dbl arrow -->
+<!ENTITY nwarr            "&#x02196;" ><!--/nwarrow A: NW pointing arrow -->
+<!ENTITY nwnear           "&#x02927;" ><!--NW & NE arrows -->
+<!ENTITY olarr            "&#x021BA;" ><!--/circlearrowleft A: l arr in circle -->
+<!ENTITY orarr            "&#x021BB;" ><!--/circlearrowright A: r arr in circle -->
+<!ENTITY origof           "&#x022B6;" ><!--original of -->
+<!ENTITY rAarr            "&#x021DB;" ><!--/Rrightarrow A: right triple arrow -->
+<!ENTITY Rarr             "&#x021A0;" ><!--/twoheadrightarrow A: -->
+<!ENTITY rarrap           "&#x02975;" ><!--approximate, right arrow above -->
+<!ENTITY rarrbfs          "&#x02920;" ><!--right arrow-bar, filled square -->
+<!ENTITY rarrc            "&#x02933;" ><!--right arrow-curved -->
+<!ENTITY rarrfs           "&#x0291E;" ><!--right arrow, filled square -->
+<!ENTITY rarrhk           "&#x021AA;" ><!--/hookrightarrow A: rt arrow-hooked -->
+<!ENTITY rarrlp           "&#x021AC;" ><!--/looparrowright A: rt arrow-looped -->
+<!ENTITY rarrpl           "&#x02945;" ><!--right arrow, plus -->
+<!ENTITY rarrsim          "&#x02974;" ><!--right arrow, similar -->
+<!ENTITY Rarrtl           "&#x02916;" ><!--right two-headed arrow with tail -->
+<!ENTITY rarrtl           "&#x021A3;" ><!--/rightarrowtail A: rt arrow-tailed -->
+<!ENTITY rarrw            "&#x0219D;" ><!--/rightsquigarrow A: rt arrow-wavy -->
+<!ENTITY rAtail           "&#x0291C;" ><!--right double arrow-tail -->
+<!ENTITY ratail           "&#x0291A;" ><!--right arrow-tail -->
+<!ENTITY RBarr            "&#x02910;" ><!--/drbkarow A: twoheaded right broken arrow -->
+<!ENTITY rBarr            "&#x0290F;" ><!--/dbkarow A: right doubly broken arrow -->
+<!ENTITY rbarr            "&#x0290D;" ><!--/bkarow A: right broken arrow -->
+<!ENTITY rdca             "&#x02937;" ><!--right down curved arrow -->
+<!ENTITY rdldhar          "&#x02969;" ><!--right harpoon-down over left harpoon-down -->
+<!ENTITY rdsh             "&#x021B3;" ><!--right down angled arrow -->
+<!ENTITY rfisht           "&#x0297D;" ><!--right fish tail -->
+<!ENTITY rHar             "&#x02964;" ><!--right harpoon-up over right harpoon-down -->
+<!ENTITY rhard            "&#x021C1;" ><!--/rightharpoondown A: rt harpoon-down -->
+<!ENTITY rharu            "&#x021C0;" ><!--/rightharpoonup A: rt harpoon-up -->
+<!ENTITY rharul           "&#x0296C;" ><!--right harpoon-up over long dash -->
+<!ENTITY rlarr            "&#x021C4;" ><!--/rightleftarrows A: r arr over l arr -->
+<!ENTITY rlhar            "&#x021CC;" ><!--/rightleftharpoons A: r harp over l -->
+<!ENTITY roarr            "&#x021FE;" ><!--right open arrow -->
+<!ENTITY rrarr            "&#x021C9;" ><!--/rightrightarrows A: two rt arrows -->
+<!ENTITY rsh              "&#x021B1;" ><!--/Rsh A: -->
+<!ENTITY ruluhar          "&#x02968;" ><!--right harpoon-up over left harpoon-up -->
+<!ENTITY searhk           "&#x02925;" ><!--/hksearow A: SE arrow-hooken -->
+<!ENTITY seArr            "&#x021D8;" ><!--SE pointing dbl arrow -->
+<!ENTITY searr            "&#x02198;" ><!--/searrow A: SE pointing arrow -->
+<!ENTITY seswar           "&#x02929;" ><!--/tosa A: SE & SW arrows -->
+<!ENTITY simrarr          "&#x02972;" ><!--similar, right arrow below -->
+<!ENTITY slarr            "&#x02190;" ><!--short left arrow -->
+<!ENTITY srarr            "&#x02192;" ><!--short right arrow -->
+<!ENTITY swarhk           "&#x02926;" ><!--/hkswarow A: SW arrow-hooked -->
+<!ENTITY swArr            "&#x021D9;" ><!--SW pointing dbl arrow -->
+<!ENTITY swarr            "&#x02199;" ><!--/swarrow A: SW pointing arrow -->
+<!ENTITY swnwar           "&#x0292A;" ><!--SW & NW arrows -->
+<!ENTITY Uarr             "&#x0219F;" ><!--up two-headed arrow -->
+<!ENTITY uArr             "&#x021D1;" ><!--/Uparrow A: up dbl arrow -->
+<!ENTITY Uarrocir         "&#x02949;" ><!--up two-headed arrow above circle -->
+<!ENTITY udarr            "&#x021C5;" ><!--up arrow, down arrow -->
+<!ENTITY udhar            "&#x0296E;" ><!--up harp, down harp -->
+<!ENTITY ufisht           "&#x0297E;" ><!--up fish tail -->
+<!ENTITY uHar             "&#x02963;" ><!--up harpoon-left, up harpoon-right -->
+<!ENTITY uharl            "&#x021BF;" ><!--/upharpoonleft A: up harpoon-left -->
+<!ENTITY uharr            "&#x021BE;" ><!--/upharpoonright /restriction A: up harp-r -->
+<!ENTITY uuarr            "&#x021C8;" ><!--/upuparrows A: two up arrows -->
+<!ENTITY vArr             "&#x021D5;" ><!--/Updownarrow A: up&down dbl arrow -->
+<!ENTITY varr             "&#x02195;" ><!--/updownarrow A: up&down arrow -->
+<!ENTITY xhArr            "&#x027FA;" ><!--/Longleftrightarrow A: long l&r dbl arr -->
+<!ENTITY xharr            "&#x027F7;" ><!--/longleftrightarrow A: long l&r arr -->
+<!ENTITY xlArr            "&#x027F8;" ><!--/Longleftarrow A: long l dbl arrow -->
+<!ENTITY xlarr            "&#x027F5;" ><!--/longleftarrow A: long left arrow -->
+<!ENTITY xmap             "&#x027FC;" ><!--/longmapsto A: -->
+<!ENTITY xrArr            "&#x027F9;" ><!--/Longrightarrow A: long rt dbl arr -->
+<!ENTITY xrarr            "&#x027F6;" ><!--/longrightarrow A: long right arrow -->
+<!ENTITY zigrarr          "&#x021DD;" ><!--right zig-zag arrow -->

--- a/publishing/1.1/iso9573-13/isoamsb.ent
+++ b/publishing/1.1/iso9573-13/isoamsb.ent
@@ -1,0 +1,143 @@
+
+<!--
+     File isoamsb.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY ac               "&#x0223E;" ><!--most positive -->
+<!ENTITY acE              "&#x0223E;&#x00333;" ><!--most positive, two lines below -->
+<!ENTITY amalg            "&#x02A3F;" ><!--/amalg B: amalgamation or coproduct -->
+<!ENTITY barvee           "&#x022BD;" ><!--bar, vee -->
+<!ENTITY Barwed           "&#x02306;" ><!--/doublebarwedge B: log and, dbl bar above -->
+<!ENTITY barwed           "&#x02305;" ><!--/barwedge B: logical and, bar above -->
+<!ENTITY bsolb            "&#x029C5;" ><!--reverse solidus in square -->
+<!ENTITY Cap              "&#x022D2;" ><!--/Cap /doublecap B: dbl intersection -->
+<!ENTITY capand           "&#x02A44;" ><!--intersection, and -->
+<!ENTITY capbrcup         "&#x02A49;" ><!--intersection, bar, union -->
+<!ENTITY capcap           "&#x02A4B;" ><!--intersection, intersection, joined -->
+<!ENTITY capcup           "&#x02A47;" ><!--intersection above union -->
+<!ENTITY capdot           "&#x02A40;" ><!--intersection, with dot -->
+<!ENTITY caps             "&#x02229;&#x0FE00;" ><!--intersection, serifs -->
+<!ENTITY ccaps            "&#x02A4D;" ><!--closed intersection, serifs -->
+<!ENTITY ccups            "&#x02A4C;" ><!--closed union, serifs -->
+<!ENTITY ccupssm          "&#x02A50;" ><!--closed union, serifs, smash product -->
+<!ENTITY coprod           "&#x02210;" ><!--/coprod L: coproduct operator -->
+<!ENTITY Cup              "&#x022D3;" ><!--/Cup /doublecup B: dbl union -->
+<!ENTITY cupbrcap         "&#x02A48;" ><!--union, bar, intersection -->
+<!ENTITY cupcap           "&#x02A46;" ><!--union above intersection -->
+<!ENTITY cupcup           "&#x02A4A;" ><!--union, union, joined -->
+<!ENTITY cupdot           "&#x0228D;" ><!--union, with dot -->
+<!ENTITY cupor            "&#x02A45;" ><!--union, or -->
+<!ENTITY cups             "&#x0222A;&#x0FE00;" ><!--union, serifs -->
+<!ENTITY cuvee            "&#x022CE;" ><!--/curlyvee B: curly logical or -->
+<!ENTITY cuwed            "&#x022CF;" ><!--/curlywedge B: curly logical and -->
+<!ENTITY Dagger           "&#x02021;" ><!--/ddagger B: double dagger relation -->
+<!ENTITY dagger           "&#x02020;" ><!--/dagger B: dagger relation -->
+<!ENTITY diam             "&#x022C4;" ><!--/diamond B: open diamond -->
+<!ENTITY divonx           "&#x022C7;" ><!--/divideontimes B: division on times -->
+<!ENTITY eplus            "&#x02A71;" ><!--equal, plus -->
+<!ENTITY hercon           "&#x022B9;" ><!--hermitian conjugate matrix -->
+<!ENTITY intcal           "&#x022BA;" ><!--/intercal B: intercal -->
+<!ENTITY iprod            "&#x02A3C;" ><!--/intprod -->
+<!ENTITY loplus           "&#x02A2D;" ><!--plus sign in left half circle -->
+<!ENTITY lotimes          "&#x02A34;" ><!--multiply sign in left half circle  -->
+<!ENTITY lthree           "&#x022CB;" ><!--/leftthreetimes B: -->
+<!ENTITY ltimes           "&#x022C9;" ><!--/ltimes B: times sign, left closed -->
+<!ENTITY midast           "&#x0002A;" ><!--/ast B: asterisk -->
+<!ENTITY minusb           "&#x0229F;" ><!--/boxminus B: minus sign in box -->
+<!ENTITY minusd           "&#x02238;" ><!--/dotminus B: minus sign, dot above -->
+<!ENTITY minusdu          "&#x02A2A;" ><!--minus sign, dot below -->
+<!ENTITY ncap             "&#x02A43;" ><!--bar, intersection -->
+<!ENTITY ncup             "&#x02A42;" ><!--bar, union -->
+<!ENTITY oast             "&#x0229B;" ><!--/circledast B: asterisk in circle -->
+<!ENTITY ocir             "&#x0229A;" ><!--/circledcirc B: small circle in circle -->
+<!ENTITY odash            "&#x0229D;" ><!--/circleddash B: hyphen in circle -->
+<!ENTITY odiv             "&#x02A38;" ><!--divide in circle -->
+<!ENTITY odot             "&#x02299;" ><!--/odot B: middle dot in circle -->
+<!ENTITY odsold           "&#x029BC;" ><!--dot, solidus, dot in circle -->
+<!ENTITY ofcir            "&#x029BF;" ><!--filled circle in circle -->
+<!ENTITY ogt              "&#x029C1;" ><!--greater-than in circle -->
+<!ENTITY ohbar            "&#x029B5;" ><!--circle with horizontal bar -->
+<!ENTITY olcir            "&#x029BE;" ><!--large circle in circle -->
+<!ENTITY olt              "&#x029C0;" ><!--less-than in circle -->
+<!ENTITY omid             "&#x029B6;" ><!--vertical bar in circle -->
+<!ENTITY ominus           "&#x02296;" ><!--/ominus B: minus sign in circle -->
+<!ENTITY opar             "&#x029B7;" ><!--parallel in circle -->
+<!ENTITY operp            "&#x029B9;" ><!--perpendicular in circle -->
+<!ENTITY oplus            "&#x02295;" ><!--/oplus B: plus sign in circle -->
+<!ENTITY osol             "&#x02298;" ><!--/oslash B: solidus in circle -->
+<!ENTITY Otimes           "&#x02A37;" ><!--multiply sign in double circle -->
+<!ENTITY otimes           "&#x02297;" ><!--/otimes B: multiply sign in circle -->
+<!ENTITY otimesas         "&#x02A36;" ><!--multiply sign in circle, circumflex accent -->
+<!ENTITY ovbar            "&#x0233D;" ><!--circle with vertical bar -->
+<!ENTITY plusacir         "&#x02A23;" ><!--plus, circumflex accent above -->
+<!ENTITY plusb            "&#x0229E;" ><!--/boxplus B: plus sign in box -->
+<!ENTITY pluscir          "&#x02A22;" ><!--plus, small circle above -->
+<!ENTITY plusdo           "&#x02214;" ><!--/dotplus B: plus sign, dot above -->
+<!ENTITY plusdu           "&#x02A25;" ><!--plus sign, dot below -->
+<!ENTITY pluse            "&#x02A72;" ><!--plus, equals -->
+<!ENTITY plussim          "&#x02A26;" ><!--plus, similar below -->
+<!ENTITY plustwo          "&#x02A27;" ><!--plus, two; Nim-addition -->
+<!ENTITY prod             "&#x0220F;" ><!--/prod L: product operator -->
+<!ENTITY race             "&#x029DA;" ><!--reverse most positive, line below -->
+<!ENTITY roplus           "&#x02A2E;" ><!--plus sign in right half circle -->
+<!ENTITY rotimes          "&#x02A35;" ><!--multiply sign in right half circle -->
+<!ENTITY rthree           "&#x022CC;" ><!--/rightthreetimes B: -->
+<!ENTITY rtimes           "&#x022CA;" ><!--/rtimes B: times sign, right closed -->
+<!ENTITY sdot             "&#x022C5;" ><!--/cdot B: small middle dot -->
+<!ENTITY sdotb            "&#x022A1;" ><!--/dotsquare /boxdot B: small dot in box -->
+<!ENTITY setmn            "&#x02216;" ><!--/setminus B: reverse solidus -->
+<!ENTITY simplus          "&#x02A24;" ><!--plus, similar above -->
+<!ENTITY smashp           "&#x02A33;" ><!--smash product -->
+<!ENTITY solb             "&#x029C4;" ><!--solidus in square -->
+<!ENTITY sqcap            "&#x02293;" ><!--/sqcap B: square intersection -->
+<!ENTITY sqcaps           "&#x02293;&#x0FE00;" ><!--square intersection, serifs -->
+<!ENTITY sqcup            "&#x02294;" ><!--/sqcup B: square union -->
+<!ENTITY sqcups           "&#x02294;&#x0FE00;" ><!--square union, serifs -->
+<!ENTITY ssetmn           "&#x02216;" ><!--/smallsetminus B: sm reverse solidus -->
+<!ENTITY sstarf           "&#x022C6;" ><!--/star B: small star, filled -->
+<!ENTITY subdot           "&#x02ABD;" ><!--subset, with dot -->
+<!ENTITY sum              "&#x02211;" ><!--/sum L: summation operator -->
+<!ENTITY supdot           "&#x02ABE;" ><!--superset, with dot -->
+<!ENTITY timesb           "&#x022A0;" ><!--/boxtimes B: multiply sign in box -->
+<!ENTITY timesbar         "&#x02A31;" ><!--multiply sign, bar below -->
+<!ENTITY timesd           "&#x02A30;" ><!--times, dot -->
+<!ENTITY tridot           "&#x025EC;" ><!--dot in triangle -->
+<!ENTITY triminus         "&#x02A3A;" ><!--minus in triangle -->
+<!ENTITY triplus          "&#x02A39;" ><!--plus in triangle -->
+<!ENTITY trisb            "&#x029CD;" ><!--triangle, serifs at bottom -->
+<!ENTITY tritime          "&#x02A3B;" ><!--multiply in triangle -->
+<!ENTITY uplus            "&#x0228E;" ><!--/uplus B: plus sign in union -->
+<!ENTITY veebar           "&#x022BB;" ><!--/veebar B: logical or, bar below -->
+<!ENTITY wedbar           "&#x02A5F;" ><!--wedge, bar below -->
+<!ENTITY wreath           "&#x02240;" ><!--/wr B: wreath product -->
+<!ENTITY xcap             "&#x022C2;" ><!--/bigcap L: intersection operator -->
+<!ENTITY xcirc            "&#x025EF;" ><!--/bigcirc B: large circle -->
+<!ENTITY xcup             "&#x022C3;" ><!--/bigcup L: union operator -->
+<!ENTITY xdtri            "&#x025BD;" ><!--/bigtriangledown B: big dn tri, open -->
+<!ENTITY xodot            "&#x02A00;" ><!--/bigodot L: circle dot operator -->
+<!ENTITY xoplus           "&#x02A01;" ><!--/bigoplus L: circle plus operator -->
+<!ENTITY xotime           "&#x02A02;" ><!--/bigotimes L: circle times operator -->
+<!ENTITY xsqcup           "&#x02A06;" ><!--/bigsqcup L: square union operator -->
+<!ENTITY xuplus           "&#x02A04;" ><!--/biguplus L: -->
+<!ENTITY xutri            "&#x025B3;" ><!--/bigtriangleup B: big up tri, open -->
+<!ENTITY xvee             "&#x022C1;" ><!--/bigvee L: logical and operator -->
+<!ENTITY xwedge           "&#x022C0;" ><!--/bigwedge L: logical or operator -->

--- a/publishing/1.1/iso9573-13/isoamsc.ent
+++ b/publishing/1.1/iso9573-13/isoamsc.ent
@@ -1,0 +1,43 @@
+
+<!--
+     File isoamsc.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY dlcorn           "&#x0231E;" ><!--/llcorner O: lower left corner -->
+<!ENTITY drcorn           "&#x0231F;" ><!--/lrcorner C: lower right corner -->
+<!ENTITY gtlPar           "&#x02995;" ><!--dbl left parenthesis, greater -->
+<!ENTITY langd            "&#x02991;" ><!--left angle, dot -->
+<!ENTITY lbrke            "&#x0298B;" ><!--left bracket, equal -->
+<!ENTITY lbrksld          "&#x0298F;" ><!--left bracket, solidus bottom corner -->
+<!ENTITY lbrkslu          "&#x0298D;" ><!--left bracket, solidus top corner -->
+<!ENTITY lceil            "&#x02308;" ><!--/lceil O: left ceiling -->
+<!ENTITY lfloor           "&#x0230A;" ><!--/lfloor O: left floor -->
+<!ENTITY lmoust           "&#x023B0;" ><!--/lmoustache -->
+<!ENTITY lparlt           "&#x02993;" ><!--O: left parenthesis, lt -->
+<!ENTITY ltrPar           "&#x02996;" ><!--dbl right parenthesis, less -->
+<!ENTITY rangd            "&#x02992;" ><!--right angle, dot -->
+<!ENTITY rbrke            "&#x0298C;" ><!--right bracket, equal -->
+<!ENTITY rbrksld          "&#x0298E;" ><!--right bracket, solidus bottom corner -->
+<!ENTITY rbrkslu          "&#x02990;" ><!--right bracket, solidus top corner -->
+<!ENTITY rceil            "&#x02309;" ><!--/rceil C: right ceiling -->
+<!ENTITY rfloor           "&#x0230B;" ><!--/rfloor C: right floor -->
+<!ENTITY rmoust           "&#x023B1;" ><!--/rmoustache -->
+<!ENTITY rpargt           "&#x02994;" ><!--C: right paren, gt -->
+<!ENTITY ulcorn           "&#x0231C;" ><!--/ulcorner O: upper left corner -->
+<!ENTITY urcorn           "&#x0231D;" ><!--/urcorner C: upper right corner -->

--- a/publishing/1.1/iso9573-13/isoamsn.ent
+++ b/publishing/1.1/iso9573-13/isoamsn.ent
@@ -1,0 +1,114 @@
+
+<!--
+     File isoamsn.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY gnap             "&#x02A8A;" ><!--/gnapprox N: greater, not approximate -->
+<!ENTITY gnE              "&#x02269;" ><!--/gneqq N: greater, not dbl equals -->
+<!ENTITY gne              "&#x02A88;" ><!--/gneq N: greater, not equals -->
+<!ENTITY gnsim            "&#x022E7;" ><!--/gnsim N: greater, not similar -->
+<!ENTITY gvnE             "&#x02269;&#x0FE00;" ><!--/gvertneqq N: gt, vert, not dbl eq -->
+<!ENTITY lnap             "&#x02A89;" ><!--/lnapprox N: less, not approximate -->
+<!ENTITY lnE              "&#x02268;" ><!--/lneqq N: less, not double equals -->
+<!ENTITY lne              "&#x02A87;" ><!--/lneq N: less, not equals -->
+<!ENTITY lnsim            "&#x022E6;" ><!--/lnsim N: less, not similar -->
+<!ENTITY lvnE             "&#x02268;&#x0FE00;" ><!--/lvertneqq N: less, vert, not dbl eq -->
+<!ENTITY nap              "&#x02249;" ><!--/napprox N: not approximate -->
+<!ENTITY napE             "&#x02A70;&#x00338;" ><!--not approximately equal or equal to -->
+<!ENTITY napid            "&#x0224B;&#x00338;" ><!--not approximately identical to -->
+<!ENTITY ncong            "&#x02247;" ><!--/ncong N: not congruent with -->
+<!ENTITY ncongdot         "&#x02A6D;&#x00338;" ><!--not congruent, dot -->
+<!ENTITY nequiv           "&#x02262;" ><!--/nequiv N: not identical with -->
+<!ENTITY ngE              "&#x02267;&#x00338;" ><!--/ngeqq N: not greater, dbl equals -->
+<!ENTITY nge              "&#x02271;" ><!--/ngeq N: not greater-than-or-equal -->
+<!ENTITY nges             "&#x02A7E;&#x00338;" ><!--/ngeqslant N: not gt-or-eq, slanted -->
+<!ENTITY nGg              "&#x022D9;&#x00338;" ><!--not triple greater than -->
+<!ENTITY ngsim            "&#x02275;" ><!--not greater, similar -->
+<!ENTITY nGt              "&#x0226B;&#x020D2;" ><!--not, vert, much greater than -->
+<!ENTITY ngt              "&#x0226F;" ><!--/ngtr N: not greater-than -->
+<!ENTITY nGtv             "&#x0226B;&#x00338;" ><!--not much greater than, variant -->
+<!ENTITY nlE              "&#x02266;&#x00338;" ><!--/nleqq N: not less, dbl equals -->
+<!ENTITY nle              "&#x02270;" ><!--/nleq N: not less-than-or-equal -->
+<!ENTITY nles             "&#x02A7D;&#x00338;" ><!--/nleqslant N: not less-or-eq, slant -->
+<!ENTITY nLl              "&#x022D8;&#x00338;" ><!--not triple less than -->
+<!ENTITY nlsim            "&#x02274;" ><!--not less, similar -->
+<!ENTITY nLt              "&#x0226A;&#x020D2;" ><!--not, vert, much less than -->
+<!ENTITY nlt              "&#x0226E;" ><!--/nless N: not less-than -->
+<!ENTITY nltri            "&#x022EA;" ><!--/ntriangleleft N: not left triangle -->
+<!ENTITY nltrie           "&#x022EC;" ><!--/ntrianglelefteq N: not l tri, eq -->
+<!ENTITY nLtv             "&#x0226A;&#x00338;" ><!--not much less than, variant -->
+<!ENTITY nmid             "&#x02224;" ><!--/nmid -->
+<!ENTITY npar             "&#x02226;" ><!--/nparallel N: not parallel -->
+<!ENTITY npr              "&#x02280;" ><!--/nprec N: not precedes -->
+<!ENTITY nprcue           "&#x022E0;" ><!--not curly precedes, eq -->
+<!ENTITY npre             "&#x02AAF;&#x00338;" ><!--/npreceq N: not precedes, equals -->
+<!ENTITY nrtri            "&#x022EB;" ><!--/ntriangleright N: not rt triangle -->
+<!ENTITY nrtrie           "&#x022ED;" ><!--/ntrianglerighteq N: not r tri, eq -->
+<!ENTITY nsc              "&#x02281;" ><!--/nsucc N: not succeeds -->
+<!ENTITY nsccue           "&#x022E1;" ><!--not succeeds, curly eq -->
+<!ENTITY nsce             "&#x02AB0;&#x00338;" ><!--/nsucceq N: not succeeds, equals -->
+<!ENTITY nsim             "&#x02241;" ><!--/nsim N: not similar -->
+<!ENTITY nsime            "&#x02244;" ><!--/nsimeq N: not similar, equals -->
+<!ENTITY nsmid            "&#x02224;" ><!--/nshortmid -->
+<!ENTITY nspar            "&#x02226;" ><!--/nshortparallel N: not short par -->
+<!ENTITY nsqsube          "&#x022E2;" ><!--not, square subset, equals -->
+<!ENTITY nsqsupe          "&#x022E3;" ><!--not, square superset, equals -->
+<!ENTITY nsub             "&#x02284;" ><!--not subset -->
+<!ENTITY nsubE            "&#x02AC5;&#x00338;" ><!--/nsubseteqq N: not subset, dbl eq -->
+<!ENTITY nsube            "&#x02288;" ><!--/nsubseteq N: not subset, equals -->
+<!ENTITY nsup             "&#x02285;" ><!--not superset -->
+<!ENTITY nsupE            "&#x02AC6;&#x00338;" ><!--/nsupseteqq N: not superset, dbl eq -->
+<!ENTITY nsupe            "&#x02289;" ><!--/nsupseteq N: not superset, equals -->
+<!ENTITY ntgl             "&#x02279;" ><!--not greater, less -->
+<!ENTITY ntlg             "&#x02278;" ><!--not less, greater -->
+<!ENTITY nvap             "&#x0224D;&#x020D2;" ><!--not, vert, approximate -->
+<!ENTITY nVDash           "&#x022AF;" ><!--/nVDash N: not dbl vert, dbl dash -->
+<!ENTITY nVdash           "&#x022AE;" ><!--/nVdash N: not dbl vertical, dash -->
+<!ENTITY nvDash           "&#x022AD;" ><!--/nvDash N: not vertical, dbl dash -->
+<!ENTITY nvdash           "&#x022AC;" ><!--/nvdash N: not vertical, dash -->
+<!ENTITY nvge             "&#x02265;&#x020D2;" ><!--not, vert, greater-than-or-equal -->
+<!ENTITY nvgt             "&#x0003E;&#x020D2;" ><!--not, vert, greater-than -->
+<!ENTITY nvle             "&#x02264;&#x020D2;" ><!--not, vert, less-than-or-equal -->
+<!ENTITY nvlt             "&#38;#x0003C;&#x020D2;" ><!--not, vert, less-than -->
+<!ENTITY nvltrie          "&#x022B4;&#x020D2;" ><!--not, vert, left triangle, equals -->
+<!ENTITY nvrtrie          "&#x022B5;&#x020D2;" ><!--not, vert, right triangle, equals -->
+<!ENTITY nvsim            "&#x0223C;&#x020D2;" ><!--not, vert, similar -->
+<!ENTITY parsim           "&#x02AF3;" ><!--parallel, similar -->
+<!ENTITY prnap            "&#x02AB9;" ><!--/precnapprox N: precedes, not approx -->
+<!ENTITY prnE             "&#x02AB5;" ><!--/precneqq N: precedes, not dbl eq -->
+<!ENTITY prnsim           "&#x022E8;" ><!--/precnsim N: precedes, not similar -->
+<!ENTITY rnmid            "&#x02AEE;" ><!--reverse /nmid -->
+<!ENTITY scnap            "&#x02ABA;" ><!--/succnapprox N: succeeds, not approx -->
+<!ENTITY scnE             "&#x02AB6;" ><!--/succneqq N: succeeds, not dbl eq -->
+<!ENTITY scnsim           "&#x022E9;" ><!--/succnsim N: succeeds, not similar -->
+<!ENTITY simne            "&#x02246;" ><!--similar, not equals -->
+<!ENTITY solbar           "&#x0233F;" ><!--solidus, bar through -->
+<!ENTITY subnE            "&#x02ACB;" ><!--/subsetneqq N: subset, not dbl eq -->
+<!ENTITY subne            "&#x0228A;" ><!--/subsetneq N: subset, not equals -->
+<!ENTITY supnE            "&#x02ACC;" ><!--/supsetneqq N: superset, not dbl eq -->
+<!ENTITY supne            "&#x0228B;" ><!--/supsetneq N: superset, not equals -->
+<!ENTITY vnsub            "&#x02282;&#x020D2;" ><!--/nsubset N: not subset, var -->
+<!ENTITY vnsup            "&#x02283;&#x020D2;" ><!--/nsupset N: not superset, var -->
+<!ENTITY vsubnE           "&#x02ACB;&#x0FE00;" ><!--/varsubsetneqq N: subset not dbl eq, var -->
+<!ENTITY vsubne           "&#x0228A;&#x0FE00;" ><!--/varsubsetneq N: subset, not eq, var -->
+<!ENTITY vsupnE           "&#x02ACC;&#x0FE00;" ><!--/varsupsetneqq N: super not dbl eq, var -->
+<!ENTITY vsupne           "&#x0228B;&#x0FE00;" ><!--/varsupsetneq N: superset, not eq, var -->

--- a/publishing/1.1/iso9573-13/isoamso.ent
+++ b/publishing/1.1/iso9573-13/isoamso.ent
@@ -1,0 +1,73 @@
+
+<!--
+     File isoamso.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY ang              "&#x02220;" ><!--/angle - angle -->
+<!ENTITY ange             "&#x029A4;" ><!--angle, equal -->
+<!ENTITY angmsd           "&#x02221;" ><!--/measuredangle - angle-measured -->
+<!ENTITY angmsdaa         "&#x029A8;" ><!--angle-measured, arrow, up, right -->
+<!ENTITY angmsdab         "&#x029A9;" ><!--angle-measured, arrow, up, left -->
+<!ENTITY angmsdac         "&#x029AA;" ><!--angle-measured, arrow, down, right -->
+<!ENTITY angmsdad         "&#x029AB;" ><!--angle-measured, arrow, down, left -->
+<!ENTITY angmsdae         "&#x029AC;" ><!--angle-measured, arrow, right, up -->
+<!ENTITY angmsdaf         "&#x029AD;" ><!--angle-measured, arrow, left, up -->
+<!ENTITY angmsdag         "&#x029AE;" ><!--angle-measured, arrow, right, down -->
+<!ENTITY angmsdah         "&#x029AF;" ><!--angle-measured, arrow, left, down -->
+<!ENTITY angrtvb          "&#x022BE;" ><!--right angle-measured -->
+<!ENTITY angrtvbd         "&#x0299D;" ><!--right angle-measured, dot -->
+<!ENTITY bbrk             "&#x023B5;" ><!--bottom square bracket -->
+<!ENTITY bbrktbrk         "&#x023B6;" ><!--bottom above top square bracket -->
+<!ENTITY bemptyv          "&#x029B0;" ><!--reversed circle, slash -->
+<!ENTITY beth             "&#x02136;" ><!--/beth - beth, Hebrew -->
+<!ENTITY boxbox           "&#x029C9;" ><!--two joined squares -->
+<!ENTITY bprime           "&#x02035;" ><!--/backprime - reverse prime -->
+<!ENTITY bsemi            "&#x0204F;" ><!--reverse semi-colon -->
+<!ENTITY cemptyv          "&#x029B2;" ><!--circle, slash, small circle above -->
+<!ENTITY cirE             "&#x029C3;" ><!--circle, two horizontal stroked to the right -->
+<!ENTITY cirscir          "&#x029C2;" ><!--circle, small circle to the right -->
+<!ENTITY comp             "&#x02201;" ><!--/complement - complement sign -->
+<!ENTITY daleth           "&#x02138;" ><!--/daleth - daleth, Hebrew -->
+<!ENTITY demptyv          "&#x029B1;" ><!--circle, slash, bar above -->
+<!ENTITY ell              "&#x02113;" ><!--/ell - cursive small l -->
+<!ENTITY empty            "&#x02205;" ><!--/emptyset - zero, slash -->
+<!ENTITY emptyv           "&#x02205;" ><!--/varnothing - circle, slash -->
+<!ENTITY gimel            "&#x02137;" ><!--/gimel - gimel, Hebrew -->
+<!ENTITY iiota            "&#x02129;" ><!--inverted iota -->
+<!ENTITY image            "&#x02111;" ><!--/Im - imaginary   -->
+<!ENTITY imath            "&#x00131;" ><!--/imath - small i, no dot -->
+<!ENTITY jmath            "&#x0006A;" ><!--/jmath - small j, no dot -->
+<!ENTITY laemptyv         "&#x029B4;" ><!--circle, slash, left arrow above -->
+<!ENTITY lltri            "&#x025FA;" ><!--lower left triangle -->
+<!ENTITY lrtri            "&#x022BF;" ><!--lower right triangle -->
+<!ENTITY mho              "&#x02127;" ><!--/mho - conductance -->
+<!ENTITY nang             "&#x02220;&#x020D2;" ><!--not, vert, angle -->
+<!ENTITY nexist           "&#x02204;" ><!--/nexists - negated exists -->
+<!ENTITY oS               "&#x024C8;" ><!--/circledS - capital S in circle -->
+<!ENTITY planck           "&#x0210F;" ><!--/hbar - Planck's over 2pi -->
+<!ENTITY plankv           "&#x0210F;" ><!--/hslash - variant Planck's over 2pi -->
+<!ENTITY raemptyv         "&#x029B3;" ><!--circle, slash, right arrow above -->
+<!ENTITY range            "&#x029A5;" ><!--reverse angle, equal -->
+<!ENTITY real             "&#x0211C;" ><!--/Re - real -->
+<!ENTITY tbrk             "&#x023B4;" ><!--top square bracket -->
+<!ENTITY trpezium         "&#x0FFFD;" ><!--trapezium -->
+<!ENTITY ultri            "&#x025F8;" ><!--upper left triangle -->
+<!ENTITY urtri            "&#x025F9;" ><!--upper right triangle -->
+<!ENTITY vzigzag          "&#x0299A;" ><!--vertical zig-zag line -->
+<!ENTITY weierp           "&#x02118;" ><!--/wp - Weierstrass p -->

--- a/publishing/1.1/iso9573-13/isoamsr.ent
+++ b/publishing/1.1/iso9573-13/isoamsr.ent
@@ -1,0 +1,204 @@
+
+<!--
+     File isoamsr.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY apE              "&#x02A70;" ><!--approximately equal or equal to -->
+<!ENTITY ape              "&#x0224A;" ><!--/approxeq R: approximate, equals -->
+<!ENTITY apid             "&#x0224B;" ><!--approximately identical to -->
+<!ENTITY asymp            "&#x02248;" ><!--/asymp R: asymptotically equal to -->
+<!ENTITY Barv             "&#x02AE7;" ><!--vert, dbl bar (over) -->
+<!ENTITY bcong            "&#x0224C;" ><!--/backcong R: reverse congruent -->
+<!ENTITY bepsi            "&#x003F6;" ><!--/backepsilon R: such that -->
+<!ENTITY bowtie           "&#x022C8;" ><!--/bowtie R: -->
+<!ENTITY bsim             "&#x0223D;" ><!--/backsim R: reverse similar -->
+<!ENTITY bsime            "&#x022CD;" ><!--/backsimeq R: reverse similar, eq -->
+<!ENTITY bsolhsub         "&#x0005C;&#x02282;" ><!--reverse solidus, subset -->
+<!ENTITY bump             "&#x0224E;" ><!--/Bumpeq R: bumpy equals -->
+<!ENTITY bumpE            "&#x02AAE;" ><!--bump, equals -->
+<!ENTITY bumpe            "&#x0224F;" ><!--/bumpeq R: bumpy equals, equals -->
+<!ENTITY cire             "&#x02257;" ><!--/circeq R: circle, equals -->
+<!ENTITY Colon            "&#x02237;" ><!--/Colon, two colons -->
+<!ENTITY Colone           "&#x02A74;" ><!--double colon, equals -->
+<!ENTITY colone           "&#x02254;" ><!--/coloneq R: colon, equals -->
+<!ENTITY congdot          "&#x02A6D;" ><!--congruent, dot -->
+<!ENTITY csub             "&#x02ACF;" ><!--subset, closed -->
+<!ENTITY csube            "&#x02AD1;" ><!--subset, closed, equals -->
+<!ENTITY csup             "&#x02AD0;" ><!--superset, closed -->
+<!ENTITY csupe            "&#x02AD2;" ><!--superset, closed, equals -->
+<!ENTITY cuepr            "&#x022DE;" ><!--/curlyeqprec R: curly eq, precedes -->
+<!ENTITY cuesc            "&#x022DF;" ><!--/curlyeqsucc R: curly eq, succeeds -->
+<!ENTITY Dashv            "&#x02AE4;" ><!--dbl dash, vertical -->
+<!ENTITY dashv            "&#x022A3;" ><!--/dashv R: dash, vertical -->
+<!ENTITY easter           "&#x02A6E;" ><!--equal, asterisk above -->
+<!ENTITY ecir             "&#x02256;" ><!--/eqcirc R: circle on equals sign -->
+<!ENTITY ecolon           "&#x02255;" ><!--/eqcolon R: equals, colon -->
+<!ENTITY eDDot            "&#x02A77;" ><!--/ddotseq R: equal with four dots -->
+<!ENTITY eDot             "&#x02251;" ><!--/doteqdot /Doteq R: eq, even dots -->
+<!ENTITY efDot            "&#x02252;" ><!--/fallingdotseq R: eq, falling dots -->
+<!ENTITY eg               "&#x02A9A;" ><!--equal-or-greater -->
+<!ENTITY egs              "&#x02A96;" ><!--/eqslantgtr R: equal-or-gtr, slanted -->
+<!ENTITY egsdot           "&#x02A98;" ><!--equal-or-greater, slanted, dot inside -->
+<!ENTITY el               "&#x02A99;" ><!--equal-or-less -->
+<!ENTITY els              "&#x02A95;" ><!--/eqslantless R: eq-or-less, slanted -->
+<!ENTITY elsdot           "&#x02A97;" ><!--equal-or-less, slanted, dot inside -->
+<!ENTITY equest           "&#x0225F;" ><!--/questeq R: equal with questionmark -->
+<!ENTITY equivDD          "&#x02A78;" ><!--equivalent, four dots above -->
+<!ENTITY erDot            "&#x02253;" ><!--/risingdotseq R: eq, rising dots -->
+<!ENTITY esdot            "&#x02250;" ><!--/doteq R: equals, single dot above -->
+<!ENTITY Esim             "&#x02A73;" ><!--equal, similar -->
+<!ENTITY esim             "&#x02242;" ><!--/esim R: equals, similar -->
+<!ENTITY fork             "&#x022D4;" ><!--/pitchfork R: pitchfork -->
+<!ENTITY forkv            "&#x02AD9;" ><!--fork, variant -->
+<!ENTITY frown            "&#x02322;" ><!--/frown R: down curve -->
+<!ENTITY gap              "&#x02A86;" ><!--/gtrapprox R: greater, approximate -->
+<!ENTITY gE               "&#x02267;" ><!--/geqq R: greater, double equals -->
+<!ENTITY gEl              "&#x02A8C;" ><!--/gtreqqless R: gt, dbl equals, less -->
+<!ENTITY gel              "&#x022DB;" ><!--/gtreqless R: greater, equals, less -->
+<!ENTITY ges              "&#x02A7E;" ><!--/geqslant R: gt-or-equal, slanted -->
+<!ENTITY gescc            "&#x02AA9;" ><!--greater than, closed by curve, equal, slanted -->
+<!ENTITY gesdot           "&#x02A80;" ><!--greater-than-or-equal, slanted, dot inside -->
+<!ENTITY gesdoto          "&#x02A82;" ><!--greater-than-or-equal, slanted, dot above -->
+<!ENTITY gesdotol         "&#x02A84;" ><!--greater-than-or-equal, slanted, dot above left -->
+<!ENTITY gesl             "&#x022DB;&#x0FE00;" ><!--greater, equal, slanted, less -->
+<!ENTITY gesles           "&#x02A94;" ><!--greater, equal, slanted, less, equal, slanted -->
+<!ENTITY Gg               "&#x022D9;" ><!--/ggg /Gg /gggtr R: triple gtr-than -->
+<!ENTITY gl               "&#x02277;" ><!--/gtrless R: greater, less -->
+<!ENTITY gla              "&#x02AA5;" ><!--greater, less, apart -->
+<!ENTITY glE              "&#x02A92;" ><!--greater, less, equal -->
+<!ENTITY glj              "&#x02AA4;" ><!--greater, less, overlapping -->
+<!ENTITY gsim             "&#x02273;" ><!--/gtrsim R: greater, similar -->
+<!ENTITY gsime            "&#x02A8E;" ><!--greater, similar, equal -->
+<!ENTITY gsiml            "&#x02A90;" ><!--greater, similar, less -->
+<!ENTITY Gt               "&#x0226B;" ><!--/gg R: dbl greater-than sign -->
+<!ENTITY gtcc             "&#x02AA7;" ><!--greater than, closed by curve -->
+<!ENTITY gtcir            "&#x02A7A;" ><!--greater than, circle inside -->
+<!ENTITY gtdot            "&#x022D7;" ><!--/gtrdot R: greater than, with dot -->
+<!ENTITY gtquest          "&#x02A7C;" ><!--greater than, questionmark above -->
+<!ENTITY gtrarr           "&#x02978;" ><!--greater than, right arrow -->
+<!ENTITY homtht           "&#x0223B;" ><!--homothetic -->
+<!ENTITY lap              "&#x02A85;" ><!--/lessapprox R: less, approximate -->
+<!ENTITY lat              "&#x02AAB;" ><!--larger than -->
+<!ENTITY late             "&#x02AAD;" ><!--larger than or equal -->
+<!ENTITY lates            "&#x02AAD;&#x0FE00;" ><!--larger than or equal, slanted -->
+<!ENTITY lE               "&#x02266;" ><!--/leqq R: less, double equals -->
+<!ENTITY lEg              "&#x02A8B;" ><!--/lesseqqgtr R: less, dbl eq, greater -->
+<!ENTITY leg              "&#x022DA;" ><!--/lesseqgtr R: less, eq, greater -->
+<!ENTITY les              "&#x02A7D;" ><!--/leqslant R: less-than-or-eq, slant -->
+<!ENTITY lescc            "&#x02AA8;" ><!--less than, closed by curve, equal, slanted -->
+<!ENTITY lesdot           "&#x02A7F;" ><!--less-than-or-equal, slanted, dot inside -->
+<!ENTITY lesdoto          "&#x02A81;" ><!--less-than-or-equal, slanted, dot above -->
+<!ENTITY lesdotor         "&#x02A83;" ><!--less-than-or-equal, slanted, dot above right -->
+<!ENTITY lesg             "&#x022DA;&#x0FE00;" ><!--less, equal, slanted, greater -->
+<!ENTITY lesges           "&#x02A93;" ><!--less, equal, slanted, greater, equal, slanted -->
+<!ENTITY lg               "&#x02276;" ><!--/lessgtr R: less, greater -->
+<!ENTITY lgE              "&#x02A91;" ><!--less, greater, equal -->
+<!ENTITY Ll               "&#x022D8;" ><!--/Ll /lll /llless R: triple less-than -->
+<!ENTITY lsim             "&#x02272;" ><!--/lesssim R: less, similar -->
+<!ENTITY lsime            "&#x02A8D;" ><!--less, similar, equal -->
+<!ENTITY lsimg            "&#x02A8F;" ><!--less, similar, greater -->
+<!ENTITY Lt               "&#x0226A;" ><!--/ll R: double less-than sign -->
+<!ENTITY ltcc             "&#x02AA6;" ><!--less than, closed by curve -->
+<!ENTITY ltcir            "&#x02A79;" ><!--less than, circle inside -->
+<!ENTITY ltdot            "&#x022D6;" ><!--/lessdot R: less than, with dot -->
+<!ENTITY ltlarr           "&#x02976;" ><!--less than, left arrow -->
+<!ENTITY ltquest          "&#x02A7B;" ><!--less than, questionmark above -->
+<!ENTITY ltrie            "&#x022B4;" ><!--/trianglelefteq R: left triangle, eq -->
+<!ENTITY mcomma           "&#x02A29;" ><!--minus, comma above -->
+<!ENTITY mDDot            "&#x0223A;" ><!--minus with four dots, geometric properties -->
+<!ENTITY mid              "&#x02223;" ><!--/mid R: -->
+<!ENTITY mlcp             "&#x02ADB;" ><!--/mlcp -->
+<!ENTITY models           "&#x022A7;" ><!--/models R: -->
+<!ENTITY mstpos           "&#x0223E;" ><!--most positive -->
+<!ENTITY Pr               "&#x02ABB;" ><!--dbl precedes -->
+<!ENTITY pr               "&#x0227A;" ><!--/prec R: precedes -->
+<!ENTITY prap             "&#x02AB7;" ><!--/precapprox R: precedes, approximate -->
+<!ENTITY prcue            "&#x0227C;" ><!--/preccurlyeq R: precedes, curly eq -->
+<!ENTITY prE              "&#x02AB3;" ><!--precedes, dbl equals -->
+<!ENTITY pre              "&#x02AAF;" ><!--/preceq R: precedes, equals -->
+<!ENTITY prsim            "&#x0227E;" ><!--/precsim R: precedes, similar -->
+<!ENTITY prurel           "&#x022B0;" ><!--element precedes under relation -->
+<!ENTITY ratio            "&#x02236;" ><!--/ratio -->
+<!ENTITY rtrie            "&#x022B5;" ><!--/trianglerighteq R: right tri, eq -->
+<!ENTITY rtriltri         "&#x029CE;" ><!--right triangle above left triangle -->
+<!ENTITY Sc               "&#x02ABC;" ><!--dbl succeeds -->
+<!ENTITY sc               "&#x0227B;" ><!--/succ R: succeeds -->
+<!ENTITY scap             "&#x02AB8;" ><!--/succapprox R: succeeds, approximate -->
+<!ENTITY sccue            "&#x0227D;" ><!--/succcurlyeq R: succeeds, curly eq -->
+<!ENTITY scE              "&#x02AB4;" ><!--succeeds, dbl equals -->
+<!ENTITY sce              "&#x02AB0;" ><!--/succeq R: succeeds, equals -->
+<!ENTITY scsim            "&#x0227F;" ><!--/succsim R: succeeds, similar -->
+<!ENTITY sdote            "&#x02A66;" ><!--equal, dot below -->
+<!ENTITY sfrown           "&#x02322;" ><!--/smallfrown R: small down curve -->
+<!ENTITY simg             "&#x02A9E;" ><!--similar, greater -->
+<!ENTITY simgE            "&#x02AA0;" ><!--similar, greater, equal -->
+<!ENTITY siml             "&#x02A9D;" ><!--similar, less -->
+<!ENTITY simlE            "&#x02A9F;" ><!--similar, less, equal -->
+<!ENTITY smid             "&#x02223;" ><!--/shortmid R: -->
+<!ENTITY smile            "&#x02323;" ><!--/smile R: up curve -->
+<!ENTITY smt              "&#x02AAA;" ><!--smaller than -->
+<!ENTITY smte             "&#x02AAC;" ><!--smaller than or equal -->
+<!ENTITY smtes            "&#x02AAC;&#x0FE00;" ><!--smaller than or equal, slanted -->
+<!ENTITY spar             "&#x02225;" ><!--/shortparallel R: short parallel -->
+<!ENTITY sqsub            "&#x0228F;" ><!--/sqsubset R: square subset -->
+<!ENTITY sqsube           "&#x02291;" ><!--/sqsubseteq R: square subset, equals -->
+<!ENTITY sqsup            "&#x02290;" ><!--/sqsupset R: square superset -->
+<!ENTITY sqsupe           "&#x02292;" ><!--/sqsupseteq R: square superset, eq -->
+<!ENTITY ssmile           "&#x02323;" ><!--/smallsmile R: small up curve -->
+<!ENTITY Sub              "&#x022D0;" ><!--/Subset R: double subset -->
+<!ENTITY subE             "&#x02AC5;" ><!--/subseteqq R: subset, dbl equals -->
+<!ENTITY subedot          "&#x02AC3;" ><!--subset, equals, dot -->
+<!ENTITY submult          "&#x02AC1;" ><!--subset, multiply -->
+<!ENTITY subplus          "&#x02ABF;" ><!--subset, plus -->
+<!ENTITY subrarr          "&#x02979;" ><!--subset, right arrow -->
+<!ENTITY subsim           "&#x02AC7;" ><!--subset, similar -->
+<!ENTITY subsub           "&#x02AD5;" ><!--subset above subset -->
+<!ENTITY subsup           "&#x02AD3;" ><!--subset above superset -->
+<!ENTITY Sup              "&#x022D1;" ><!--/Supset R: dbl superset -->
+<!ENTITY supdsub          "&#x02AD8;" ><!--superset, subset, dash joining them -->
+<!ENTITY supE             "&#x02AC6;" ><!--/supseteqq R: superset, dbl equals -->
+<!ENTITY supedot          "&#x02AC4;" ><!--superset, equals, dot -->
+<!ENTITY suphsol          "&#x02283;&#x0002F;" ><!--superset, solidus -->
+<!ENTITY suphsub          "&#x02AD7;" ><!--superset, subset -->
+<!ENTITY suplarr          "&#x0297B;" ><!--superset, left arrow -->
+<!ENTITY supmult          "&#x02AC2;" ><!--superset, multiply -->
+<!ENTITY supplus          "&#x02AC0;" ><!--superset, plus -->
+<!ENTITY supsim           "&#x02AC8;" ><!--superset, similar -->
+<!ENTITY supsub           "&#x02AD4;" ><!--superset above subset -->
+<!ENTITY supsup           "&#x02AD6;" ><!--superset above superset -->
+<!ENTITY thkap            "&#x02248;" ><!--/thickapprox R: thick approximate -->
+<!ENTITY thksim           "&#x0223C;" ><!--/thicksim R: thick similar -->
+<!ENTITY topfork          "&#x02ADA;" ><!--fork with top -->
+<!ENTITY trie             "&#x0225C;" ><!--/triangleq R: triangle, equals -->
+<!ENTITY twixt            "&#x0226C;" ><!--/between R: between -->
+<!ENTITY Vbar             "&#x02AEB;" ><!--dbl vert, bar (under) -->
+<!ENTITY vBar             "&#x02AE8;" ><!--vert, dbl bar (under) -->
+<!ENTITY vBarv            "&#x02AE9;" ><!--dbl bar, vert over and under -->
+<!ENTITY VDash            "&#x022AB;" ><!--dbl vert, dbl dash -->
+<!ENTITY Vdash            "&#x022A9;" ><!--/Vdash R: dbl vertical, dash -->
+<!ENTITY vDash            "&#x022A8;" ><!--/vDash R: vertical, dbl dash -->
+<!ENTITY vdash            "&#x022A2;" ><!--/vdash R: vertical, dash -->
+<!ENTITY Vdashl           "&#x02AE6;" ><!--vertical, dash (long) -->
+<!ENTITY vltri            "&#x022B2;" ><!--/vartriangleleft R: l tri, open, var -->
+<!ENTITY vprop            "&#x0221D;" ><!--/varpropto R: proportional, variant -->
+<!ENTITY vrtri            "&#x022B3;" ><!--/vartriangleright R: r tri, open, var -->
+<!ENTITY Vvdash           "&#x022AA;" ><!--/Vvdash R: triple vertical, dash -->

--- a/publishing/1.1/iso9573-13/isogrk3.ent
+++ b/publishing/1.1/iso9573-13/isogrk3.ent
@@ -1,0 +1,64 @@
+
+<!--
+     File isogrk3.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY alpha            "&#x003B1;" ><!--/alpha small alpha, Greek -->
+<!ENTITY beta             "&#x003B2;" ><!--/beta small beta, Greek -->
+<!ENTITY chi              "&#x003C7;" ><!--/chi small chi, Greek -->
+<!ENTITY Delta            "&#x00394;" ><!--/Delta capital Delta, Greek -->
+<!ENTITY delta            "&#x003B4;" ><!--/delta small delta, Greek -->
+<!ENTITY epsi             "&#x003F5;" ><!--/straightepsilon, small epsilon, Greek -->
+<!ENTITY epsiv            "&#x003B5;" ><!--/varepsilon -->
+<!ENTITY eta              "&#x003B7;" ><!--/eta small eta, Greek -->
+<!ENTITY Gamma            "&#x00393;" ><!--/Gamma capital Gamma, Greek -->
+<!ENTITY gamma            "&#x003B3;" ><!--/gamma small gamma, Greek -->
+<!ENTITY Gammad           "&#x003DC;" ><!--capital digamma -->
+<!ENTITY gammad           "&#x003DD;" ><!--/digamma -->
+<!ENTITY iota             "&#x003B9;" ><!--/iota small iota, Greek -->
+<!ENTITY kappa            "&#x003BA;" ><!--/kappa small kappa, Greek -->
+<!ENTITY kappav           "&#x003F0;" ><!--/varkappa -->
+<!ENTITY Lambda           "&#x0039B;" ><!--/Lambda capital Lambda, Greek -->
+<!ENTITY lambda           "&#x003BB;" ><!--/lambda small lambda, Greek -->
+<!ENTITY mu               "&#x003BC;" ><!--/mu small mu, Greek -->
+<!ENTITY nu               "&#x003BD;" ><!--/nu small nu, Greek -->
+<!ENTITY Omega            "&#x003A9;" ><!--/Omega capital Omega, Greek -->
+<!ENTITY omega            "&#x003C9;" ><!--/omega small omega, Greek -->
+<!ENTITY Phi              "&#x003A6;" ><!--/Phi capital Phi, Greek -->
+<!ENTITY phi              "&#x003D5;" ><!--/straightphi - small phi, Greek -->
+<!ENTITY phiv             "&#x003C6;" ><!--/varphi - curly or open phi -->
+<!ENTITY Pi               "&#x003A0;" ><!--/Pi capital Pi, Greek -->
+<!ENTITY pi               "&#x003C0;" ><!--/pi small pi, Greek -->
+<!ENTITY piv              "&#x003D6;" ><!--/varpi -->
+<!ENTITY Psi              "&#x003A8;" ><!--/Psi capital Psi, Greek -->
+<!ENTITY psi              "&#x003C8;" ><!--/psi small psi, Greek -->
+<!ENTITY rho              "&#x003C1;" ><!--/rho small rho, Greek -->
+<!ENTITY rhov             "&#x003F1;" ><!--/varrho -->
+<!ENTITY Sigma            "&#x003A3;" ><!--/Sigma capital Sigma, Greek -->
+<!ENTITY sigma            "&#x003C3;" ><!--/sigma small sigma, Greek -->
+<!ENTITY sigmav           "&#x003C2;" ><!--/varsigma -->
+<!ENTITY tau              "&#x003C4;" ><!--/tau small tau, Greek -->
+<!ENTITY Theta            "&#x00398;" ><!--/Theta capital Theta, Greek -->
+<!ENTITY theta            "&#x003B8;" ><!--/theta straight theta, small theta, Greek -->
+<!ENTITY thetav           "&#x003D1;" ><!--/vartheta - curly or open theta -->
+<!ENTITY Upsi             "&#x003D2;" ><!--/Upsilon capital Upsilon, Greek -->
+<!ENTITY upsi             "&#x003C5;" ><!--/upsilon small upsilon, Greek -->
+<!ENTITY Xi               "&#x0039E;" ><!--/Xi capital Xi, Greek -->
+<!ENTITY xi               "&#x003BE;" ><!--/xi small xi, Greek -->
+<!ENTITY zeta             "&#x003B6;" ><!--/zeta small zeta, Greek -->

--- a/publishing/1.1/iso9573-13/isomfrk.ent
+++ b/publishing/1.1/iso9573-13/isomfrk.ent
@@ -1,0 +1,75 @@
+
+<!--
+     File isomfrk.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Afr              "%plane1D;504;" ><!--/frak A, upper case a -->
+<!ENTITY afr              "%plane1D;51E;" ><!--/frak a, lower case a -->
+<!ENTITY Bfr              "%plane1D;505;" ><!--/frak B, upper case b -->
+<!ENTITY bfr              "%plane1D;51F;" ><!--/frak b, lower case b -->
+<!ENTITY Cfr              "&#x0212D;" ><!--/frak C, upper case c -->
+<!ENTITY cfr              "%plane1D;520;" ><!--/frak c, lower case c -->
+<!ENTITY Dfr              "%plane1D;507;" ><!--/frak D, upper case d -->
+<!ENTITY dfr              "%plane1D;521;" ><!--/frak d, lower case d -->
+<!ENTITY Efr              "%plane1D;508;" ><!--/frak E, upper case e -->
+<!ENTITY efr              "%plane1D;522;" ><!--/frak e, lower case e -->
+<!ENTITY Ffr              "%plane1D;509;" ><!--/frak F, upper case f -->
+<!ENTITY ffr              "%plane1D;523;" ><!--/frak f, lower case f -->
+<!ENTITY Gfr              "%plane1D;50A;" ><!--/frak G, upper case g -->
+<!ENTITY gfr              "%plane1D;524;" ><!--/frak g, lower case g -->
+<!ENTITY Hfr              "&#x0210C;" ><!--/frak H, upper case h -->
+<!ENTITY hfr              "%plane1D;525;" ><!--/frak h, lower case h -->
+<!ENTITY Ifr              "&#x02111;" ><!--/frak I, upper case i -->
+<!ENTITY ifr              "%plane1D;526;" ><!--/frak i, lower case i -->
+<!ENTITY Jfr              "%plane1D;50D;" ><!--/frak J, upper case j -->
+<!ENTITY jfr              "%plane1D;527;" ><!--/frak j, lower case j -->
+<!ENTITY Kfr              "%plane1D;50E;" ><!--/frak K, upper case k -->
+<!ENTITY kfr              "%plane1D;528;" ><!--/frak k, lower case k -->
+<!ENTITY Lfr              "%plane1D;50F;" ><!--/frak L, upper case l -->
+<!ENTITY lfr              "%plane1D;529;" ><!--/frak l, lower case l -->
+<!ENTITY Mfr              "%plane1D;510;" ><!--/frak M, upper case m -->
+<!ENTITY mfr              "%plane1D;52A;" ><!--/frak m, lower case m -->
+<!ENTITY Nfr              "%plane1D;511;" ><!--/frak N, upper case n -->
+<!ENTITY nfr              "%plane1D;52B;" ><!--/frak n, lower case n -->
+<!ENTITY Ofr              "%plane1D;512;" ><!--/frak O, upper case o -->
+<!ENTITY ofr              "%plane1D;52C;" ><!--/frak o, lower case o -->
+<!ENTITY Pfr              "%plane1D;513;" ><!--/frak P, upper case p -->
+<!ENTITY pfr              "%plane1D;52D;" ><!--/frak p, lower case p -->
+<!ENTITY Qfr              "%plane1D;514;" ><!--/frak Q, upper case q -->
+<!ENTITY qfr              "%plane1D;52E;" ><!--/frak q, lower case q -->
+<!ENTITY Rfr              "&#x0211C;" ><!--/frak R, upper case r -->
+<!ENTITY rfr              "%plane1D;52F;" ><!--/frak r, lower case r -->
+<!ENTITY Sfr              "%plane1D;516;" ><!--/frak S, upper case s -->
+<!ENTITY sfr              "%plane1D;530;" ><!--/frak s, lower case s -->
+<!ENTITY Tfr              "%plane1D;517;" ><!--/frak T, upper case t -->
+<!ENTITY tfr              "%plane1D;531;" ><!--/frak t, lower case t -->
+<!ENTITY Ufr              "%plane1D;518;" ><!--/frak U, upper case u -->
+<!ENTITY ufr              "%plane1D;532;" ><!--/frak u, lower case u -->
+<!ENTITY Vfr              "%plane1D;519;" ><!--/frak V, upper case v -->
+<!ENTITY vfr              "%plane1D;533;" ><!--/frak v, lower case v -->
+<!ENTITY Wfr              "%plane1D;51A;" ><!--/frak W, upper case w -->
+<!ENTITY wfr              "%plane1D;534;" ><!--/frak w, lower case w -->
+<!ENTITY Xfr              "%plane1D;51B;" ><!--/frak X, upper case x -->
+<!ENTITY xfr              "%plane1D;535;" ><!--/frak x, lower case x -->
+<!ENTITY Yfr              "%plane1D;51C;" ><!--/frak Y, upper case y -->
+<!ENTITY yfr              "%plane1D;536;" ><!--/frak y, lower case y -->
+<!ENTITY Zfr              "&#x02128;" ><!--/frak Z, upper case z  -->
+<!ENTITY zfr              "%plane1D;537;" ><!--/frak z, lower case z -->

--- a/publishing/1.1/iso9573-13/isomopf.ent
+++ b/publishing/1.1/iso9573-13/isomopf.ent
@@ -1,0 +1,49 @@
+
+<!--
+     File isomopf.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Aopf             "%plane1D;538;" ><!--/Bbb A, open face A -->
+<!ENTITY Bopf             "%plane1D;539;" ><!--/Bbb B, open face B -->
+<!ENTITY Copf             "&#x02102;" ><!--/Bbb C, open face C -->
+<!ENTITY Dopf             "%plane1D;53B;" ><!--/Bbb D, open face D -->
+<!ENTITY Eopf             "%plane1D;53C;" ><!--/Bbb E, open face E -->
+<!ENTITY Fopf             "%plane1D;53D;" ><!--/Bbb F, open face F -->
+<!ENTITY Gopf             "%plane1D;53E;" ><!--/Bbb G, open face G -->
+<!ENTITY Hopf             "&#x0210D;" ><!--/Bbb H, open face H -->
+<!ENTITY Iopf             "%plane1D;540;" ><!--/Bbb I, open face I -->
+<!ENTITY Jopf             "%plane1D;541;" ><!--/Bbb J, open face J -->
+<!ENTITY Kopf             "%plane1D;542;" ><!--/Bbb K, open face K  -->
+<!ENTITY Lopf             "%plane1D;543;" ><!--/Bbb L, open face L  -->
+<!ENTITY Mopf             "%plane1D;544;" ><!--/Bbb M, open face M  -->
+<!ENTITY Nopf             "&#x02115;" ><!--/Bbb N, open face N -->
+<!ENTITY Oopf             "%plane1D;546;" ><!--/Bbb O, open face O -->
+<!ENTITY Popf             "&#x02119;" ><!--/Bbb P, open face P -->
+<!ENTITY Qopf             "&#x0211A;" ><!--/Bbb Q, open face Q -->
+<!ENTITY Ropf             "&#x0211D;" ><!--/Bbb R, open face R -->
+<!ENTITY Sopf             "%plane1D;54A;" ><!--/Bbb S, open face S -->
+<!ENTITY Topf             "%plane1D;54B;" ><!--/Bbb T, open face T -->
+<!ENTITY Uopf             "%plane1D;54C;" ><!--/Bbb U, open face U -->
+<!ENTITY Vopf             "%plane1D;54D;" ><!--/Bbb V, open face V -->
+<!ENTITY Wopf             "%plane1D;54E;" ><!--/Bbb W, open face W -->
+<!ENTITY Xopf             "%plane1D;54F;" ><!--/Bbb X, open face X -->
+<!ENTITY Yopf             "%plane1D;550;" ><!--/Bbb Y, open face Y -->
+<!ENTITY Zopf             "&#x02124;" ><!--/Bbb Z, open face Z -->

--- a/publishing/1.1/iso9573-13/isomscr.ent
+++ b/publishing/1.1/iso9573-13/isomscr.ent
@@ -1,0 +1,75 @@
+
+<!--
+     File isomscr.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY Ascr             "%plane1D;49C;" ><!--/scr A, script letter A -->
+<!ENTITY ascr             "%plane1D;4B6;" ><!--/scr a, script letter a -->
+<!ENTITY Bscr             "&#x0212C;" ><!--/scr B, script letter B -->
+<!ENTITY bscr             "%plane1D;4B7;" ><!--/scr b, script letter b -->
+<!ENTITY Cscr             "%plane1D;49E;" ><!--/scr C, script letter C -->
+<!ENTITY cscr             "%plane1D;4B8;" ><!--/scr c, script letter c -->
+<!ENTITY Dscr             "%plane1D;49F;" ><!--/scr D, script letter D -->
+<!ENTITY dscr             "%plane1D;4B9;" ><!--/scr d, script letter d -->
+<!ENTITY Escr             "&#x02130;" ><!--/scr E, script letter E -->
+<!ENTITY escr             "&#x0212F;" ><!--/scr e, script letter e -->
+<!ENTITY Fscr             "&#x02131;" ><!--/scr F, script letter F -->
+<!ENTITY fscr             "%plane1D;4BB;" ><!--/scr f, script letter f -->
+<!ENTITY Gscr             "%plane1D;4A2;" ><!--/scr G, script letter G -->
+<!ENTITY gscr             "&#x0210A;" ><!--/scr g, script letter g -->
+<!ENTITY Hscr             "&#x0210B;" ><!--/scr H, script letter H -->
+<!ENTITY hscr             "%plane1D;4BD;" ><!--/scr h, script letter h -->
+<!ENTITY Iscr             "&#x02110;" ><!--/scr I, script letter I -->
+<!ENTITY iscr             "%plane1D;4BE;" ><!--/scr i, script letter i -->
+<!ENTITY Jscr             "%plane1D;4A5;" ><!--/scr J, script letter J -->
+<!ENTITY jscr             "%plane1D;4BF;" ><!--/scr j, script letter j -->
+<!ENTITY Kscr             "%plane1D;4A6;" ><!--/scr K, script letter K -->
+<!ENTITY kscr             "%plane1D;4C0;" ><!--/scr k, script letter k -->
+<!ENTITY Lscr             "&#x02112;" ><!--/scr L, script letter L -->
+<!ENTITY lscr             "%plane1D;4C1;" ><!--/scr l, script letter l -->
+<!ENTITY Mscr             "&#x02133;" ><!--/scr M, script letter M -->
+<!ENTITY mscr             "%plane1D;4C2;" ><!--/scr m, script letter m -->
+<!ENTITY Nscr             "%plane1D;4A9;" ><!--/scr N, script letter N -->
+<!ENTITY nscr             "%plane1D;4C3;" ><!--/scr n, script letter n -->
+<!ENTITY Oscr             "%plane1D;4AA;" ><!--/scr O, script letter O -->
+<!ENTITY oscr             "&#x02134;" ><!--/scr o, script letter o -->
+<!ENTITY Pscr             "%plane1D;4AB;" ><!--/scr P, script letter P -->
+<!ENTITY pscr             "%plane1D;4C5;" ><!--/scr p, script letter p -->
+<!ENTITY Qscr             "%plane1D;4AC;" ><!--/scr Q, script letter Q -->
+<!ENTITY qscr             "%plane1D;4C6;" ><!--/scr q, script letter q -->
+<!ENTITY Rscr             "&#x0211B;" ><!--/scr R, script letter R -->
+<!ENTITY rscr             "%plane1D;4C7;" ><!--/scr r, script letter r -->
+<!ENTITY Sscr             "%plane1D;4AE;" ><!--/scr S, script letter S -->
+<!ENTITY sscr             "%plane1D;4C8;" ><!--/scr s, script letter s -->
+<!ENTITY Tscr             "%plane1D;4AF;" ><!--/scr T, script letter T -->
+<!ENTITY tscr             "%plane1D;4C9;" ><!--/scr t, script letter t -->
+<!ENTITY Uscr             "%plane1D;4B0;" ><!--/scr U, script letter U -->
+<!ENTITY uscr             "%plane1D;4CA;" ><!--/scr u, script letter u -->
+<!ENTITY Vscr             "%plane1D;4B1;" ><!--/scr V, script letter V -->
+<!ENTITY vscr             "%plane1D;4CB;" ><!--/scr v, script letter v -->
+<!ENTITY Wscr             "%plane1D;4B2;" ><!--/scr W, script letter W -->
+<!ENTITY wscr             "%plane1D;4CC;" ><!--/scr w, script letter w -->
+<!ENTITY Xscr             "%plane1D;4B3;" ><!--/scr X, script letter X -->
+<!ENTITY xscr             "%plane1D;4CD;" ><!--/scr x, script letter x -->
+<!ENTITY Yscr             "%plane1D;4B4;" ><!--/scr Y, script letter Y -->
+<!ENTITY yscr             "%plane1D;4CE;" ><!--/scr y, script letter y -->
+<!ENTITY Zscr             "%plane1D;4B5;" ><!--/scr Z, script letter Z -->
+<!ENTITY zscr             "%plane1D;4CF;" ><!--/scr z, script letter z -->

--- a/publishing/1.1/iso9573-13/isotech.ent
+++ b/publishing/1.1/iso9573-13/isotech.ent
@@ -1,0 +1,182 @@
+
+<!--
+     File isotech.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY acd              "&#x0223F;" ><!--ac current -->
+<!ENTITY aleph            "&#x02135;" ><!--/aleph aleph, Hebrew -->
+<!ENTITY And              "&#x02A53;" ><!--dbl logical and -->
+<!ENTITY and              "&#x02227;" ><!--/wedge /land B: logical and -->
+<!ENTITY andand           "&#x02A55;" ><!--two logical and -->
+<!ENTITY andd             "&#x02A5C;" ><!--and, horizontal dash -->
+<!ENTITY andslope         "&#x02A58;" ><!--sloping large and -->
+<!ENTITY andv             "&#x02A5A;" ><!--and with middle stem -->
+<!ENTITY angrt            "&#x0221F;" ><!--right (90 degree) angle -->
+<!ENTITY angsph           "&#x02222;" ><!--/sphericalangle angle-spherical -->
+<!ENTITY angst            "&#x0212B;" ><!--Angstrom capital A, ring -->
+<!ENTITY ap               "&#x02248;" ><!--/approx R: approximate -->
+<!ENTITY apacir           "&#x02A6F;" ><!--approximate, circumflex accent -->
+<!ENTITY awconint         "&#x02233;" ><!--contour integral, anti-clockwise -->
+<!ENTITY awint            "&#x02A11;" ><!--anti clock-wise integration -->
+<!ENTITY becaus           "&#x02235;" ><!--/because R: because -->
+<!ENTITY bernou           "&#x0212C;" ><!--Bernoulli function (script capital B)  -->
+<!ENTITY bne              "&#x0003D;&#x020E5;" ><!--reverse not equal -->
+<!ENTITY bnequiv          "&#x02261;&#x020E5;" ><!--reverse not equivalent -->
+<!ENTITY bNot             "&#x02AED;" ><!--reverse not with two horizontal strokes -->
+<!ENTITY bnot             "&#x02310;" ><!--reverse not -->
+<!ENTITY bottom           "&#x022A5;" ><!--/bot bottom -->
+<!ENTITY cap              "&#x02229;" ><!--/cap B: intersection -->
+<!ENTITY Cconint          "&#x02230;" ><!--triple contour integral operator -->
+<!ENTITY cirfnint         "&#x02A10;" ><!--circulation function -->
+<!ENTITY compfn           "&#x02218;" ><!--/circ B: composite function (small circle) -->
+<!ENTITY cong             "&#x02245;" ><!--/cong R: congruent with -->
+<!ENTITY Conint           "&#x0222F;" ><!--double contour integral operator -->
+<!ENTITY conint           "&#x0222E;" ><!--/oint L: contour integral operator -->
+<!ENTITY ctdot            "&#x022EF;" ><!--/cdots, three dots, centered -->
+<!ENTITY cup              "&#x0222A;" ><!--/cup B: union or logical sum -->
+<!ENTITY cwconint         "&#x02232;" ><!--contour integral, clockwise -->
+<!ENTITY cwint            "&#x02231;" ><!--clockwise integral -->
+<!ENTITY cylcty           "&#x0232D;" ><!--cylindricity -->
+<!ENTITY disin            "&#x022F2;" ><!--set membership, long horizontal stroke -->
+<!ENTITY Dot              "&#x000A8;" ><!--dieresis or umlaut mark -->
+<!ENTITY DotDot           "&#x020DC;" ><!--four dots above -->
+<!ENTITY dsol             "&#x029F6;" ><!--solidus, bar above -->
+<!ENTITY dtdot            "&#x022F1;" ><!--/ddots, three dots, descending -->
+<!ENTITY dwangle          "&#x029A6;" ><!--large downward pointing angle -->
+<!ENTITY elinters         "&#x0FFFD;" ><!--electrical intersection -->
+<!ENTITY epar             "&#x022D5;" ><!--parallel, equal; equal or parallel -->
+<!ENTITY eparsl           "&#x029E3;" ><!--parallel, slanted, equal; homothetically congruent to -->
+<!ENTITY equiv            "&#x02261;" ><!--/equiv R: identical with -->
+<!ENTITY eqvparsl         "&#x029E5;" ><!--equivalent, equal; congruent and parallel -->
+<!ENTITY exist            "&#x02203;" ><!--/exists at least one exists -->
+<!ENTITY fltns            "&#x025B1;" ><!--flatness -->
+<!ENTITY fnof             "&#x00192;" ><!--function of (italic small f) -->
+<!ENTITY forall           "&#x02200;" ><!--/forall for all -->
+<!ENTITY fpartint         "&#x02A0D;" ><!--finite part integral -->
+<!ENTITY ge               "&#x02265;" ><!--/geq /ge R: greater-than-or-equal -->
+<!ENTITY hamilt           "&#x0210B;" ><!--Hamiltonian (script capital H)  -->
+<!ENTITY iff              "&#x021D4;" ><!--/iff if and only if  -->
+<!ENTITY iinfin           "&#x029DC;" ><!--infinity sign, incomplete -->
+<!ENTITY imped            "&#x001B5;" ><!--impedance -->
+<!ENTITY infin            "&#x0221E;" ><!--/infty infinity -->
+<!ENTITY infintie         "&#x029DD;" ><!--tie, infinity -->
+<!ENTITY Int              "&#x0222C;" ><!--double integral operator -->
+<!ENTITY int              "&#x0222B;" ><!--/int L: integral operator -->
+<!ENTITY intlarhk         "&#x02A17;" ><!--integral, left arrow with hook -->
+<!ENTITY isin             "&#x02208;" ><!--/in R: set membership  -->
+<!ENTITY isindot          "&#x022F5;" ><!--set membership, dot above -->
+<!ENTITY isinE            "&#x022F9;" ><!--set membership, two horizontal strokes -->
+<!ENTITY isins            "&#x022F4;" ><!--set membership, vertical bar on horizontal stroke -->
+<!ENTITY isinsv           "&#x022F3;" ><!--large set membership, vertical bar on horizontal stroke -->
+<!ENTITY isinv            "&#x02208;" ><!--set membership, variant -->
+<!ENTITY lagran           "&#x02112;" ><!--Lagrangian (script capital L)  -->
+<!ENTITY Lang             "&#x0300A;" ><!--left angle bracket, double -->
+<!ENTITY lang             "&#x02329;" ><!--/langle O: left angle bracket -->
+<!ENTITY lArr             "&#x021D0;" ><!--/Leftarrow A: is implied by -->
+<!ENTITY lbbrk            "&#x03014;" ><!--left broken bracket -->
+<!ENTITY le               "&#x02264;" ><!--/leq /le R: less-than-or-equal -->
+<!ENTITY loang            "&#x03018;" ><!--left open angular bracket -->
+<!ENTITY lobrk            "&#x0301A;" ><!--left open bracket -->
+<!ENTITY lopar            "&#x02985;" ><!--left open parenthesis -->
+<!ENTITY lowast           "&#x02217;" ><!--low asterisk -->
+<!ENTITY minus            "&#x02212;" ><!--B: minus sign -->
+<!ENTITY mnplus           "&#x02213;" ><!--/mp B: minus-or-plus sign -->
+<!ENTITY nabla            "&#x02207;" ><!--/nabla del, Hamilton operator -->
+<!ENTITY ne               "&#x02260;" ><!--/ne /neq R: not equal -->
+<!ENTITY nedot            "&#x02250;&#x00338;" ><!--not equal, dot -->
+<!ENTITY nhpar            "&#x02AF2;" ><!--not, horizontal, parallel -->
+<!ENTITY ni               "&#x0220B;" ><!--/ni /owns R: contains -->
+<!ENTITY nis              "&#x022FC;" ><!--contains, vertical bar on horizontal stroke -->
+<!ENTITY nisd             "&#x022FA;" ><!--contains, long horizontal stroke -->
+<!ENTITY niv              "&#x0220B;" ><!--contains, variant -->
+<!ENTITY Not              "&#x02AEC;" ><!--not with two horizontal strokes -->
+<!ENTITY notin            "&#x02209;" ><!--/notin N: negated set membership -->
+<!ENTITY notindot         "&#x022F5;&#x00338;" ><!--negated set membership, dot above -->
+<!ENTITY notinE           "&#x022F9;&#x00338;" ><!--negated set membership, two horizontal strokes -->
+<!ENTITY notinva          "&#x02209;" ><!--negated set membership, variant -->
+<!ENTITY notinvb          "&#x022F7;" ><!--negated set membership, variant -->
+<!ENTITY notinvc          "&#x022F6;" ><!--negated set membership, variant -->
+<!ENTITY notni            "&#x0220C;" ><!--negated contains -->
+<!ENTITY notniva          "&#x0220C;" ><!--negated contains, variant -->
+<!ENTITY notnivb          "&#x022FE;" ><!--contains, variant -->
+<!ENTITY notnivc          "&#x022FD;" ><!--contains, variant -->
+<!ENTITY nparsl           "&#x02AFD;&#x020E5;" ><!--not parallel, slanted -->
+<!ENTITY npart            "&#x02202;&#x00338;" ><!--not partial differential -->
+<!ENTITY npolint          "&#x02A14;" ><!--line integration, not including the pole -->
+<!ENTITY nvinfin          "&#x029DE;" ><!--not, vert, infinity -->
+<!ENTITY olcross          "&#x029BB;" ><!--circle, cross -->
+<!ENTITY Or               "&#x02A54;" ><!--dbl logical or -->
+<!ENTITY or               "&#x02228;" ><!--/vee /lor B: logical or -->
+<!ENTITY ord              "&#x02A5D;" ><!--or, horizontal dash -->
+<!ENTITY order            "&#x02134;" ><!--order of (script small o)  -->
+<!ENTITY oror             "&#x02A56;" ><!--two logical or -->
+<!ENTITY orslope          "&#x02A57;" ><!--sloping large or -->
+<!ENTITY orv              "&#x02A5B;" ><!--or with middle stem -->
+<!ENTITY par              "&#x02225;" ><!--/parallel R: parallel -->
+<!ENTITY parsl            "&#x02AFD;" ><!--parallel, slanted -->
+<!ENTITY part             "&#x02202;" ><!--/partial partial differential -->
+<!ENTITY permil           "&#x02030;" ><!--per thousand -->
+<!ENTITY perp             "&#x022A5;" ><!--/perp R: perpendicular -->
+<!ENTITY pertenk          "&#x02031;" ><!--per 10 thousand -->
+<!ENTITY phmmat           "&#x02133;" ><!--physics M-matrix (script capital M)  -->
+<!ENTITY pointint         "&#x02A15;" ><!--integral around a point operator -->
+<!ENTITY Prime            "&#x02033;" ><!--double prime or second -->
+<!ENTITY prime            "&#x02032;" ><!--/prime prime or minute -->
+<!ENTITY profalar         "&#x0232E;" ><!--all-around profile -->
+<!ENTITY profline         "&#x02312;" ><!--profile of a line -->
+<!ENTITY profsurf         "&#x02313;" ><!--profile of a surface -->
+<!ENTITY prop             "&#x0221D;" ><!--/propto R: is proportional to -->
+<!ENTITY qint             "&#x02A0C;" ><!--/iiiint quadruple integral operator -->
+<!ENTITY qprime           "&#x02057;" ><!--quadruple prime -->
+<!ENTITY quatint          "&#x02A16;" ><!--quaternion integral operator -->
+<!ENTITY radic            "&#x0221A;" ><!--/surd radical -->
+<!ENTITY Rang             "&#x0300B;" ><!--right angle bracket, double -->
+<!ENTITY rang             "&#x0232A;" ><!--/rangle C: right angle bracket -->
+<!ENTITY rArr             "&#x021D2;" ><!--/Rightarrow A: implies -->
+<!ENTITY rbbrk            "&#x03015;" ><!--right broken bracket -->
+<!ENTITY roang            "&#x03019;" ><!--right open angular bracket -->
+<!ENTITY robrk            "&#x0301B;" ><!--right open bracket -->
+<!ENTITY ropar            "&#x02986;" ><!--right open parenthesis -->
+<!ENTITY rppolint         "&#x02A12;" ><!--line integration, rectangular path around pole -->
+<!ENTITY scpolint         "&#x02A13;" ><!--line integration, semi-circular path around pole -->
+<!ENTITY sim              "&#x0223C;" ><!--/sim R: similar -->
+<!ENTITY simdot           "&#x02A6A;" ><!--similar, dot -->
+<!ENTITY sime             "&#x02243;" ><!--/simeq R: similar, equals -->
+<!ENTITY smeparsl         "&#x029E4;" ><!--similar, parallel, slanted, equal -->
+<!ENTITY square           "&#x025A1;" ><!--/square, square -->
+<!ENTITY squarf           "&#x025AA;" ><!--/blacksquare, square, filled  -->
+<!ENTITY strns            "&#x000AF;" ><!--straightness -->
+<!ENTITY sub              "&#x02282;" ><!--/subset R: subset or is implied by -->
+<!ENTITY sube             "&#x02286;" ><!--/subseteq R: subset, equals -->
+<!ENTITY sup              "&#x02283;" ><!--/supset R: superset or implies -->
+<!ENTITY supe             "&#x02287;" ><!--/supseteq R: superset, equals -->
+<!ENTITY tdot             "&#x020DB;" ><!--three dots above -->
+<!ENTITY there4           "&#x02234;" ><!--/therefore R: therefore -->
+<!ENTITY tint             "&#x0222D;" ><!--/iiint triple integral operator -->
+<!ENTITY top              "&#x022A4;" ><!--/top top -->
+<!ENTITY topbot           "&#x02336;" ><!--top and bottom -->
+<!ENTITY topcir           "&#x02AF1;" ><!--top, circle below -->
+<!ENTITY tprime           "&#x02034;" ><!--triple prime -->
+<!ENTITY utdot            "&#x022F0;" ><!--three dots, ascending -->
+<!ENTITY uwangle          "&#x029A7;" ><!--large upward pointing angle -->
+<!ENTITY vangrt           "&#x0299C;" ><!--right angle, variant -->
+<!ENTITY veeeq            "&#x0225A;" ><!--logical or, equals -->
+<!ENTITY Verbar           "&#x02016;" ><!--/Vert dbl vertical bar -->
+<!ENTITY wedgeq           "&#x02259;" ><!--/wedgeq R: corresponds to (wedge, equals) -->
+<!ENTITY xnis             "&#x022FB;" ><!--large contains, vertical bar on horizontal stroke -->

--- a/publishing/1.1/mathml/mmlalias.ent
+++ b/publishing/1.1/mathml/mmlalias.ent
@@ -1,0 +1,564 @@
+
+<!--
+     File mmlalias.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     References to the VARIANT SELECTOR 1 character (&#x0FE00;)
+     should match the uses listed in Unicode Technical Report 25.
+
+-->
+
+<!ENTITY angle            "&#x02220;" ><!--alias ISOAMSO ang -->
+<!ENTITY ApplyFunction    "&#x02061;" ><!--character showing function application in presentation tagging -->
+<!ENTITY approx           "&#x02248;" ><!--alias ISOTECH ap -->
+<!ENTITY approxeq         "&#x0224A;" ><!--alias ISOAMSR ape -->
+<!ENTITY Assign           "&#x02254;" ><!--assignment operator, alias ISOAMSR colone -->
+<!ENTITY backcong         "&#x0224C;" ><!--alias ISOAMSR bcong -->
+<!ENTITY backepsilon      "&#x003F6;" ><!--alias ISOAMSR bepsi -->
+<!ENTITY backprime        "&#x02035;" ><!--alias ISOAMSO bprime -->
+<!ENTITY backsim          "&#x0223D;" ><!--alias ISOAMSR bsim -->
+<!ENTITY backsimeq        "&#x022CD;" ><!--alias ISOAMSR bsime -->
+<!ENTITY Backslash        "&#x02216;" ><!--alias ISOAMSB setmn -->
+<!ENTITY barwedge         "&#x02305;" ><!--alias ISOAMSB barwed -->
+<!ENTITY Because          "&#x02235;" ><!--alias ISOTECH becaus -->
+<!ENTITY because          "&#x02235;" ><!--alias ISOTECH becaus -->
+<!ENTITY Bernoullis       "&#x0212C;" ><!--alias ISOTECH bernou -->
+<!ENTITY between          "&#x0226C;" ><!--alias ISOAMSR twixt -->
+<!ENTITY bigcap           "&#x022C2;" ><!--alias ISOAMSB xcap -->
+<!ENTITY bigcirc          "&#x025EF;" ><!--alias ISOAMSB xcirc -->
+<!ENTITY bigcup           "&#x022C3;" ><!--alias ISOAMSB xcup -->
+<!ENTITY bigodot          "&#x02A00;" ><!--alias ISOAMSB xodot -->
+<!ENTITY bigoplus         "&#x02A01;" ><!--alias ISOAMSB xoplus -->
+<!ENTITY bigotimes        "&#x02A02;" ><!--alias ISOAMSB xotime -->
+<!ENTITY bigsqcup         "&#x02A06;" ><!--alias ISOAMSB xsqcup -->
+<!ENTITY bigstar          "&#x02605;" ><!--ISOPUB    starf  -->
+<!ENTITY bigtriangledown  "&#x025BD;" ><!--alias ISOAMSB xdtri -->
+<!ENTITY bigtriangleup    "&#x025B3;" ><!--alias ISOAMSB xutri -->
+<!ENTITY biguplus         "&#x02A04;" ><!--alias ISOAMSB xuplus -->
+<!ENTITY bigvee           "&#x022C1;" ><!--alias ISOAMSB xvee -->
+<!ENTITY bigwedge         "&#x022C0;" ><!--alias ISOAMSB xwedge -->
+<!ENTITY bkarow           "&#x0290D;" ><!--alias ISOAMSA rbarr -->
+<!ENTITY blacklozenge     "&#x029EB;" ><!--alias ISOPUB lozf -->
+<!ENTITY blacksquare      "&#x025AA;" ><!--ISOTECH  squarf  -->
+<!ENTITY blacktriangle    "&#x025B4;" ><!--alias ISOPUB utrif -->
+<!ENTITY blacktriangledown "&#x025BE;" ><!--alias ISOPUB dtrif -->
+<!ENTITY blacktriangleleft "&#x025C2;" ><!--alias ISOPUB ltrif -->
+<!ENTITY blacktriangleright "&#x025B8;" ><!--alias ISOPUB rtrif -->
+<!ENTITY bot              "&#x022A5;" ><!--alias ISOTECH bottom -->
+<!ENTITY boxminus         "&#x0229F;" ><!--alias ISOAMSB minusb -->
+<!ENTITY boxplus          "&#x0229E;" ><!--alias ISOAMSB plusb -->
+<!ENTITY boxtimes         "&#x022A0;" ><!--alias ISOAMSB timesb -->
+<!ENTITY Breve            "&#x002D8;" ><!--alias ISODIA breve -->
+<!ENTITY bullet           "&#x02022;" ><!--alias ISOPUB bull -->
+<!ENTITY Bumpeq           "&#x0224E;" ><!--alias ISOAMSR bump -->
+<!ENTITY bumpeq           "&#x0224F;" ><!--alias ISOAMSR bumpe -->
+<!ENTITY CapitalDifferentialD "&#x02145;" ><!--D for use in differentials, e.g., within integrals -->
+<!ENTITY Cayleys          "&#x0212D;" ><!--the non-associative ring of octonions or Cayley numbers -->
+<!ENTITY Cedilla          "&#x000B8;" ><!--alias ISODIA cedil -->
+<!ENTITY CenterDot        "&#x000B7;" ><!--alias ISONUM middot -->
+<!ENTITY centerdot        "&#x000B7;" ><!--alias ISONUM middot -->
+<!ENTITY checkmark        "&#x02713;" ><!--alias ISOPUB check -->
+<!ENTITY circeq           "&#x02257;" ><!--alias ISOAMSR cire -->
+<!ENTITY circlearrowleft  "&#x021BA;" ><!--alias ISOAMSA olarr -->
+<!ENTITY circlearrowright "&#x021BB;" ><!--alias ISOAMSA orarr -->
+<!ENTITY circledast       "&#x0229B;" ><!--alias ISOAMSB oast -->
+<!ENTITY circledcirc      "&#x0229A;" ><!--alias ISOAMSB ocir -->
+<!ENTITY circleddash      "&#x0229D;" ><!--alias ISOAMSB odash -->
+<!ENTITY CircleDot        "&#x02299;" ><!--alias ISOAMSB odot -->
+<!ENTITY circledR         "&#x000AE;" ><!--alias ISONUM reg -->
+<!ENTITY circledS         "&#x024C8;" ><!--alias ISOAMSO oS -->
+<!ENTITY CircleMinus      "&#x02296;" ><!--alias ISOAMSB ominus -->
+<!ENTITY CirclePlus       "&#x02295;" ><!--alias ISOAMSB oplus -->
+<!ENTITY CircleTimes      "&#x02297;" ><!--alias ISOAMSB otimes -->
+<!ENTITY ClockwiseContourIntegral "&#x02232;" ><!--alias ISOTECH cwconint -->
+<!ENTITY CloseCurlyDoubleQuote "&#x0201D;" ><!--alias ISONUM rdquo -->
+<!ENTITY CloseCurlyQuote  "&#x02019;" ><!--alias ISONUM rsquo -->
+<!ENTITY clubsuit         "&#x02663;" ><!--ISOPUB    clubs  -->
+<!ENTITY coloneq          "&#x02254;" ><!--alias ISOAMSR colone -->
+<!ENTITY complement       "&#x02201;" ><!--alias ISOAMSO comp -->
+<!ENTITY complexes        "&#x02102;" ><!--the field of complex numbers -->
+<!ENTITY Congruent        "&#x02261;" ><!--alias ISOTECH equiv -->
+<!ENTITY ContourIntegral  "&#x0222E;" ><!--alias ISOTECH conint -->
+<!ENTITY Coproduct        "&#x02210;" ><!--alias ISOAMSB coprod -->
+<!ENTITY CounterClockwiseContourIntegral "&#x02233;" ><!--alias ISOTECH awconint -->
+<!ENTITY CupCap           "&#x0224D;" ><!--alias asympeq -->
+<!ENTITY curlyeqprec      "&#x022DE;" ><!--alias ISOAMSR cuepr -->
+<!ENTITY curlyeqsucc      "&#x022DF;" ><!--alias ISOAMSR cuesc -->
+<!ENTITY curlyvee         "&#x022CE;" ><!--alias ISOAMSB cuvee -->
+<!ENTITY curlywedge       "&#x022CF;" ><!--alias ISOAMSB cuwed -->
+<!ENTITY curvearrowleft   "&#x021B6;" ><!--alias ISOAMSA cularr -->
+<!ENTITY curvearrowright  "&#x021B7;" ><!--alias ISOAMSA curarr -->
+<!ENTITY dbkarow          "&#x0290F;" ><!--alias ISOAMSA rBarr -->
+<!ENTITY ddagger          "&#x02021;" ><!--alias ISOPUB Dagger -->
+<!ENTITY ddotseq          "&#x02A77;" ><!--alias ISOAMSR eDDot -->
+<!ENTITY Del              "&#x02207;" ><!--alias ISOTECH nabla -->
+<!ENTITY DiacriticalAcute "&#x000B4;" ><!--alias ISODIA acute -->
+<!ENTITY DiacriticalDot   "&#x002D9;" ><!--alias ISODIA dot -->
+<!ENTITY DiacriticalDoubleAcute "&#x002DD;" ><!--alias ISODIA dblac -->
+<!ENTITY DiacriticalGrave "&#x00060;" ><!--alias ISODIA grave -->
+<!ENTITY DiacriticalTilde "&#x002DC;" ><!--alias ISODIA tilde -->
+<!ENTITY Diamond          "&#x022C4;" ><!--alias ISOAMSB diam -->
+<!ENTITY diamond          "&#x022C4;" ><!--alias ISOAMSB diam -->
+<!ENTITY diamondsuit      "&#x02666;" ><!--ISOPUB    diams  -->
+<!ENTITY DifferentialD    "&#x02146;" ><!--d for use in differentials, e.g., within integrals -->
+<!ENTITY digamma          "&#x003DD;" ><!--alias ISOGRK3 gammad -->
+<!ENTITY div              "&#x000F7;" ><!--alias ISONUM divide -->
+<!ENTITY divideontimes    "&#x022C7;" ><!--alias ISOAMSB divonx -->
+<!ENTITY doteq            "&#x02250;" ><!--alias ISOAMSR esdot -->
+<!ENTITY doteqdot         "&#x02251;" ><!--alias ISOAMSR eDot -->
+<!ENTITY DotEqual         "&#x02250;" ><!--alias ISOAMSR esdot -->
+<!ENTITY dotminus         "&#x02238;" ><!--alias ISOAMSB minusd -->
+<!ENTITY dotplus          "&#x02214;" ><!--alias ISOAMSB plusdo -->
+<!ENTITY dotsquare        "&#x022A1;" ><!--alias ISOAMSB sdotb -->
+<!ENTITY doublebarwedge   "&#x02306;" ><!--alias ISOAMSB Barwed -->
+<!ENTITY DoubleContourIntegral "&#x0222F;" ><!--alias ISOTECH Conint -->
+<!ENTITY DoubleDot        "&#x000A8;" ><!--alias ISODIA die -->
+<!ENTITY DoubleDownArrow  "&#x021D3;" ><!--alias ISOAMSA dArr -->
+<!ENTITY DoubleLeftArrow  "&#x021D0;" ><!--alias ISOTECH lArr -->
+<!ENTITY DoubleLeftRightArrow "&#x021D4;" ><!--alias ISOAMSA hArr -->
+<!ENTITY DoubleLeftTee    "&#x02AE4;" ><!--alias for  &Dashv;  -->
+<!ENTITY DoubleLongLeftArrow "&#x027F8;" ><!--alias ISOAMSA xlArr -->
+<!ENTITY DoubleLongLeftRightArrow "&#x027FA;" ><!--alias ISOAMSA xhArr -->
+<!ENTITY DoubleLongRightArrow "&#x027F9;" ><!--alias ISOAMSA xrArr -->
+<!ENTITY DoubleRightArrow "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY DoubleRightTee   "&#x022A8;" ><!--alias ISOAMSR vDash -->
+<!ENTITY DoubleUpArrow    "&#x021D1;" ><!--alias ISOAMSA uArr -->
+<!ENTITY DoubleUpDownArrow "&#x021D5;" ><!--alias ISOAMSA vArr -->
+<!ENTITY DoubleVerticalBar "&#x02225;" ><!--alias ISOTECH par -->
+<!ENTITY DownArrow        "&#x02193;" ><!--alias ISONUM darr -->
+<!ENTITY Downarrow        "&#x021D3;" ><!--alias ISOAMSA dArr -->
+<!ENTITY downarrow        "&#x02193;" ><!--alias ISONUM darr -->
+<!ENTITY DownArrowUpArrow "&#x021F5;" ><!--alias ISOAMSA duarr -->
+<!ENTITY downdownarrows   "&#x021CA;" ><!--alias ISOAMSA ddarr -->
+<!ENTITY downharpoonleft  "&#x021C3;" ><!--alias ISOAMSA dharl -->
+<!ENTITY downharpoonright "&#x021C2;" ><!--alias ISOAMSA dharr -->
+<!ENTITY DownLeftVector   "&#x021BD;" ><!--alias ISOAMSA lhard -->
+<!ENTITY DownRightVector  "&#x021C1;" ><!--alias ISOAMSA rhard -->
+<!ENTITY DownTee          "&#x022A4;" ><!--alias ISOTECH top -->
+<!ENTITY DownTeeArrow     "&#x021A7;" ><!--alias for mapstodown -->
+<!ENTITY drbkarow         "&#x02910;" ><!--alias ISOAMSA RBarr -->
+<!ENTITY Element          "&#x02208;" ><!--alias ISOTECH isinv -->
+<!ENTITY emptyset         "&#x02205;" ><!--alias ISOAMSO empty -->
+<!ENTITY eqcirc           "&#x02256;" ><!--alias ISOAMSR ecir -->
+<!ENTITY eqcolon          "&#x02255;" ><!--alias ISOAMSR ecolon -->
+<!ENTITY eqsim            "&#x02242;" ><!--alias ISOAMSR esim -->
+<!ENTITY eqslantgtr       "&#x02A96;" ><!--alias ISOAMSR egs -->
+<!ENTITY eqslantless      "&#x02A95;" ><!--alias ISOAMSR els -->
+<!ENTITY EqualTilde       "&#x02242;" ><!--alias ISOAMSR esim -->
+<!ENTITY Equilibrium      "&#x021CC;" ><!--alias ISOAMSA rlhar -->
+<!ENTITY Exists           "&#x02203;" ><!--alias ISOTECH exist -->
+<!ENTITY expectation      "&#x02130;" ><!--expectation (operator) -->
+<!ENTITY ExponentialE     "&#x02147;" ><!--e use for the exponential base of the natural logarithms -->
+<!ENTITY exponentiale     "&#x02147;" ><!--base of the Napierian logarithms -->
+<!ENTITY fallingdotseq    "&#x02252;" ><!--alias ISOAMSR efDot -->
+<!ENTITY ForAll           "&#x02200;" ><!--alias ISOTECH forall -->
+<!ENTITY Fouriertrf       "&#x02131;" ><!--Fourier transform -->
+<!ENTITY geq              "&#x02265;" ><!--alias ISOTECH ge -->
+<!ENTITY geqq             "&#x02267;" ><!--alias ISOAMSR gE -->
+<!ENTITY geqslant         "&#x02A7E;" ><!--alias ISOAMSR ges -->
+<!ENTITY gg               "&#x0226B;" ><!--alias ISOAMSR Gt -->
+<!ENTITY ggg              "&#x022D9;" ><!--alias ISOAMSR Gg -->
+<!ENTITY gnapprox         "&#x02A8A;" ><!--alias ISOAMSN gnap -->
+<!ENTITY gneq             "&#x02A88;" ><!--alias ISOAMSN gne -->
+<!ENTITY gneqq            "&#x02269;" ><!--alias ISOAMSN gnE -->
+<!ENTITY GreaterEqual     "&#x02265;" ><!--alias ISOTECH ge -->
+<!ENTITY GreaterEqualLess "&#x022DB;" ><!--alias ISOAMSR gel -->
+<!ENTITY GreaterFullEqual "&#x02267;" ><!--alias ISOAMSR gE -->
+<!ENTITY GreaterLess      "&#x02277;" ><!--alias ISOAMSR gl -->
+<!ENTITY GreaterSlantEqual "&#x02A7E;" ><!--alias ISOAMSR ges -->
+<!ENTITY GreaterTilde     "&#x02273;" ><!--alias ISOAMSR gsim -->
+<!ENTITY gtrapprox        "&#x02A86;" ><!--alias ISOAMSR gap -->
+<!ENTITY gtrdot           "&#x022D7;" ><!--alias ISOAMSR gtdot -->
+<!ENTITY gtreqless        "&#x022DB;" ><!--alias ISOAMSR gel -->
+<!ENTITY gtreqqless       "&#x02A8C;" ><!--alias ISOAMSR gEl -->
+<!ENTITY gtrless          "&#x02277;" ><!--alias ISOAMSR gl -->
+<!ENTITY gtrsim           "&#x02273;" ><!--alias ISOAMSR gsim -->
+<!ENTITY gvertneqq        "&#x02269;&#x0FE00;" ><!--alias ISOAMSN gvnE -->
+<!ENTITY Hacek            "&#x002C7;" ><!--alias ISODIA caron -->
+<!ENTITY hbar             "&#x0210F;" ><!--alias ISOAMSO plank -->
+<!ENTITY heartsuit        "&#x02665;" ><!--ISOPUB hearts -->
+<!ENTITY HilbertSpace     "&#x0210B;" ><!--Hilbert space -->
+<!ENTITY hksearow         "&#x02925;" ><!--alias ISOAMSA searhk -->
+<!ENTITY hkswarow         "&#x02926;" ><!--alias ISOAMSA swarhk -->
+<!ENTITY hookleftarrow    "&#x021A9;" ><!--alias ISOAMSA larrhk -->
+<!ENTITY hookrightarrow   "&#x021AA;" ><!--alias ISOAMSA rarrhk -->
+<!ENTITY hslash           "&#x0210F;" ><!--alias ISOAMSO plankv -->
+<!ENTITY HumpDownHump     "&#x0224E;" ><!--alias ISOAMSR bump -->
+<!ENTITY HumpEqual        "&#x0224F;" ><!--alias ISOAMSR bumpe -->
+<!ENTITY iiiint           "&#x02A0C;" ><!--alias ISOTECH qint -->
+<!ENTITY iiint            "&#x0222D;" ><!--alias ISOTECH tint -->
+<!ENTITY Im               "&#x02111;" ><!--alias ISOAMSO image -->
+<!ENTITY ImaginaryI       "&#x02148;" ><!--i for use as a square root of -1 -->
+<!ENTITY imagline         "&#x02110;" ><!--the geometric imaginary line -->
+<!ENTITY imagpart         "&#x02111;" ><!--alias ISOAMSO image -->
+<!ENTITY Implies          "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY in               "&#x02208;" ><!--ISOTECH   isin  -->
+<!ENTITY integers         "&#x02124;" ><!--the ring of integers -->
+<!ENTITY Integral         "&#x0222B;" ><!--alias ISOTECH int -->
+<!ENTITY intercal         "&#x022BA;" ><!--alias ISOAMSB intcal -->
+<!ENTITY Intersection     "&#x022C2;" ><!--alias ISOAMSB xcap -->
+<!ENTITY intprod          "&#x02A3C;" ><!--alias ISOAMSB iprod -->
+<!ENTITY InvisibleComma   "&#x02063;" ><!--used as a separator, e.g., in indices -->
+<!ENTITY InvisibleTimes   "&#x02062;" ><!--marks multiplication when it is understood without a mark -->
+<!ENTITY langle           "&#x02329;" ><!--alias ISOTECH lang -->
+<!ENTITY Laplacetrf       "&#x02112;" ><!--Laplace transform -->
+<!ENTITY lbrace           "&#x0007B;" ><!--alias ISONUM lcub -->
+<!ENTITY lbrack           "&#x0005B;" ><!--alias ISONUM lsqb -->
+<!ENTITY LeftAngleBracket "&#x02329;" ><!--alias ISOTECH lang -->
+<!ENTITY LeftArrow        "&#x02190;" ><!--alias ISONUM larr -->
+<!ENTITY Leftarrow        "&#x021D0;" ><!--alias ISOTECH lArr -->
+<!ENTITY leftarrow        "&#x02190;" ><!--alias ISONUM larr -->
+<!ENTITY LeftArrowBar     "&#x021E4;" ><!--alias for larrb -->
+<!ENTITY LeftArrowRightArrow "&#x021C6;" ><!--alias ISOAMSA lrarr -->
+<!ENTITY leftarrowtail    "&#x021A2;" ><!--alias ISOAMSA larrtl -->
+<!ENTITY LeftCeiling      "&#x02308;" ><!--alias ISOAMSC lceil -->
+<!ENTITY LeftDoubleBracket "&#x0301A;" ><!--left double bracket delimiter -->
+<!ENTITY LeftDownVector   "&#x021C3;" ><!--alias ISOAMSA dharl -->
+<!ENTITY LeftFloor        "&#x0230A;" ><!--alias ISOAMSC lfloor -->
+<!ENTITY leftharpoondown  "&#x021BD;" ><!--alias ISOAMSA lhard -->
+<!ENTITY leftharpoonup    "&#x021BC;" ><!--alias ISOAMSA lharu -->
+<!ENTITY leftleftarrows   "&#x021C7;" ><!--alias ISOAMSA llarr -->
+<!ENTITY LeftRightArrow   "&#x02194;" ><!--alias ISOAMSA harr -->
+<!ENTITY Leftrightarrow   "&#x021D4;" ><!--alias ISOAMSA hArr -->
+<!ENTITY leftrightarrow   "&#x02194;" ><!--alias ISOAMSA harr -->
+<!ENTITY leftrightarrows  "&#x021C6;" ><!--alias ISOAMSA lrarr -->
+<!ENTITY leftrightharpoons "&#x021CB;" ><!--alias ISOAMSA lrhar -->
+<!ENTITY leftrightsquigarrow "&#x021AD;" ><!--alias ISOAMSA harrw -->
+<!ENTITY LeftTee          "&#x022A3;" ><!--alias ISOAMSR dashv -->
+<!ENTITY LeftTeeArrow     "&#x021A4;" ><!--alias for mapstoleft -->
+<!ENTITY leftthreetimes   "&#x022CB;" ><!--alias ISOAMSB lthree -->
+<!ENTITY LeftTriangle     "&#x022B2;" ><!--alias ISOAMSR vltri -->
+<!ENTITY LeftTriangleEqual "&#x022B4;" ><!--alias ISOAMSR ltrie -->
+<!ENTITY LeftUpVector     "&#x021BF;" ><!--alias ISOAMSA uharl -->
+<!ENTITY LeftVector       "&#x021BC;" ><!--alias ISOAMSA lharu -->
+<!ENTITY leq              "&#x02264;" ><!--alias ISOTECH le -->
+<!ENTITY leqq             "&#x02266;" ><!--alias ISOAMSR lE -->
+<!ENTITY leqslant         "&#x02A7D;" ><!--alias ISOAMSR les -->
+<!ENTITY lessapprox       "&#x02A85;" ><!--alias ISOAMSR lap -->
+<!ENTITY lessdot          "&#x022D6;" ><!--alias ISOAMSR ltdot -->
+<!ENTITY lesseqgtr        "&#x022DA;" ><!--alias ISOAMSR leg -->
+<!ENTITY lesseqqgtr       "&#x02A8B;" ><!--alias ISOAMSR lEg -->
+<!ENTITY LessEqualGreater "&#x022DA;" ><!--alias ISOAMSR leg -->
+<!ENTITY LessFullEqual    "&#x02266;" ><!--alias ISOAMSR lE -->
+<!ENTITY LessGreater      "&#x02276;" ><!--alias ISOAMSR lg -->
+<!ENTITY lessgtr          "&#x02276;" ><!--alias ISOAMSR lg -->
+<!ENTITY lesssim          "&#x02272;" ><!--alias ISOAMSR lsim -->
+<!ENTITY LessSlantEqual   "&#x02A7D;" ><!--alias ISOAMSR les -->
+<!ENTITY LessTilde        "&#x02272;" ><!--alias ISOAMSR lsim -->
+<!ENTITY ll               "&#x0226A;" ><!--alias ISOAMSR Lt -->
+<!ENTITY llcorner         "&#x0231E;" ><!--alias ISOAMSC dlcorn -->
+<!ENTITY Lleftarrow       "&#x021DA;" ><!--alias ISOAMSA lAarr -->
+<!ENTITY lmoustache       "&#x023B0;" ><!--alias ISOAMSC lmoust -->
+<!ENTITY lnapprox         "&#x02A89;" ><!--alias ISOAMSN lnap -->
+<!ENTITY lneq             "&#x02A87;" ><!--alias ISOAMSN lne -->
+<!ENTITY lneqq            "&#x02268;" ><!--alias ISOAMSN lnE -->
+<!ENTITY LongLeftArrow    "&#x027F5;" ><!--alias ISOAMSA xlarr -->
+<!ENTITY Longleftarrow    "&#x027F8;" ><!--alias ISOAMSA xlArr -->
+<!ENTITY longleftarrow    "&#x027F5;" ><!--alias ISOAMSA xlarr -->
+<!ENTITY LongLeftRightArrow "&#x027F7;" ><!--alias ISOAMSA xharr -->
+<!ENTITY Longleftrightarrow "&#x027FA;" ><!--alias ISOAMSA xhArr -->
+<!ENTITY longleftrightarrow "&#x027F7;" ><!--alias ISOAMSA xharr -->
+<!ENTITY longmapsto       "&#x027FC;" ><!--alias ISOAMSA xmap -->
+<!ENTITY LongRightArrow   "&#x027F6;" ><!--alias ISOAMSA xrarr -->
+<!ENTITY Longrightarrow   "&#x027F9;" ><!--alias ISOAMSA xrArr -->
+<!ENTITY longrightarrow   "&#x027F6;" ><!--alias ISOAMSA xrarr -->
+<!ENTITY looparrowleft    "&#x021AB;" ><!--alias ISOAMSA larrlp -->
+<!ENTITY looparrowright   "&#x021AC;" ><!--alias ISOAMSA rarrlp -->
+<!ENTITY LowerLeftArrow   "&#x02199;" ><!--alias ISOAMSA swarr -->
+<!ENTITY LowerRightArrow  "&#x02198;" ><!--alias ISOAMSA searr -->
+<!ENTITY lozenge          "&#x025CA;" ><!--alias ISOPUB loz -->
+<!ENTITY lrcorner         "&#x0231F;" ><!--alias ISOAMSC drcorn -->
+<!ENTITY Lsh              "&#x021B0;" ><!--alias ISOAMSA lsh -->
+<!ENTITY lvertneqq        "&#x02268;&#x0FE00;" ><!--alias ISOAMSN lvnE -->
+<!ENTITY maltese          "&#x02720;" ><!--alias ISOPUB malt -->
+<!ENTITY mapsto           "&#x021A6;" ><!--alias ISOAMSA map -->
+<!ENTITY measuredangle    "&#x02221;" ><!--alias ISOAMSO angmsd -->
+<!ENTITY Mellintrf        "&#x02133;" ><!--Mellin transform -->
+<!ENTITY MinusPlus        "&#x02213;" ><!--alias ISOTECH mnplus -->
+<!ENTITY mp               "&#x02213;" ><!--alias ISOTECH mnplus -->
+<!ENTITY multimap         "&#x022B8;" ><!--alias ISOAMSA mumap -->
+<!ENTITY napprox          "&#x02249;" ><!--alias ISOAMSN nap -->
+<!ENTITY natural          "&#x0266E;" ><!--alias ISOPUB natur -->
+<!ENTITY naturals         "&#x02115;" ><!--the semi-ring of natural numbers -->
+<!ENTITY nearrow          "&#x02197;" ><!--alias ISOAMSA nearr -->
+<!ENTITY NegativeMediumSpace "&#x0200B;" ><!--space of width -4/18 em -->
+<!ENTITY NegativeThickSpace "&#x0200B;" ><!--space of width -5/18 em -->
+<!ENTITY NegativeThinSpace "&#x0200B;" ><!--space of width -3/18 em -->
+<!ENTITY NegativeVeryThinSpace "&#x0200B;" ><!--space of width -1/18 em -->
+<!ENTITY NestedGreaterGreater "&#x0226B;" ><!--alias ISOAMSR Gt -->
+<!ENTITY NestedLessLess   "&#x0226A;" ><!--alias ISOAMSR Lt -->
+<!ENTITY nexists          "&#x02204;" ><!--alias ISOAMSO nexist -->
+<!ENTITY ngeq             "&#x02271;" ><!--alias ISOAMSN nge -->
+<!ENTITY ngeqq            "&#x02267;&#x00338;" ><!--alias ISOAMSN ngE -->
+<!ENTITY ngeqslant        "&#x02A7E;&#x00338;" ><!--alias ISOAMSN nges -->
+<!ENTITY ngtr             "&#x0226F;" ><!--alias ISOAMSN ngt -->
+<!ENTITY nLeftarrow       "&#x021CD;" ><!--alias ISOAMSA nlArr -->
+<!ENTITY nleftarrow       "&#x0219A;" ><!--alias ISOAMSA nlarr -->
+<!ENTITY nLeftrightarrow  "&#x021CE;" ><!--alias ISOAMSA nhArr -->
+<!ENTITY nleftrightarrow  "&#x021AE;" ><!--alias ISOAMSA nharr -->
+<!ENTITY nleq             "&#x02270;" ><!--alias ISOAMSN nle -->
+<!ENTITY nleqq            "&#x02266;&#x00338;" ><!--alias ISOAMSN nlE -->
+<!ENTITY nleqslant        "&#x02A7D;&#x00338;" ><!--alias ISOAMSN nles -->
+<!ENTITY nless            "&#x0226E;" ><!--alias ISOAMSN nlt -->
+<!ENTITY NonBreakingSpace "&#x000A0;" ><!--alias ISONUM nbsp -->
+<!ENTITY NotCongruent     "&#x02262;" ><!--alias ISOAMSN nequiv -->
+<!ENTITY NotDoubleVerticalBar "&#x02226;" ><!--alias ISOAMSN npar -->
+<!ENTITY NotElement       "&#x02209;" ><!--alias ISOTECH notin -->
+<!ENTITY NotEqual         "&#x02260;" ><!--alias ISOTECH ne -->
+<!ENTITY NotEqualTilde    "&#x02242;&#x00338;" ><!--alias for  &nesim; -->
+<!ENTITY NotExists        "&#x02204;" ><!--alias ISOAMSO nexist -->
+<!ENTITY NotGreater       "&#x0226F;" ><!--alias ISOAMSN ngt -->
+<!ENTITY NotGreaterEqual  "&#x02271;" ><!--alias ISOAMSN nge -->
+<!ENTITY NotGreaterFullEqual "&#x02266;&#x00338;" ><!--alias ISOAMSN nlE -->
+<!ENTITY NotGreaterGreater "&#x0226B;&#x00338;" ><!--alias ISOAMSN nGtv -->
+<!ENTITY NotGreaterLess   "&#x02279;" ><!--alias ISOAMSN ntvgl -->
+<!ENTITY NotGreaterSlantEqual "&#x02A7E;&#x00338;" ><!--alias ISOAMSN nges -->
+<!ENTITY NotGreaterTilde  "&#x02275;" ><!--alias ISOAMSN ngsim -->
+<!ENTITY NotHumpDownHump  "&#x0224E;&#x00338;" ><!--alias for &nbump; -->
+<!ENTITY NotLeftTriangle  "&#x022EA;" ><!--alias ISOAMSN nltri -->
+<!ENTITY NotLeftTriangleEqual "&#x022EC;" ><!--alias ISOAMSN nltrie -->
+<!ENTITY NotLess          "&#x0226E;" ><!--alias ISOAMSN nlt -->
+<!ENTITY NotLessEqual     "&#x02270;" ><!--alias ISOAMSN nle -->
+<!ENTITY NotLessGreater   "&#x02278;" ><!--alias ISOAMSN ntvlg -->
+<!ENTITY NotLessLess      "&#x0226A;&#x00338;" ><!--alias ISOAMSN nLtv -->
+<!ENTITY NotLessSlantEqual "&#x02A7D;&#x00338;" ><!--alias ISOAMSN nles -->
+<!ENTITY NotLessTilde     "&#x02274;" ><!--alias ISOAMSN nlsim -->
+<!ENTITY NotPrecedes      "&#x02280;" ><!--alias ISOAMSN npr -->
+<!ENTITY NotPrecedesEqual "&#x02AAF;&#x00338;" ><!--alias ISOAMSN npre -->
+<!ENTITY NotPrecedesSlantEqual "&#x022E0;" ><!--alias ISOAMSN nprcue -->
+<!ENTITY NotReverseElement "&#x0220C;" ><!--alias ISOTECH notniva -->
+<!ENTITY NotRightTriangle "&#x022EB;" ><!--alias ISOAMSN nrtri -->
+<!ENTITY NotRightTriangleEqual "&#x022ED;" ><!--alias ISOAMSN nrtrie -->
+<!ENTITY NotSquareSubsetEqual "&#x022E2;" ><!--alias ISOAMSN nsqsube -->
+<!ENTITY NotSquareSupersetEqual "&#x022E3;" ><!--alias ISOAMSN nsqsupe -->
+<!ENTITY NotSubset        "&#x02282;&#x020D2;" ><!--alias ISOAMSN vnsub -->
+<!ENTITY NotSubsetEqual   "&#x02288;" ><!--alias ISOAMSN nsube -->
+<!ENTITY NotSucceeds      "&#x02281;" ><!--alias ISOAMSN nsc -->
+<!ENTITY NotSucceedsEqual "&#x02AB0;&#x00338;" ><!--alias ISOAMSN nsce -->
+<!ENTITY NotSucceedsSlantEqual "&#x022E1;" ><!--alias ISOAMSN nsccue -->
+<!ENTITY NotSuperset      "&#x02283;&#x020D2;" ><!--alias ISOAMSN vnsup -->
+<!ENTITY NotSupersetEqual "&#x02289;" ><!--alias ISOAMSN nsupe -->
+<!ENTITY NotTilde         "&#x02241;" ><!--alias ISOAMSN nsim -->
+<!ENTITY NotTildeEqual    "&#x02244;" ><!--alias ISOAMSN nsime -->
+<!ENTITY NotTildeFullEqual "&#x02247;" ><!--alias ISOAMSN ncong -->
+<!ENTITY NotTildeTilde    "&#x02249;" ><!--alias ISOAMSN nap -->
+<!ENTITY NotVerticalBar   "&#x02224;" ><!--alias ISOAMSN nmid -->
+<!ENTITY nparallel        "&#x02226;" ><!--alias ISOAMSN npar -->
+<!ENTITY nprec            "&#x02280;" ><!--alias ISOAMSN npr -->
+<!ENTITY npreceq          "&#x02AAF;&#x00338;" ><!--alias ISOAMSN npre -->
+<!ENTITY nRightarrow      "&#x021CF;" ><!--alias ISOAMSA nrArr -->
+<!ENTITY nrightarrow      "&#x0219B;" ><!--alias ISOAMSA nrarr -->
+<!ENTITY nshortmid        "&#x02224;" ><!--alias ISOAMSN nsmid -->
+<!ENTITY nshortparallel   "&#x02226;" ><!--alias ISOAMSN nspar -->
+<!ENTITY nsimeq           "&#x02244;" ><!--alias ISOAMSN nsime -->
+<!ENTITY nsubset          "&#x02282;&#x020D2;" ><!--alias ISOAMSN vnsub -->
+<!ENTITY nsubseteq        "&#x02288;" ><!--alias ISOAMSN nsube -->
+<!ENTITY nsubseteqq       "&#x02AC5;&#x00338;" ><!--alias ISOAMSN nsubE -->
+<!ENTITY nsucc            "&#x02281;" ><!--alias ISOAMSN nsc -->
+<!ENTITY nsucceq          "&#x02AB0;&#x00338;" ><!--alias ISOAMSN nsce -->
+<!ENTITY nsupset          "&#x02283;&#x020D2;" ><!--alias ISOAMSN vnsup -->
+<!ENTITY nsupseteq        "&#x02289;" ><!--alias ISOAMSN nsupe -->
+<!ENTITY nsupseteqq       "&#x02AC6;&#x00338;" ><!--alias ISOAMSN nsupE -->
+<!ENTITY ntriangleleft    "&#x022EA;" ><!--alias ISOAMSN nltri -->
+<!ENTITY ntrianglelefteq  "&#x022EC;" ><!--alias ISOAMSN nltrie -->
+<!ENTITY ntriangleright   "&#x022EB;" ><!--alias ISOAMSN nrtri -->
+<!ENTITY ntrianglerighteq "&#x022ED;" ><!--alias ISOAMSN nrtrie -->
+<!ENTITY nwarrow          "&#x02196;" ><!--alias ISOAMSA nwarr -->
+<!ENTITY oint             "&#x0222E;" ><!--alias ISOTECH conint -->
+<!ENTITY OpenCurlyDoubleQuote "&#x0201C;" ><!--alias ISONUM ldquo -->
+<!ENTITY OpenCurlyQuote   "&#x02018;" ><!--alias ISONUM lsquo -->
+<!ENTITY orderof          "&#x02134;" ><!--alias ISOTECH order -->
+<!ENTITY parallel         "&#x02225;" ><!--alias ISOTECH par -->
+<!ENTITY PartialD         "&#x02202;" ><!--alias ISOTECH part -->
+<!ENTITY pitchfork        "&#x022D4;" ><!--alias ISOAMSR fork -->
+<!ENTITY PlusMinus        "&#x000B1;" ><!--alias ISONUM plusmn -->
+<!ENTITY pm               "&#x000B1;" ><!--alias ISONUM plusmn -->
+<!ENTITY Poincareplane    "&#x0210C;" ><!--the Poincare upper half-plane -->
+<!ENTITY prec             "&#x0227A;" ><!--alias ISOAMSR pr -->
+<!ENTITY precapprox       "&#x02AB7;" ><!--alias ISOAMSR prap -->
+<!ENTITY preccurlyeq      "&#x0227C;" ><!--alias ISOAMSR prcue -->
+<!ENTITY Precedes         "&#x0227A;" ><!--alias ISOAMSR pr -->
+<!ENTITY PrecedesEqual    "&#x02AAF;" ><!--alias ISOAMSR pre -->
+<!ENTITY PrecedesSlantEqual "&#x0227C;" ><!--alias ISOAMSR prcue -->
+<!ENTITY PrecedesTilde    "&#x0227E;" ><!--alias ISOAMSR prsim -->
+<!ENTITY preceq           "&#x02AAF;" ><!--alias ISOAMSR pre -->
+<!ENTITY precnapprox      "&#x02AB9;" ><!--alias ISOAMSN prnap -->
+<!ENTITY precneqq         "&#x02AB5;" ><!--alias ISOAMSN prnE -->
+<!ENTITY precnsim         "&#x022E8;" ><!--alias ISOAMSN prnsim -->
+<!ENTITY precsim          "&#x0227E;" ><!--alias ISOAMSR prsim -->
+<!ENTITY primes           "&#x02119;" ><!--the prime natural numbers -->
+<!ENTITY Proportion       "&#x02237;" ><!--alias ISOAMSR Colon -->
+<!ENTITY Proportional     "&#x0221D;" ><!--alias ISOTECH prop -->
+<!ENTITY propto           "&#x0221D;" ><!--alias ISOTECH prop -->
+<!ENTITY quaternions      "&#x0210D;" ><!--the ring (skew field) of quaternions -->
+<!ENTITY questeq          "&#x0225F;" ><!--alias ISOAMSR equest -->
+<!ENTITY rangle           "&#x0232A;" ><!--alias ISOTECH rang -->
+<!ENTITY rationals        "&#x0211A;" ><!--the field of rational numbers -->
+<!ENTITY rbrace           "&#x0007D;" ><!--alias ISONUM rcub -->
+<!ENTITY rbrack           "&#x0005D;" ><!--alias ISONUM rsqb -->
+<!ENTITY Re               "&#x0211C;" ><!--alias ISOAMSO real -->
+<!ENTITY realine          "&#x0211B;" ><!--the geometric real line -->
+<!ENTITY realpart         "&#x0211C;" ><!--alias ISOAMSO real -->
+<!ENTITY reals            "&#x0211D;" ><!--the field of real numbers -->
+<!ENTITY ReverseElement   "&#x0220B;" ><!--alias ISOTECH niv -->
+<!ENTITY ReverseEquilibrium "&#x021CB;" ><!--alias ISOAMSA lrhar -->
+<!ENTITY ReverseUpEquilibrium "&#x0296F;" ><!--alias ISOAMSA duhar -->
+<!ENTITY RightAngleBracket "&#x0232A;" ><!--alias ISOTECH rang -->
+<!ENTITY RightArrow       "&#x02192;" ><!--alias ISONUM rarr -->
+<!ENTITY Rightarrow       "&#x021D2;" ><!--alias ISOTECH rArr -->
+<!ENTITY rightarrow       "&#x02192;" ><!--alias ISONUM rarr -->
+<!ENTITY RightArrowBar    "&#x021E5;" ><!--alias for rarrb -->
+<!ENTITY RightArrowLeftArrow "&#x021C4;" ><!--alias ISOAMSA rlarr -->
+<!ENTITY rightarrowtail   "&#x021A3;" ><!--alias ISOAMSA rarrtl -->
+<!ENTITY RightCeiling     "&#x02309;" ><!--alias ISOAMSC rceil -->
+<!ENTITY RightDoubleBracket "&#x0301B;" ><!--right double bracket delimiter -->
+<!ENTITY RightDownVector  "&#x021C2;" ><!--alias ISOAMSA dharr -->
+<!ENTITY RightFloor       "&#x0230B;" ><!--alias ISOAMSC rfloor -->
+<!ENTITY rightharpoondown "&#x021C1;" ><!--alias ISOAMSA rhard -->
+<!ENTITY rightharpoonup   "&#x021C0;" ><!--alias ISOAMSA rharu -->
+<!ENTITY rightleftarrows  "&#x021C4;" ><!--alias ISOAMSA rlarr -->
+<!ENTITY rightleftharpoons "&#x021CC;" ><!--alias ISOAMSA rlhar -->
+<!ENTITY rightrightarrows "&#x021C9;" ><!--alias ISOAMSA rrarr -->
+<!ENTITY rightsquigarrow  "&#x0219D;" ><!--alias ISOAMSA rarrw -->
+<!ENTITY RightTee         "&#x022A2;" ><!--alias ISOAMSR vdash -->
+<!ENTITY RightTeeArrow    "&#x021A6;" ><!--alias ISOAMSA map -->
+<!ENTITY rightthreetimes  "&#x022CC;" ><!--alias ISOAMSB rthree -->
+<!ENTITY RightTriangle    "&#x022B3;" ><!--alias ISOAMSR vrtri -->
+<!ENTITY RightTriangleEqual "&#x022B5;" ><!--alias ISOAMSR rtrie -->
+<!ENTITY RightUpVector    "&#x021BE;" ><!--alias ISOAMSA uharr -->
+<!ENTITY RightVector      "&#x021C0;" ><!--alias ISOAMSA rharu -->
+<!ENTITY risingdotseq     "&#x02253;" ><!--alias ISOAMSR erDot -->
+<!ENTITY rmoustache       "&#x023B1;" ><!--alias ISOAMSC rmoust -->
+<!ENTITY Rrightarrow      "&#x021DB;" ><!--alias ISOAMSA rAarr -->
+<!ENTITY Rsh              "&#x021B1;" ><!--alias ISOAMSA rsh -->
+<!ENTITY searrow          "&#x02198;" ><!--alias ISOAMSA searr -->
+<!ENTITY setminus         "&#x02216;" ><!--alias ISOAMSB setmn -->
+<!ENTITY ShortDownArrow   "&#x02193;" ><!--short down arrow -->
+<!ENTITY ShortLeftArrow   "&#x02190;" ><!--alias ISOAMSA slarr -->
+<!ENTITY shortmid         "&#x02223;" ><!--alias ISOAMSR smid -->
+<!ENTITY shortparallel    "&#x02225;" ><!--alias ISOAMSR spar -->
+<!ENTITY ShortRightArrow  "&#x02192;" ><!--alias ISOAMSA srarr -->
+<!ENTITY ShortUpArrow     "&#x02191;" ><!--short up arrow  -->
+<!ENTITY simeq            "&#x02243;" ><!--alias ISOTECH sime -->
+<!ENTITY SmallCircle      "&#x02218;" ><!--alias ISOTECH compfn -->
+<!ENTITY smallsetminus    "&#x02216;" ><!--alias ISOAMSB ssetmn -->
+<!ENTITY spadesuit        "&#x02660;" ><!--ISOPUB    spades  -->
+<!ENTITY Sqrt             "&#x0221A;" ><!--alias ISOTECH radic -->
+<!ENTITY sqsubset         "&#x0228F;" ><!--alias ISOAMSR sqsub -->
+<!ENTITY sqsubseteq       "&#x02291;" ><!--alias ISOAMSR sqsube -->
+<!ENTITY sqsupset         "&#x02290;" ><!--alias ISOAMSR sqsup -->
+<!ENTITY sqsupseteq       "&#x02292;" ><!--alias ISOAMSR sqsupe -->
+<!ENTITY Square           "&#x025A1;" ><!--alias for square -->
+<!ENTITY SquareIntersection "&#x02293;" ><!--alias ISOAMSB sqcap -->
+<!ENTITY SquareSubset     "&#x0228F;" ><!--alias ISOAMSR sqsub -->
+<!ENTITY SquareSubsetEqual "&#x02291;" ><!--alias ISOAMSR sqsube -->
+<!ENTITY SquareSuperset   "&#x02290;" ><!--alias ISOAMSR sqsup -->
+<!ENTITY SquareSupersetEqual "&#x02292;" ><!--alias ISOAMSR sqsupe -->
+<!ENTITY SquareUnion      "&#x02294;" ><!--alias ISOAMSB sqcup -->
+<!ENTITY Star             "&#x022C6;" ><!--alias ISOAMSB sstarf -->
+<!ENTITY straightepsilon  "&#x003F5;" ><!--alias ISOGRK3 epsi -->
+<!ENTITY straightphi      "&#x003D5;" ><!--alias ISOGRK3 phi -->
+<!ENTITY Subset           "&#x022D0;" ><!--alias ISOAMSR Sub -->
+<!ENTITY subset           "&#x02282;" ><!--alias ISOTECH sub -->
+<!ENTITY subseteq         "&#x02286;" ><!--alias ISOTECH sube -->
+<!ENTITY subseteqq        "&#x02AC5;" ><!--alias ISOAMSR subE -->
+<!ENTITY SubsetEqual      "&#x02286;" ><!--alias ISOTECH sube -->
+<!ENTITY subsetneq        "&#x0228A;" ><!--alias ISOAMSN subne -->
+<!ENTITY subsetneqq       "&#x02ACB;" ><!--alias ISOAMSN subnE -->
+<!ENTITY succ             "&#x0227B;" ><!--alias ISOAMSR sc -->
+<!ENTITY succapprox       "&#x02AB8;" ><!--alias ISOAMSR scap -->
+<!ENTITY succcurlyeq      "&#x0227D;" ><!--alias ISOAMSR sccue -->
+<!ENTITY Succeeds         "&#x0227B;" ><!--alias ISOAMSR sc -->
+<!ENTITY SucceedsEqual    "&#x02AB0;" ><!--alias ISOAMSR sce -->
+<!ENTITY SucceedsSlantEqual "&#x0227D;" ><!--alias ISOAMSR sccue -->
+<!ENTITY SucceedsTilde    "&#x0227F;" ><!--alias ISOAMSR scsim -->
+<!ENTITY succeq           "&#x02AB0;" ><!--alias ISOAMSR sce -->
+<!ENTITY succnapprox      "&#x02ABA;" ><!--alias ISOAMSN scnap -->
+<!ENTITY succneqq         "&#x02AB6;" ><!--alias ISOAMSN scnE -->
+<!ENTITY succnsim         "&#x022E9;" ><!--alias ISOAMSN scnsim -->
+<!ENTITY succsim          "&#x0227F;" ><!--alias ISOAMSR scsim -->
+<!ENTITY SuchThat         "&#x0220B;" ><!--ISOTECH  ni -->
+<!ENTITY Sum              "&#x02211;" ><!--alias ISOAMSB sum -->
+<!ENTITY Superset         "&#x02283;" ><!--alias ISOTECH sup -->
+<!ENTITY SupersetEqual    "&#x02287;" ><!--alias ISOTECH supe -->
+<!ENTITY Supset           "&#x022D1;" ><!--alias ISOAMSR Sup -->
+<!ENTITY supset           "&#x02283;" ><!--alias ISOTECH sup -->
+<!ENTITY supseteq         "&#x02287;" ><!--alias ISOTECH supe -->
+<!ENTITY supseteqq        "&#x02AC6;" ><!--alias ISOAMSR supE -->
+<!ENTITY supsetneq        "&#x0228B;" ><!--alias ISOAMSN supne -->
+<!ENTITY supsetneqq       "&#x02ACC;" ><!--alias ISOAMSN supnE -->
+<!ENTITY swarrow          "&#x02199;" ><!--alias ISOAMSA swarr -->
+<!ENTITY Therefore        "&#x02234;" ><!--alias ISOTECH there4 -->
+<!ENTITY therefore        "&#x02234;" ><!--alias ISOTECH there4 -->
+<!ENTITY thickapprox      "&#x02248;" ><!--ISOAMSR   thkap  -->
+<!ENTITY thicksim         "&#x0223C;" ><!--ISOAMSR   thksim -->
+<!ENTITY ThinSpace        "&#x02009;" ><!--space of width 3/18 em alias ISOPUB thinsp -->
+<!ENTITY Tilde            "&#x0223C;" ><!--alias ISOTECH sim -->
+<!ENTITY TildeEqual       "&#x02243;" ><!--alias ISOTECH sime -->
+<!ENTITY TildeFullEqual   "&#x02245;" ><!--alias ISOTECH cong -->
+<!ENTITY TildeTilde       "&#x02248;" ><!--alias ISOTECH ap -->
+<!ENTITY toea             "&#x02928;" ><!--alias ISOAMSA nesear -->
+<!ENTITY tosa             "&#x02929;" ><!--alias ISOAMSA seswar -->
+<!ENTITY triangle         "&#x025B5;" ><!--alias ISOPUB utri -->
+<!ENTITY triangledown     "&#x025BF;" ><!--alias ISOPUB dtri -->
+<!ENTITY triangleleft     "&#x025C3;" ><!--alias ISOPUB ltri -->
+<!ENTITY trianglelefteq   "&#x022B4;" ><!--alias ISOAMSR ltrie -->
+<!ENTITY triangleq        "&#x0225C;" ><!--alias ISOAMSR trie -->
+<!ENTITY triangleright    "&#x025B9;" ><!--alias ISOPUB rtri -->
+<!ENTITY trianglerighteq  "&#x022B5;" ><!--alias ISOAMSR rtrie -->
+<!ENTITY TripleDot        "&#x020DB;" ><!--alias ISOTECH tdot -->
+<!ENTITY twoheadleftarrow "&#x0219E;" ><!--alias ISOAMSA Larr -->
+<!ENTITY twoheadrightarrow "&#x021A0;" ><!--alias ISOAMSA Rarr -->
+<!ENTITY ulcorner         "&#x0231C;" ><!--alias ISOAMSC ulcorn -->
+<!ENTITY Union            "&#x022C3;" ><!--alias ISOAMSB xcup -->
+<!ENTITY UnionPlus        "&#x0228E;" ><!--alias ISOAMSB uplus -->
+<!ENTITY UpArrow          "&#x02191;" ><!--alias ISONUM uarr -->
+<!ENTITY Uparrow          "&#x021D1;" ><!--alias ISOAMSA uArr -->
+<!ENTITY uparrow          "&#x02191;" ><!--alias ISONUM uarr -->
+<!ENTITY UpArrowDownArrow "&#x021C5;" ><!--alias ISOAMSA udarr -->
+<!ENTITY UpDownArrow      "&#x02195;" ><!--alias ISOAMSA varr -->
+<!ENTITY Updownarrow      "&#x021D5;" ><!--alias ISOAMSA vArr -->
+<!ENTITY updownarrow      "&#x02195;" ><!--alias ISOAMSA varr -->
+<!ENTITY UpEquilibrium    "&#x0296E;" ><!--alias ISOAMSA udhar -->
+<!ENTITY upharpoonleft    "&#x021BF;" ><!--alias ISOAMSA uharl -->
+<!ENTITY upharpoonright   "&#x021BE;" ><!--alias ISOAMSA uharr -->
+<!ENTITY UpperLeftArrow   "&#x02196;" ><!--alias ISOAMSA nwarr -->
+<!ENTITY UpperRightArrow  "&#x02197;" ><!--alias ISOAMSA nearr -->
+<!ENTITY upsilon          "&#x003C5;" ><!--alias ISOGRK3 upsi -->
+<!ENTITY UpTee            "&#x022A5;" ><!--alias ISOTECH perp -->
+<!ENTITY UpTeeArrow       "&#x021A5;" ><!--Alias mapstoup -->
+<!ENTITY upuparrows       "&#x021C8;" ><!--alias ISOAMSA uuarr -->
+<!ENTITY urcorner         "&#x0231D;" ><!--alias ISOAMSC urcorn -->
+<!ENTITY varepsilon       "&#x003B5;" ><!--alias ISOGRK3 epsiv -->
+<!ENTITY varkappa         "&#x003F0;" ><!--alias ISOGRK3 kappav -->
+<!ENTITY varnothing       "&#x02205;" ><!--alias ISOAMSO emptyv -->
+<!ENTITY varphi           "&#x003C6;" ><!--alias ISOGRK3 phiv -->
+<!ENTITY varpi            "&#x003D6;" ><!--alias ISOGRK3 piv -->
+<!ENTITY varpropto        "&#x0221D;" ><!--alias ISOAMSR vprop -->
+<!ENTITY varrho           "&#x003F1;" ><!--alias ISOGRK3 rhov -->
+<!ENTITY varsigma         "&#x003C2;" ><!--alias ISOGRK3 sigmav -->
+<!ENTITY varsubsetneq     "&#x0228A;&#x0FE00;" ><!--alias ISOAMSN vsubne -->
+<!ENTITY varsubsetneqq    "&#x02ACB;&#x0FE00;" ><!--alias ISOAMSN vsubnE -->
+<!ENTITY varsupsetneq     "&#x0228B;&#x0FE00;" ><!--alias ISOAMSN vsupne -->
+<!ENTITY varsupsetneqq    "&#x02ACC;&#x0FE00;" ><!--alias ISOAMSN vsupnE -->
+<!ENTITY vartheta         "&#x003D1;" ><!--alias ISOGRK3 thetav -->
+<!ENTITY vartriangleleft  "&#x022B2;" ><!--alias ISOAMSR vltri -->
+<!ENTITY vartriangleright "&#x022B3;" ><!--alias ISOAMSR vrtri -->
+<!ENTITY Vee              "&#x022C1;" ><!--alias ISOAMSB xvee -->
+<!ENTITY vee              "&#x02228;" ><!--alias ISOTECH or -->
+<!ENTITY Vert             "&#x02016;" ><!--alias ISOTECH Verbar -->
+<!ENTITY vert             "&#x0007C;" ><!--alias ISONUM verbar -->
+<!ENTITY VerticalBar      "&#x02223;" ><!--alias ISOAMSR mid -->
+<!ENTITY VerticalTilde    "&#x02240;" ><!--alias ISOAMSB wreath -->
+<!ENTITY VeryThinSpace    "&#x0200A;" ><!--space of width 1/18 em alias ISOPUB hairsp -->
+<!ENTITY Wedge            "&#x022C0;" ><!--alias ISOAMSB xwedge -->
+<!ENTITY wedge            "&#x02227;" ><!--alias ISOTECH and -->
+<!ENTITY wp               "&#x02118;" ><!--alias ISOAMSO weierp -->
+<!ENTITY wr               "&#x02240;" ><!--alias ISOAMSB wreath -->
+<!ENTITY zeetrf           "&#x02128;" ><!--zee transform -->

--- a/publishing/1.1/mathml/mmlextra.ent
+++ b/publishing/1.1/mathml/mmlextra.ent
@@ -1,0 +1,122 @@
+
+<!--
+     File mmlextra.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY af               "&#x02061;" ><!--character showing function application in presentation tagging -->
+<!ENTITY aopf             "%plane1D;552;" ><!-- -->
+<!ENTITY asympeq          "&#x0224D;" ><!--Old ISOAMSR asymp (for HTML compatibility) -->
+<!ENTITY bopf             "%plane1D;553;" ><!-- -->
+<!ENTITY copf             "%plane1D;554;" ><!-- -->
+<!ENTITY Cross            "&#x02A2F;" ><!--cross or vector product -->
+<!ENTITY DD               "&#x02145;" ><!--D for use in differentials, e.g., within integrals -->
+<!ENTITY dd               "&#x02146;" ><!--d for use in differentials, e.g., within integrals -->
+<!ENTITY dopf             "%plane1D;555;" ><!-- -->
+<!ENTITY DownArrowBar     "&#x02913;" ><!--down arrow to bar -->
+<!ENTITY DownBreve        "&#x00311;" ><!--breve, inverted (non-spacing) -->
+<!ENTITY DownLeftRightVector "&#x02950;" ><!--left-down-right-down harpoon -->
+<!ENTITY DownLeftTeeVector "&#x0295E;" ><!--left-down harpoon from bar -->
+<!ENTITY DownLeftVectorBar "&#x02956;" ><!--left-down harpoon to bar -->
+<!ENTITY DownRightTeeVector "&#x0295F;" ><!--right-down harpoon from bar -->
+<!ENTITY DownRightVectorBar "&#x02957;" ><!--right-down harpoon to bar -->
+<!ENTITY ee               "&#x02147;" ><!--e use for the exponential base of the natural logarithms -->
+<!ENTITY EmptySmallSquare "&#x025FB;" ><!--empty small square -->
+<!ENTITY EmptyVerySmallSquare "&#x025AB;" ><!--empty small square -->
+<!ENTITY eopf             "%plane1D;556;" ><!-- -->
+<!ENTITY Equal            "&#x02A75;" ><!--two consecutive equal signs -->
+<!ENTITY FilledSmallSquare "&#x025FC;" ><!--filled small square -->
+<!ENTITY FilledVerySmallSquare "&#x025AA;" ><!--filled very small square -->
+<!ENTITY fopf             "%plane1D;557;" ><!-- -->
+<!ENTITY gopf             "%plane1D;558;" ><!-- -->
+<!ENTITY GreaterGreater   "&#x02AA2;" ><!--alias for GT -->
+<!ENTITY Hat              "&#x0005E;" ><!--circumflex accent -->
+<!ENTITY hopf             "%plane1D;559;" ><!-- -->
+<!ENTITY HorizontalLine   "&#x02500;" ><!--short horizontal line  -->
+<!ENTITY ic               "&#x02063;" ><!--short form of  &InvisibleComma; -->
+<!ENTITY ii               "&#x02148;" ><!--i for use as a square root of -1 -->
+<!ENTITY iopf             "%plane1D;55A;" ><!-- -->
+<!ENTITY it               "&#x02062;" ><!--marks multiplication when it is understood without a mark -->
+<!ENTITY jopf             "%plane1D;55B;" ><!-- -->
+<!ENTITY kopf             "%plane1D;55C;" ><!-- -->
+<!ENTITY larrb            "&#x021E4;" ><!--leftwards arrow to bar -->
+<!ENTITY LeftDownTeeVector "&#x02961;" ><!--down-left harpoon from bar -->
+<!ENTITY LeftDownVectorBar "&#x02959;" ><!--down-left harpoon to bar -->
+<!ENTITY LeftRightVector  "&#x0294E;" ><!--left-up-right-up harpoon -->
+<!ENTITY LeftTeeVector    "&#x0295A;" ><!--left-up harpoon from bar -->
+<!ENTITY LeftTriangleBar  "&#x029CF;" ><!--left triangle, vertical bar -->
+<!ENTITY LeftUpDownVector "&#x02951;" ><!--up-left-down-left harpoon -->
+<!ENTITY LeftUpTeeVector  "&#x02960;" ><!--up-left harpoon from bar -->
+<!ENTITY LeftUpVectorBar  "&#x02958;" ><!--up-left harpoon to bar -->
+<!ENTITY LeftVectorBar    "&#x02952;" ><!--left-up harpoon to bar -->
+<!ENTITY LessLess         "&#x02AA1;" ><!--alias for Lt -->
+<!ENTITY lopf             "%plane1D;55D;" ><!-- -->
+<!ENTITY mapstodown       "&#x021A7;" ><!--downwards arrow from bar -->
+<!ENTITY mapstoleft       "&#x021A4;" ><!--leftwards arrow from bar -->
+<!ENTITY mapstoup         "&#x021A5;" ><!--upwards arrow from bar -->
+<!ENTITY MediumSpace      "&#x0205F;" ><!--space of width 4/18 em -->
+<!ENTITY mopf             "%plane1D;55E;" ><!-- -->
+<!ENTITY nbump            "&#x0224E;&#x00338;" ><!--not bumpy equals -->
+<!ENTITY nbumpe           "&#x0224F;&#x00338;" ><!--not bumpy single equals -->
+<!ENTITY nesim            "&#x02242;&#x00338;" ><!--not equal or similar -->
+<!ENTITY NewLine          "&#x0000A;" ><!--force a line break; line feed -->
+<!ENTITY NoBreak          "&#x02060;" ><!--never break line here -->
+<!ENTITY nopf             "%plane1D;55F;" ><!-- -->
+<!ENTITY NotCupCap        "&#x0226D;" ><!--alias for &nasymp; -->
+<!ENTITY NotHumpEqual     "&#x0224F;&#x00338;" ><!--alias for &nbumpe; -->
+<!ENTITY NotLeftTriangleBar "&#x029CF;&#x00338;" ><!--not left triangle, vertical bar -->
+<!ENTITY NotNestedGreaterGreater "&#x02AA2;&#x00338;" ><!--not double greater-than sign -->
+<!ENTITY NotNestedLessLess "&#x02AA1;&#x00338;" ><!--not double less-than sign -->
+<!ENTITY NotRightTriangleBar "&#x029D0;&#x00338;" ><!--not vertical bar, right triangle -->
+<!ENTITY NotSquareSubset  "&#x0228F;&#x00338;" ><!--square not subset -->
+<!ENTITY NotSquareSuperset "&#x02290;&#x00338;" ><!--negated set-like partial order operator -->
+<!ENTITY NotSucceedsTilde "&#x0227F;&#x00338;" ><!--not succeeds or similar -->
+<!ENTITY oopf             "%plane1D;560;" ><!-- -->
+<!ENTITY OverBar          "&#x000AF;" ><!--over bar -->
+<!ENTITY OverBrace        "&#x0FE37;" ><!--over brace  -->
+<!ENTITY OverBracket      "&#x023B4;" ><!--over bracket -->
+<!ENTITY OverParenthesis  "&#x0FE35;" ><!--over parenthesis -->
+<!ENTITY planckh          "&#x0210E;" ><!--the ring (skew field) of quaternions -->
+<!ENTITY popf             "%plane1D;561;" ><!-- -->
+<!ENTITY Product          "&#x0220F;" ><!--alias for &prod; -->
+<!ENTITY qopf             "%plane1D;562;" ><!-- -->
+<!ENTITY rarrb            "&#x021E5;" ><!--leftwards arrow to bar -->
+<!ENTITY RightDownTeeVector "&#x0295D;" ><!--down-right harpoon from bar -->
+<!ENTITY RightDownVectorBar "&#x02955;" ><!--down-right harpoon to bar -->
+<!ENTITY RightTeeVector   "&#x0295B;" ><!--right-up harpoon from bar -->
+<!ENTITY RightTriangleBar "&#x029D0;" ><!--vertical bar, right triangle -->
+<!ENTITY RightUpDownVector "&#x0294F;" ><!--up-right-down-right harpoon -->
+<!ENTITY RightUpTeeVector "&#x0295C;" ><!--up-right harpoon from bar -->
+<!ENTITY RightUpVectorBar "&#x02954;" ><!--up-right harpoon to bar -->
+<!ENTITY RightVectorBar   "&#x02953;" ><!--up-right harpoon to bar -->
+<!ENTITY ropf             "%plane1D;563;" ><!-- -->
+<!ENTITY RoundImplies     "&#x02970;" ><!--round implies -->
+<!ENTITY RuleDelayed      "&#x029F4;" ><!--rule-delayed (colon right arrow) -->
+<!ENTITY sopf             "%plane1D;564;" ><!-- -->
+<!ENTITY Tab              "&#x00009;" ><!--tabulator stop; horizontal tabulation -->
+<!ENTITY ThickSpace       "&#x02009;&#x0200A;&#x0200A;" ><!--space of width 5/18 em -->
+<!ENTITY topf             "%plane1D;565;" ><!-- -->
+<!ENTITY UnderBar         "&#x00332;" ><!--combining low line -->
+<!ENTITY UnderBrace       "&#x0FE38;" ><!--under brace  -->
+<!ENTITY UnderBracket     "&#x023B5;" ><!--under bracket -->
+<!ENTITY UnderParenthesis "&#x0FE36;" ><!--under parenthesis -->
+<!ENTITY uopf             "%plane1D;566;" ><!-- -->
+<!ENTITY UpArrowBar       "&#x02912;" ><!--up arrow to bar -->
+<!ENTITY Upsilon          "&#x003A5;" ><!--ISOGRK1 Ugr, HTML4 Upsilon -->
+<!ENTITY VerticalLine     "&#x0007C;" ><!--alias ISONUM verbar -->
+<!ENTITY VerticalSeparator "&#x02758;" ><!--vertical separating operator -->
+<!ENTITY vopf             "%plane1D;567;" ><!-- -->
+<!ENTITY wopf             "%plane1D;568;" ><!-- -->
+<!ENTITY xopf             "%plane1D;569;" ><!-- -->
+<!ENTITY yopf             "%plane1D;56A;" ><!-- -->
+<!ENTITY ZeroWidthSpace   "&#x0200B;" ><!--zero width space -->
+<!ENTITY zopf             "%plane1D;56B;" ><!-- -->

--- a/publishing/1.1/mathml2-qname-1.mod
+++ b/publishing/1.1/mathml2-qname-1.mod
@@ -1,0 +1,286 @@
+<!-- ....................................................................... -->
+<!-- MathML Qualified Names Module  ........................................ -->
+<!-- file: mathml2-qname-1.mod
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML 
+     application for describing mathematical notation and capturing 
+     both its structure and content.
+
+     Copyright 1998-2000 W3C (MIT, INRIA, Keio), All Rights Reserved.
+     Revision: $Id: mathml2-qname-1.mod,v 1.2 2003/04/08 00:11:16 davidc Exp $ 
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+       SYSTEM "mathml2-qname-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- MathML Qualified Names
+
+     This module is contained in two parts, labeled Section 'A' and 'B':
+
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing 
+       for MathML.
+    
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all MathML element types.
+
+     This module is derived from the XHTML Qualified Names Template module.
+-->
+
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+
+<!ENTITY % NS.prefixed     "IGNORE" >
+<!ENTITY % MATHML.prefixed "%NS.prefixed;" >
+
+<!-- XLink ............... -->
+
+<!ENTITY % XLINK.prefix         "xlink" >		
+<!ENTITY % XLINK.xmlns "http://www.w3.org/1999/xlink" >
+<!ENTITY % XLINK.xmlns.attrib
+     "xmlns:%XLINK.prefix;  CDATA           #FIXED '%XLINK.xmlns;'"
+>
+
+<!-- W3C XML Schema ............... -->
+
+<!ENTITY % Schema.prefix         "xsi" >		
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA           #IMPLIED"
+>
+
+<!-- MathML .............. -->
+
+<!ENTITY % MATHML.xmlns    "http://www.w3.org/1998/Math/MathML" >
+<!ENTITY % MATHML.prefix   "m" >
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.xmlns.extra.attrib  "" >
+]]>
+<!ENTITY % MATHML.xmlns.extra.attrib 
+     "%XLINK.xmlns.attrib; 
+      %Schema.xmlns.attrib;" >
+
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx  "%MATHML.prefix;:" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns:%MATHML.prefix;  CDATA   #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+]]>
+<!ENTITY % MATHML.pfx  "" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns        CDATA           #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+
+<![%NS.prefixed;[
+<!ENTITY % XHTML.xmlns.extra.attrib 
+     "%MATHML.xmlns.attrib;" >
+]]>
+<!ENTITY % XHTML.xmlns.extra.attrib
+     "%XLINK.xmlns.attrib;
+      %Schema.xmlns.attrib;"
+>
+
+<!-- Section B: MathML Qualified Names ::::::::::::::::::::::::::::: -->
+
+<!-- 9. This section declares parameter entities used to provide
+        namespace-qualified names for all MathML element types.
+-->
+
+<!ENTITY % abs.qname            "%MATHML.pfx;abs" >
+<!ENTITY % and.qname            "%MATHML.pfx;and" >
+<!ENTITY % annotation-xml.qname "%MATHML.pfx;annotation-xml" >
+<!ENTITY % annotation.qname     "%MATHML.pfx;annotation" >
+<!ENTITY % apply.qname          "%MATHML.pfx;apply" >
+<!ENTITY % approx.qname         "%MATHML.pfx;approx" >
+<!ENTITY % arccos.qname         "%MATHML.pfx;arccos" >
+<!ENTITY % arccosh.qname        "%MATHML.pfx;arccosh" >
+<!ENTITY % arccosh.qname        "%MATHML.pfx;arccosh" >
+<!ENTITY % arccot.qname         "%MATHML.pfx;arccot" >
+<!ENTITY % arccoth.qname        "%MATHML.pfx;arccoth" >
+<!ENTITY % arccsc.qname         "%MATHML.pfx;arccsc" >
+<!ENTITY % arccsch.qname        "%MATHML.pfx;arccsch" >
+<!ENTITY % arcsec.qname         "%MATHML.pfx;arcsec" >
+<!ENTITY % arcsech.qname        "%MATHML.pfx;arcsech" >
+<!ENTITY % arcsin.qname         "%MATHML.pfx;arcsin" >
+<!ENTITY % arcsinh.qname        "%MATHML.pfx;arcsinh" >
+<!ENTITY % arctan.qname         "%MATHML.pfx;arctan" >
+<!ENTITY % arctanh.qname        "%MATHML.pfx;arctanh" >
+<!ENTITY % arg.qname            "%MATHML.pfx;arg" >
+<!ENTITY % bvar.qname           "%MATHML.pfx;bvar" >
+<!ENTITY % card.qname           "%MATHML.pfx;card" >
+<!ENTITY % cartesianproduct.qname "%MATHML.pfx;cartesianproduct" >
+<!ENTITY % ceiling.qname         "%MATHML.pfx;ceiling" >
+<!ENTITY % ci.qname             "%MATHML.pfx;ci" >
+<!ENTITY % cn.qname             "%MATHML.pfx;cn" >
+<!ENTITY % codomain.qname       "%MATHML.pfx;codomain" >
+<!ENTITY % complexes.qname      "%MATHML.pfx;complexes" >
+<!ENTITY % compose.qname        "%MATHML.pfx;compose" >
+<!ENTITY % condition.qname      "%MATHML.pfx;condition" >
+<!ENTITY % conjugate.qname      "%MATHML.pfx;conjugate" >
+<!ENTITY % cos.qname            "%MATHML.pfx;cos" >
+<!ENTITY % cosh.qname           "%MATHML.pfx;cosh" >
+<!ENTITY % cot.qname            "%MATHML.pfx;cot" >
+<!ENTITY % coth.qname           "%MATHML.pfx;coth" >
+<!ENTITY % csc.qname            "%MATHML.pfx;csc" >
+<!ENTITY % csch.qname           "%MATHML.pfx;csch" >
+<!ENTITY % csymbol.qname        "%MATHML.pfx;csymbol" >
+<!ENTITY % curl.qname           "%MATHML.pfx;curl" >
+<!ENTITY % declare.qname        "%MATHML.pfx;declare" >
+<!ENTITY % degree.qname         "%MATHML.pfx;degree" >
+<!ENTITY % determinant.qname    "%MATHML.pfx;determinant" >
+<!ENTITY % diff.qname           "%MATHML.pfx;diff" >
+<!ENTITY % divergence.qname     "%MATHML.pfx;divergence" >
+<!ENTITY % divide.qname         "%MATHML.pfx;divide" >
+<!ENTITY % domain.qname         "%MATHML.pfx;domain" >
+<!ENTITY % domainofapplication.qname "%MATHML.pfx;domainofapplication" >
+<!ENTITY % emptyset.qname       "%MATHML.pfx;emptyset" >
+<!ENTITY % eq.qname             "%MATHML.pfx;eq" >
+<!ENTITY % equivalent.qname     "%MATHML.pfx;equivalent" >
+<!ENTITY % eulergamma.qname     "%MATHML.pfx;eulergamma" >
+<!ENTITY % exists.qname         "%MATHML.pfx;exists" >
+<!ENTITY % exp.qname            "%MATHML.pfx;exp" >
+<!ENTITY % exponentiale.qname   "%MATHML.pfx;exponentiale" >
+<!ENTITY % factorial.qname      "%MATHML.pfx;factorial" >
+<!ENTITY % factorof.qname       "%MATHML.pfx;factorof" >
+<!ENTITY % false.qname          "%MATHML.pfx;false" >
+<!ENTITY % floor.qname          "%MATHML.pfx;floor" >
+<!ENTITY % fn.qname             "%MATHML.pfx;fn" >
+<!ENTITY % forall.qname         "%MATHML.pfx;forall" >
+<!ENTITY % gcd.qname            "%MATHML.pfx;gcd" >
+<!ENTITY % geq.qname            "%MATHML.pfx;geq" >
+<!ENTITY % grad.qname           "%MATHML.pfx;grad" >
+<!ENTITY % gt.qname             "%MATHML.pfx;gt" >
+<!ENTITY % ident.qname          "%MATHML.pfx;ident" >
+<!ENTITY % image.qname          "%MATHML.pfx;image" >
+<!ENTITY % imaginary.qname      "%MATHML.pfx;imaginary" >
+<!ENTITY % imaginaryi.qname     "%MATHML.pfx;imaginaryi" >
+<!ENTITY % implies.qname        "%MATHML.pfx;implies" >
+<!ENTITY % in.qname             "%MATHML.pfx;in" >
+<!ENTITY % infinity.qname       "%MATHML.pfx;infinity" >
+<!ENTITY % int.qname            "%MATHML.pfx;int" >
+<!ENTITY % integers.qname       "%MATHML.pfx;integers" >
+<!ENTITY % intersect.qname      "%MATHML.pfx;intersect" >
+<!ENTITY % interval.qname       "%MATHML.pfx;interval" >
+<!ENTITY % inverse.qname        "%MATHML.pfx;inverse" >
+<!ENTITY % lambda.qname         "%MATHML.pfx;lambda" >
+<!ENTITY % laplacian.qname      "%MATHML.pfx;laplacian" >
+<!ENTITY % lcm.qname            "%MATHML.pfx;lcm" >
+<!ENTITY % leq.qname            "%MATHML.pfx;leq" >
+<!ENTITY % limit.qname          "%MATHML.pfx;limit" >
+<!ENTITY % list.qname           "%MATHML.pfx;list" >
+<!ENTITY % ln.qname             "%MATHML.pfx;ln" >
+<!ENTITY % log.qname            "%MATHML.pfx;log" >
+<!ENTITY % logbase.qname        "%MATHML.pfx;logbase" >
+<!ENTITY % lowlimit.qname       "%MATHML.pfx;lowlimit" >
+<!ENTITY % lt.qname             "%MATHML.pfx;lt" >
+<!ENTITY % maction.qname        "%MATHML.pfx;maction" >
+<!ENTITY % maligngroup.qname    "%MATHML.pfx;maligngroup" >
+<!ENTITY % malignmark.qname     "%MATHML.pfx;malignmark" >
+<!ENTITY % math.qname           "%MATHML.pfx;math" >
+<!ENTITY % matrix.qname         "%MATHML.pfx;matrix" >
+<!ENTITY % matrixrow.qname      "%MATHML.pfx;matrixrow" >
+<!ENTITY % max.qname            "%MATHML.pfx;max" >
+<!ENTITY % mean.qname           "%MATHML.pfx;mean" >
+<!ENTITY % median.qname         "%MATHML.pfx;median" >
+<!ENTITY % menclose.qname       "%MATHML.pfx;menclose" >
+<!ENTITY % merror.qname         "%MATHML.pfx;merror" >
+<!ENTITY % mfenced.qname        "%MATHML.pfx;mfenced" >
+<!ENTITY % mfrac.qname          "%MATHML.pfx;mfrac" >
+<!ENTITY % mglyph.qname         "%MATHML.pfx;mglyph" >
+<!ENTITY % mi.qname             "%MATHML.pfx;mi" >
+<!ENTITY % min.qname            "%MATHML.pfx;min" >
+<!ENTITY % minus.qname          "%MATHML.pfx;minus" >
+<!ENTITY % mlabeledtr.qname     "%MATHML.pfx;mlabeledtr" >
+<!ENTITY % mmultiscripts.qname  "%MATHML.pfx;mmultiscripts" >
+<!ENTITY % mn.qname             "%MATHML.pfx;mn" >
+<!ENTITY % mo.qname             "%MATHML.pfx;mo" >
+<!ENTITY % mode.qname           "%MATHML.pfx;mode" >
+<!ENTITY % moment.qname         "%MATHML.pfx;moment" >
+<!ENTITY % momentabout.qname    "%MATHML.pfx;momentabout" >
+<!ENTITY % mover.qname          "%MATHML.pfx;mover" >
+<!ENTITY % mpadded.qname        "%MATHML.pfx;mpadded" >
+<!ENTITY % mphantom.qname       "%MATHML.pfx;mphantom" >
+<!ENTITY % mprescripts.qname    "%MATHML.pfx;mprescripts" >
+<!ENTITY % mroot.qname          "%MATHML.pfx;mroot" >
+<!ENTITY % mrow.qname           "%MATHML.pfx;mrow" >
+<!ENTITY % ms.qname             "%MATHML.pfx;ms" >
+<!ENTITY % mspace.qname         "%MATHML.pfx;mspace" >
+<!ENTITY % msqrt.qname          "%MATHML.pfx;msqrt" >
+<!ENTITY % mstyle.qname         "%MATHML.pfx;mstyle" >
+<!ENTITY % msub.qname           "%MATHML.pfx;msub" >
+<!ENTITY % msubsup.qname        "%MATHML.pfx;msubsup" >
+<!ENTITY % msup.qname           "%MATHML.pfx;msup" >
+<!ENTITY % mtable.qname         "%MATHML.pfx;mtable" >
+<!ENTITY % mtd.qname            "%MATHML.pfx;mtd" >
+<!ENTITY % mtext.qname          "%MATHML.pfx;mtext" >
+<!ENTITY % mtr.qname            "%MATHML.pfx;mtr" >
+<!ENTITY % munder.qname         "%MATHML.pfx;munder" >
+<!ENTITY % munderover.qname     "%MATHML.pfx;munderover" >
+<!ENTITY % naturalnumbers.qname "%MATHML.pfx;naturalnumbers" >
+<!ENTITY % neq.qname            "%MATHML.pfx;neq" >
+<!ENTITY % none.qname           "%MATHML.pfx;none" >
+<!ENTITY % not.qname            "%MATHML.pfx;not" >
+<!ENTITY % notanumber.qname     "%MATHML.pfx;notanumber" >
+<!ENTITY % notin.qname          "%MATHML.pfx;notin" >
+<!ENTITY % notprsubset.qname    "%MATHML.pfx;notprsubset" >
+<!ENTITY % notsubset.qname      "%MATHML.pfx;notsubset" >
+<!ENTITY % or.qname             "%MATHML.pfx;or" >
+<!ENTITY % otherwise.qname      "%MATHML.pfx;otherwise" >
+<!ENTITY % outerproduct.qname   "%MATHML.pfx;outerproduct" >
+<!ENTITY % partialdiff.qname    "%MATHML.pfx;partialdiff" >
+<!ENTITY % pi.qname             "%MATHML.pfx;pi" >
+<!ENTITY % piece.qname          "%MATHML.pfx;piece" >
+<!ENTITY % piecewise.qname      "%MATHML.pfx;piecewise" >
+<!ENTITY % plus.qname           "%MATHML.pfx;plus" >
+<!ENTITY % power.qname          "%MATHML.pfx;power" >
+<!ENTITY % primes.qname         "%MATHML.pfx;primes" >
+<!ENTITY % product.qname        "%MATHML.pfx;product" >
+<!ENTITY % prsubset.qname       "%MATHML.pfx;prsubset" >
+<!ENTITY % quotient.qname       "%MATHML.pfx;quotient" >
+<!ENTITY % rationals.qname      "%MATHML.pfx;rationals" >
+<!ENTITY % real.qname           "%MATHML.pfx;real" >
+<!ENTITY % reals.qname          "%MATHML.pfx;reals" >
+<!ENTITY % reln.qname           "%MATHML.pfx;reln" >
+<!ENTITY % rem.qname            "%MATHML.pfx;rem" >
+<!ENTITY % root.qname           "%MATHML.pfx;root" >
+<!ENTITY % scalarproduct.qname  "%MATHML.pfx;scalarproduct" >
+<!ENTITY % sdev.qname           "%MATHML.pfx;sdev" >
+<!ENTITY % sec.qname            "%MATHML.pfx;sec" >
+<!ENTITY % sech.qname           "%MATHML.pfx;sech" >
+<!ENTITY % selector.qname       "%MATHML.pfx;selector" >
+<!ENTITY % semantics.qname      "%MATHML.pfx;semantics" >
+<!ENTITY % sep.qname            "%MATHML.pfx;sep" >
+<!ENTITY % set.qname            "%MATHML.pfx;set" >
+<!ENTITY % setdiff.qname        "%MATHML.pfx;setdiff" >
+<!ENTITY % sin.qname            "%MATHML.pfx;sin" >
+<!ENTITY % sinh.qname           "%MATHML.pfx;sinh" >
+<!ENTITY % subset.qname         "%MATHML.pfx;subset" >
+<!ENTITY % sum.qname            "%MATHML.pfx;sum" >
+<!ENTITY % tan.qname            "%MATHML.pfx;tan" >
+<!ENTITY % tanh.qname           "%MATHML.pfx;tanh" >
+<!ENTITY % tendsto.qname        "%MATHML.pfx;tendsto" >
+<!ENTITY % times.qname          "%MATHML.pfx;times" >
+<!ENTITY % transpose.qname      "%MATHML.pfx;transpose" >
+<!ENTITY % true.qname           "%MATHML.pfx;true" >
+<!ENTITY % union.qname          "%MATHML.pfx;union" >
+<!ENTITY % uplimit.qname        "%MATHML.pfx;uplimit" >
+<!ENTITY % variance.qname       "%MATHML.pfx;variance" >
+<!ENTITY % vector.qname         "%MATHML.pfx;vector" >
+<!ENTITY % vectorproduct.qname  "%MATHML.pfx;vectorproduct" >
+<!ENTITY % xor.qname            "%MATHML.pfx;xor" >
+
+
+<!-- ignores subsequent instantiation of this module when
+     used as external subset rather than module fragment.
+     NOTE: Do not modify this parameter entity, otherwise
+     a recursive parsing situation may result.
+-->
+<!ENTITY % mathml-qname.module "IGNORE" >
+
+<!-- end of template-qname-1.mod -->

--- a/publishing/1.1/mathml2.dtd
+++ b/publishing/1.1/mathml2.dtd
@@ -1,0 +1,2206 @@
+<!-- MathML 2.0 DTD  ....................................................... -->
+<!-- file: mathml2.dtd
+-->
+
+<!-- MathML 2.0 DTD
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML
+     application for describing mathematical notation and capturing
+     both its structure and content.
+
+     Copyright &#xa9; 1998-2003 W3C&#xae; (MIT, ERCIM, Keio), All Rights 
+     Reserved. W3C liability, trademark, document use and software
+     licensing rules apply. 
+
+     Permission to use, copy, modify and distribute the MathML 2.0 DTD and
+     its accompanying documentation for any purpose and without fee is
+     hereby granted in perpetuity, provided that the above copyright notice
+     and this paragraph appear in all copies.  The copyright holders make
+     no representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.
+
+        Revision:   $Id: mathml2.dtd,v 1.12 2003/11/04 13:14:35 davidc Exp $
+
+     This entity may be identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//DTD MathML 2.0//EN"
+       SYSTEM "mathml2.dtd"
+
+     Revisions: editor and revision history at EOF
+-->
+<!-- Entity used to enable marked sections which enforces stricter		
+     checking of MathML syntax rules		
+-->
+<!ENTITY % MathMLstrict "IGNORE">		
+
+<!-- MathML Qualified Names module ............................... -->
+<!ENTITY % mathml-qname.module "INCLUDE" >
+<![%mathml-qname.module;[
+<!ENTITY % mathml-qname.mod
+     PUBLIC "-//W3C//ENTITIES MathML 2.0 Qualified Names 1.0//EN"
+            "mathml2-qname-1.mod" >
+%mathml-qname.mod;]]>
+
+<!-- if %NS.prefixed; is INCLUDE, include all NS attributes, 
+     otherwise just those associated with MathML
+-->
+<![%NS.prefixed;[
+  <!ENTITY % MATHML.NamespaceDecl.attrib 
+         "%NamespaceDecl.attrib;"
+>
+]]>
+<!ENTITY % MATHML.NamespaceDecl.attrib 
+     "%MATHML.xmlns.attrib;"
+>
+
+
+<!-- Attributes shared by all elements  .......................... -->
+
+<!ENTITY % MATHML.Common.attrib
+     "%MATHML.NamespaceDecl.attrib;
+      %XLINK.prefix;:href   CDATA           #IMPLIED		
+      %XLINK.prefix;:type   CDATA           #IMPLIED	
+      class        CDATA                    #IMPLIED
+      style        CDATA                    #IMPLIED
+      id           ID                       #IMPLIED
+      xref         IDREF                    #IMPLIED
+      other        CDATA                    #IMPLIED"
+>
+
+<!-- Presentation element set  ................................... -->
+
+<!-- Attribute definitions -->
+
+<!ENTITY % att-fontsize
+     "fontsize     CDATA                    #IMPLIED" >
+<!ENTITY % att-fontweight
+     "fontweight   ( normal | bold )        #IMPLIED" >
+<!ENTITY % att-fontstyle
+     "fontstyle    ( normal | italic )      #IMPLIED" >
+<!ENTITY % att-fontfamily
+     "fontfamily   CDATA                    #IMPLIED" >
+<!ENTITY % att-color
+     "color        CDATA                    #IMPLIED" >
+
+<!-- MathML2 typographically-distinguished symbol attributes -->
+
+<![%MathMLstrict;[
+  <!ENTITY % att-mathvariant
+     "mathvariant     ( normal | bold | italic | bold-italic | double-struck | 
+                        bold-fraktur | script | bold-script | fraktur |
+                        sans-serif | bold-sans-serif | sans-serif-italic |
+                        sans-serif-bold-italic | monospace )
+                                                                   #IMPLIED" >
+]]>
+<!ENTITY % att-mathvariant
+     "mathvariant     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathsize
+     "mathsize     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathcolor
+     "mathcolor     CDATA                    #IMPLIED" >
+<!ENTITY % att-mathbackground
+     "mathbackground     CDATA                    #IMPLIED" >
+
+<!ENTITY % att-fontinfo
+     "%att-fontsize;
+      %att-fontweight;
+      %att-fontstyle;
+      %att-fontfamily;
+      %att-color;
+      %att-mathvariant;
+      %att-mathsize;
+      %att-mathcolor;
+      %att-mathbackground;"
+>
+
+<!ENTITY % att-form
+     "form         ( prefix | infix | postfix )  #IMPLIED" >
+<!ENTITY % att-fence
+     "fence        ( true | false )         #IMPLIED" >
+<!ENTITY % att-separator
+     "separator    ( true | false )         #IMPLIED" >
+<!ENTITY % att-lspace
+     "lspace       CDATA                    #IMPLIED" >
+<!ENTITY % att-rspace
+     "rspace       CDATA                    #IMPLIED" >
+<!ENTITY % att-stretchy
+     "stretchy     ( true | false )         #IMPLIED" >
+<!ENTITY % att-symmetric
+     "symmetric    ( true | false )         #IMPLIED" >
+<!ENTITY % att-maxsize
+     "maxsize      CDATA                    #IMPLIED" >
+<!ENTITY % att-minsize
+     "minsize      CDATA                    #IMPLIED" >
+<!ENTITY % att-largeop
+     "largeop      ( true | false)          #IMPLIED" >
+<!ENTITY % att-movablelimits
+     "movablelimits ( true | false )        #IMPLIED" >
+<!ENTITY % att-accent
+     "accent       ( true | false )         #IMPLIED" >
+
+<!ENTITY % att-opinfo
+     "%att-form;
+      %att-fence;
+      %att-separator;
+      %att-lspace;
+      %att-rspace;
+      %att-stretchy;
+      %att-symmetric;
+      %att-maxsize;
+      %att-minsize;
+      %att-largeop;
+      %att-movablelimits;
+      %att-accent;"
+>
+<!ENTITY % att-width
+     "width        CDATA                    #IMPLIED" >
+<!ENTITY % att-height
+     "height       CDATA                    #IMPLIED" >
+<!ENTITY % att-depth
+     "depth        CDATA                    #IMPLIED" >
+<!ENTITY % att-linebreak
+     "linebreak    CDATA                    #IMPLIED" >
+<!ENTITY % att-sizeinfo
+     "%att-width;
+      %att-height;
+      %att-depth;"
+>
+<!ENTITY % att-lquote               
+     "lquote       CDATA                    #IMPLIED" >
+<!ENTITY % att-rquote               
+     "rquote       CDATA                    #IMPLIED" >
+<!ENTITY % att-linethickness        
+     "linethickness CDATA                   #IMPLIED" >
+<!ENTITY % att-scriptlevel          
+     "scriptlevel  CDATA                    #IMPLIED" >
+<!ENTITY % att-displaystyle         
+     "displaystyle ( true | false )         #IMPLIED" >
+<!ENTITY % att-scriptsizemultiplier 
+     "scriptsizemultiplier CDATA            #IMPLIED" >
+<!ENTITY % att-scriptminsize        
+     "scriptminsize CDATA                   #IMPLIED" >
+<!ENTITY % att-background           
+     "background   CDATA                    #IMPLIED" >
+<!ENTITY % att-veryverythinmathspace           
+     "veryverythinmathspace   CDATA         #IMPLIED" >
+<!ENTITY % att-verythinmathspace           
+     "verythinmathspace   CDATA             #IMPLIED" >
+<!ENTITY % att-thinmathspace           
+     "thinmathspace   CDATA                 #IMPLIED" >
+<!ENTITY % att-mediummathspace           
+     "mediummathspace   CDATA               #IMPLIED" >
+<!ENTITY % att-thickmathspace           
+     "thickmathspace   CDATA                #IMPLIED" >
+<!ENTITY % att-verythickmathspace           
+     "verythickmathspace   CDATA            #IMPLIED" >
+<!ENTITY % att-veryverythickmathspace           
+     "veryverythickmathspace   CDATA        #IMPLIED" >
+<!ENTITY % att-open                 
+     "open         CDATA                    #IMPLIED" >
+<!ENTITY % att-close                
+     "close        CDATA                    #IMPLIED" >
+<!ENTITY % att-separators          
+     "separators   CDATA                    #IMPLIED" >
+<!ENTITY % att-subscriptshift       
+     "subscriptshift CDATA                  #IMPLIED" >
+<!ENTITY % att-superscriptshift     
+     "superscriptshift CDATA                #IMPLIED" >
+<!ENTITY % att-accentunder          
+     "accentunder  ( true | false )         #IMPLIED" >
+<!ENTITY % att-align       
+     "align        CDATA                    #IMPLIED" >
+<![%MathMLstrict;[
+  <!ENTITY % att-numalign	
+     "numalign     ( left | center | right )         #IMPLIED" >
+  <!ENTITY % att-denomalign
+     "denomalign   ( left | center | right )         #IMPLIED" >
+]]>
+<!ENTITY % att-numalign		
+     "numalign        CDATA                    #IMPLIED" >		
+<!ENTITY % att-denomalign		
+     "denomalign        CDATA                    #IMPLIED" >		
+<!ENTITY % att-rowalign-list		
+     "rowalign     CDATA                    #IMPLIED" >		
+<!ENTITY % att-columnalign-list		
+     "columnalign  CDATA                    #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-rowalign
+     "rowalign     ( top | bottom |	center | baseline | axis )    #IMPLIED" >
+  <!ENTITY % att-columnalign
+     "columnalign  ( left | center | right )        #IMPLIED" >
+]]>
+<!ENTITY % att-rowalign      
+     "rowalign     CDATA                    #IMPLIED" >
+<!ENTITY % att-columnalign     
+     "columnalign  CDATA                    #IMPLIED" >
+<!ENTITY % att-columnwidth   
+     "columnwidth  CDATA                    #IMPLIED" >
+<!ENTITY % att-groupalign-list		
+     "groupalign   CDATA                    #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-groupalign
+     "groupalign   ( left | right | center | decimalpoint )   #IMPLIED" >
+]]>
+<!ENTITY % att-groupalign      
+     "groupalign   CDATA                    #IMPLIED" >
+<!ENTITY % att-alignmentscope 
+     "alignmentscope CDATA                  #IMPLIED" >
+<!ENTITY % att-rowspacing           
+     "rowspacing   CDATA                    #IMPLIED" >
+<!ENTITY % att-columnspacing      
+     "columnspacing CDATA                   #IMPLIED" >
+<!ENTITY % att-rowlines            
+     "rowlines     CDATA                    #IMPLIED" >
+<!ENTITY % att-columnlines        
+     "columnlines  CDATA                    #IMPLIED" >
+<!ENTITY % att-frame            
+     "frame       ( none | solid | dashed ) #IMPLIED" >
+<!ENTITY % att-side		
+     "side       ( left | right | leftoverlap | rightoverlap ) #IMPLIED" >		
+<!ENTITY % att-framespacing         
+     "framespacing CDATA                    #IMPLIED" >
+<!ENTITY % att-minlabelspacing		
+     "minlabelspacing CDATA                 #IMPLIED" >		
+<![%MathMLstrict;[
+  <!ENTITY % att-equalrows
+     "equalrows    ( true | false )         #IMPLIED" >
+  <!ENTITY % att-equalcolumns
+     "equalcolumns ( true | false )         #IMPLIED" >
+]]>
+<!ENTITY % att-equalrows        
+     "equalrows    CDATA                    #IMPLIED" >
+<!ENTITY % att-equalcolumns         
+     "equalcolumns CDATA                    #IMPLIED" >
+
+<!ENTITY % att-tableinfo            
+     "%att-align;
+      %att-rowalign-list;	
+      %att-columnalign-list;	
+      %att-columnwidth;
+      %att-groupalign-list;	
+      %att-alignmentscope;
+      %att-side;		
+      %att-rowspacing;
+      %att-columnspacing;
+      %att-rowlines;
+      %att-columnlines;
+      %att-width;		
+      %att-frame;
+      %att-framespacing;
+      %att-minlabelspacing;		
+      %att-equalrows;
+      %att-equalcolumns;
+      %att-displaystyle;" 
+>
+
+<!ENTITY % att-rowspan              
+     "rowspan      CDATA                    #IMPLIED" >
+<!ENTITY % att-columnspan           
+     "columnspan   CDATA                    #IMPLIED" >
+<!ENTITY % att-edge        
+     "edge         ( left | right )         #IMPLIED" >
+<!ENTITY % att-actiontype          
+     "actiontype   CDATA                    #IMPLIED" >
+<!ENTITY % att-selection       
+     "selection    CDATA                    #IMPLIED" >
+
+<!ENTITY % att-name                 
+     "name         CDATA                    #IMPLIED" >
+<!ENTITY % att-alt              
+     "alt          CDATA                    #IMPLIED" >
+<!ENTITY % att-index           
+     "index        CDATA                    #IMPLIED" >
+
+<![%MathMLstrict;[
+  <!ENTITY % att-bevelled
+     "bevelled      ( true | false )        #IMPLIED" >
+]]>
+<!ENTITY % att-bevelled       
+     "bevelled      CDATA                    #IMPLIED" >
+
+<!-- Presentation schemata with content -->
+
+<!ENTITY % ptoken                   
+     "%mi.qname; | %mn.qname; | %mo.qname;
+      | %mtext.qname; | %ms.qname;" >
+
+<!ATTLIST %mi.qname;
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+>
+
+<!ATTLIST %mn.qname;      
+      %MATHML.Common.attrib; 
+      %att-fontinfo;
+>
+
+<!ATTLIST %mo.qname;     
+      %MATHML.Common.attrib; 
+      %att-fontinfo;
+      %att-opinfo;
+>
+
+<!ATTLIST %mtext.qname;  
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+>
+
+<!ATTLIST %ms.qname;     
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+      %att-lquote;
+      %att-rquote;
+>
+
+<!-- Empty presentation schemata -->
+
+<!ENTITY % petoken                  
+     "%mspace.qname;" >
+<!ELEMENT %mspace.qname;  EMPTY >
+
+<!ATTLIST %mspace.qname; 
+      %att-sizeinfo;
+      %att-linebreak;
+      %MATHML.Common.attrib;
+>
+
+<!-- Presentation: general layout schemata -->
+
+<!ENTITY % pgenschema               
+     "%mrow.qname; | %mfrac.qname; | %msqrt.qname; | %mroot.qname; 
+      | %menclose.qname; | %mstyle.qname; | %merror.qname; 
+      | %mpadded.qname; | %mphantom.qname; | %mfenced.qname;" >
+
+<!ATTLIST %mrow.qname;        
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mfrac.qname;     
+      %MATHML.Common.attrib;
+      %att-bevelled;		
+      %att-numalign;		
+      %att-denomalign;		
+      %att-linethickness;
+>
+
+<!ATTLIST %msqrt.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %menclose.qname;  
+      %MATHML.Common.attrib;
+      notation CDATA 'longdiv' >
+
+<!ATTLIST %mroot.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mstyle.qname;  
+      %MATHML.Common.attrib;
+      %att-fontinfo;
+      %att-opinfo;
+      %att-lquote;
+      %att-rquote;
+      %att-linethickness;
+      %att-scriptlevel;
+      %att-scriptsizemultiplier;
+      %att-scriptminsize;
+      %att-background;
+      %att-veryverythinmathspace;
+      %att-verythinmathspace;
+      %att-thinmathspace;
+      %att-mediummathspace;
+      %att-thickmathspace;
+      %att-verythickmathspace;
+      %att-veryverythickmathspace;
+      %att-open;
+      %att-close;
+      %att-separators;
+      %att-subscriptshift;
+      %att-superscriptshift;
+      %att-accentunder;
+      %att-tableinfo;
+      %att-rowspan;
+      %att-columnspan;
+      %att-edge;
+      %att-selection;
+      %att-bevelled;	
+      %att-height;		
+      %att-depth;		
+>
+
+<!ATTLIST %merror.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mpadded.qname;     
+      %MATHML.Common.attrib;
+      %att-sizeinfo;
+      %att-lspace;
+>
+
+<!ATTLIST %mphantom.qname;      
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %mfenced.qname;     
+      %MATHML.Common.attrib;
+      %att-open;
+      %att-close;
+      %att-separators;
+>
+
+<!-- Presentation layout schemata: scripts and limits -->
+
+<!ENTITY % pscrschema               
+     "%msub.qname; | %msup.qname; | %msubsup.qname; | %munder.qname; 
+      | %mover.qname; | %munderover.qname; | %mmultiscripts.qname;" >
+
+<!ATTLIST %msub.qname;      
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+>
+
+<!ATTLIST %msup.qname;         
+      %MATHML.Common.attrib;
+      %att-superscriptshift;
+>
+
+<!ATTLIST %msubsup.qname;    
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+      %att-superscriptshift;
+>
+
+<!ATTLIST %munder.qname;   
+      %MATHML.Common.attrib;
+      %att-accentunder;
+>
+
+<!ATTLIST %mover.qname;   
+      %MATHML.Common.attrib;
+      %att-accent;
+>
+
+<!ATTLIST %munderover.qname;   
+      %MATHML.Common.attrib;
+      %att-accent;
+      %att-accentunder;
+>
+
+<!ATTLIST %mmultiscripts.qname;   
+      %MATHML.Common.attrib;
+      %att-subscriptshift;
+      %att-superscriptshift;
+>
+
+<!-- Presentation layout schemata: empty elements for scripts -->
+
+<!ENTITY % pscreschema              
+     "%mprescripts.qname; | %none.qname;" >
+
+<!ELEMENT %mprescripts.qname;  EMPTY >
+<!ATTLIST %mprescripts.qname;   
+      %MATHML.xmlns.attrib; >
+
+<!ELEMENT %none.qname;  EMPTY >
+<!ATTLIST %none.qname;    
+      %MATHML.xmlns.attrib; >
+
+<!-- Presentation layout schemata: tables -->
+
+<![%MathMLstrict;[
+<!-- in strict mode only allow mtable at top level.
+     mtr ,mlabledtr and mtd only allowed inside mtable.
+-->
+  <!ENTITY % ptabschema    "%mtable.qname;" >
+]]>
+
+<!ENTITY % ptabschema               
+     "%mtable.qname; | %mtr.qname; | %mlabeledtr.qname; | %mtd.qname;" >
+
+<!ATTLIST %mtable.qname;
+      %MATHML.Common.attrib;
+      %att-tableinfo;
+>
+
+<!ATTLIST %mtr.qname;    
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign-list;	
+      %att-groupalign-list;	
+>
+
+<!ATTLIST %mlabeledtr.qname;  
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign-list;	
+      %att-groupalign-list;	
+>
+
+<!ATTLIST %mtd.qname;   
+      %MATHML.Common.attrib;
+      %att-rowalign;
+      %att-columnalign;
+      %att-groupalign-list;	
+      %att-rowspan;
+      %att-columnspan;
+>
+<!ENTITY % plschema                 
+     "%pgenschema; | %pscrschema; | %ptabschema;" >
+
+<!-- Empty presentation layout schemata -->
+
+<!ENTITY % peschema                 
+     "%maligngroup.qname; | %malignmark.qname;" >
+
+<!ELEMENT %malignmark.qname;  EMPTY >
+
+<!ATTLIST %malignmark.qname;  
+      %att-edge; >
+
+<!ELEMENT %maligngroup.qname;  EMPTY >
+<!ATTLIST %maligngroup.qname;  
+      %MATHML.Common.attrib;
+      %att-groupalign;
+>
+
+
+<!ELEMENT %mglyph.qname;  EMPTY >
+<!ATTLIST %mglyph.qname;    
+      %att-alt;
+      %att-fontfamily;
+      %att-index; >
+
+<!-- Presentation action schemata -->
+
+<!ENTITY % pactions                 
+     "%maction.qname;" >
+<!ATTLIST %maction.qname;    
+      %MATHML.Common.attrib;
+      %att-actiontype;
+      %att-selection;
+>
+
+<!-- The following entity for substitution into
+     content constructs excludes elements that
+     are not valid as expressions.
+-->
+
+<!ENTITY % PresInCont               
+     "%ptoken; | %petoken; |
+      %plschema; | %peschema; | %pactions;" >
+
+<!-- Presentation entity: all presentation constructs -->
+
+
+<![%MathMLstrict;[
+<!-- In strict mode don't allow prescripts and none at top level.-->
+  <!ENTITY % Presentation "%PresInCont;">             
+]]>
+<!ENTITY % Presentation             
+     "%ptoken; | %petoken; | %pscreschema; |
+      %plschema; | %peschema; | %pactions;">
+
+<!-- Content element set  ........................................ -->
+
+<!-- Attribute definitions -->
+
+<!ENTITY % att-base                 
+     "base         CDATA                    '10'" >
+<!ENTITY % att-closure              
+     "closure      CDATA                    'closed'" >
+<!ENTITY % att-definition           
+     "definitionURL CDATA                   ''" >
+<!ENTITY % att-encoding             
+     "encoding     CDATA                    ''" >
+<!ENTITY % att-nargs             
+     "nargs        CDATA                    '1'" >
+<!ENTITY % att-occurrence           
+     "occurrence   CDATA                    'function-model'" >
+<!ENTITY % att-order   
+     "order        CDATA                    'numeric'" >
+<!ENTITY % att-scope                
+     "scope        CDATA                    'local'" >
+<!ENTITY % att-type                 
+     "type         CDATA                    #IMPLIED" >
+
+<!-- Content elements: leaf nodes -->
+
+<!ENTITY % ctoken               
+     "%csymbol.qname; | %ci.qname; | %cn.qname;" >
+
+<!ATTLIST %ci.qname;     
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ATTLIST %csymbol.qname;   
+      %MATHML.Common.attrib;
+      %att-encoding;
+      %att-type;
+      %att-definition;
+>
+
+<!ATTLIST %cn.qname;    
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-base;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: specials -->
+
+<!ENTITY % cspecial                 
+     "%apply.qname; | %reln.qname; |
+      %lambda.qname;" >
+
+<!ATTLIST %apply.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %reln.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %lambda.qname;      
+      %MATHML.Common.attrib;
+>
+
+<!-- Content elements: others -->
+
+<!ENTITY % cother                   
+     "%condition.qname; | %declare.qname; | %sep.qname;" >
+
+<!ATTLIST %condition.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %declare.qname;    
+      %MATHML.Common.attrib;
+      %att-type;
+      %att-scope;
+      %att-nargs;
+      %att-occurrence;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sep.qname;  EMPTY >
+<!ATTLIST %sep.qname;         
+      %MATHML.xmlns.attrib; >
+
+<!-- Content elements: semantic mapping -->
+
+<![%MathMLstrict;[
+<!-- in strict mode only allow semantics at top level.
+     annotation and annotation-xml only allowed in semantics
+-->
+  <!ENTITY % csemantics  "%semantics.qname;" >
+]]>
+<!ENTITY % csemantics               
+     "%semantics.qname; | %annotation.qname; |
+      %annotation-xml.qname;" >
+
+<!ATTLIST %semantics.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ATTLIST %annotation.qname;  
+      %MATHML.Common.attrib;
+      %att-encoding;
+>
+
+<!ATTLIST %annotation-xml.qname; 
+      %MATHML.Common.attrib;
+      %att-encoding;
+>
+
+<!-- Content elements: constructors -->
+
+<!ENTITY % cconstructor             
+     "%interval.qname; | %list.qname; | %matrix.qname; 
+      | %matrixrow.qname; | %set.qname; | %vector.qname;
+      | %piecewise.qname; " >
+
+<!ATTLIST %interval.qname;   
+      %MATHML.Common.attrib;
+      %att-closure;
+>
+
+<!ATTLIST %set.qname;        
+      %MATHML.Common.attrib;
+      %att-type;
+>
+
+<!ATTLIST %list.qname;          
+      %MATHML.Common.attrib;
+      %att-order;
+>
+
+<!ATTLIST %vector.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %matrix.qname;    
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %matrixrow.qname;     
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %piecewise.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %piece.qname;   
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %otherwise.qname;   
+      %MATHML.Common.attrib;
+>
+
+
+<!-- Content elements: symbols -->
+
+<!ENTITY % c0ary              
+    "%integers.qname; |
+     %reals.qname; |
+     %rationals.qname; |
+     %naturalnumbers.qname; |
+     %complexes.qname; |
+     %primes.qname; |
+     %exponentiale.qname; |
+     %imaginaryi.qname; |
+     %notanumber.qname; |
+     %true.qname; |
+     %false.qname; |
+     %emptyset.qname; |
+     %pi.qname; |
+     %eulergamma.qname; |
+     %infinity.qname;" >
+
+<!ELEMENT %integers.qname;  EMPTY >
+<!ATTLIST %integers.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %reals.qname;  EMPTY >
+<!ATTLIST %reals.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %rationals.qname;  EMPTY >
+<!ATTLIST %rationals.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %naturalnumbers.qname;  EMPTY >
+<!ATTLIST %naturalnumbers.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %complexes.qname;  EMPTY >
+<!ATTLIST %complexes.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %primes.qname;  EMPTY >
+<!ATTLIST %primes.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %exponentiale.qname;  EMPTY >
+<!ATTLIST %exponentiale.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %imaginaryi.qname;  EMPTY >
+<!ATTLIST %imaginaryi.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notanumber.qname;  EMPTY >
+<!ATTLIST %notanumber.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %true.qname;  EMPTY >
+<!ATTLIST %true.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %false.qname;  EMPTY >
+<!ATTLIST %false.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %emptyset.qname;  EMPTY >
+<!ATTLIST %emptyset.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %pi.qname;  EMPTY >
+<!ATTLIST %pi.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %eulergamma.qname;  EMPTY >
+<!ATTLIST %eulergamma.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %infinity.qname;  EMPTY >
+<!ATTLIST %infinity.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: operators -->
+
+<!ENTITY % cfuncop1ary              
+     "%inverse.qname; | %ident.qname;|
+      %domain.qname; |  %codomain.qname; | 
+      %image.qname;  " >
+
+<!ELEMENT %inverse.qname;  EMPTY >
+<!ATTLIST %inverse.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %domain.qname;  EMPTY >
+<!ATTLIST %domain.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %codomain.qname;  EMPTY >
+<!ATTLIST %codomain.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %image.qname;  EMPTY >
+<!ATTLIST %image.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+
+<!ENTITY % cfuncopnary              
+     "%fn.qname; | %compose.qname;" >
+
+<!ATTLIST %fn.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %ident.qname;  EMPTY >
+<!ATTLIST %ident.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %compose.qname;  EMPTY >
+<!ATTLIST %compose.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithop1ary             
+     "%abs.qname; | %conjugate.qname; | %exp.qname; | %factorial.qname; |
+      %arg.qname; | %real.qname; | %imaginary.qname; |
+      %floor.qname; | %ceiling.qname;" >
+
+<!ELEMENT %exp.qname;  EMPTY >
+<!ATTLIST %exp.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %abs.qname;  EMPTY >
+<!ATTLIST %abs.qname;        
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arg.qname;  EMPTY >
+<!ATTLIST %arg.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %real.qname;  EMPTY >
+<!ATTLIST %real.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %imaginary.qname;  EMPTY >
+<!ATTLIST %imaginary.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %conjugate.qname;  EMPTY >
+<!ATTLIST %conjugate.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %factorial.qname;  EMPTY >
+<!ATTLIST %factorial.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %floor.qname;  EMPTY >
+<!ATTLIST %floor.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %ceiling.qname;  EMPTY >
+<!ATTLIST %ceiling.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+<!ENTITY % carithop1or2ary          
+     "%minus.qname;" >
+
+<!ELEMENT %minus.qname;  EMPTY >
+<!ATTLIST %minus.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithop2ary             
+     "%quotient.qname; | %divide.qname; | %power.qname; | %rem.qname;" >
+
+<!ELEMENT %quotient.qname;  EMPTY >
+<!ATTLIST %quotient.qname;       
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %divide.qname;  EMPTY >
+<!ATTLIST %divide.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %power.qname;  EMPTY >
+<!ATTLIST %power.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %rem.qname;  EMPTY >
+<!ATTLIST %rem.qname;       
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithopnary             
+     "%plus.qname; | %times.qname; | %max.qname; 
+      | %min.qname; | %gcd.qname; | %lcm.qname;" >
+
+<!ELEMENT %plus.qname;  EMPTY >
+<!ATTLIST %plus.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %max.qname;  EMPTY >
+<!ATTLIST %max.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %min.qname;  EMPTY >
+<!ATTLIST %min.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %times.qname;  EMPTY >
+<!ATTLIST %times.qname;      
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %gcd.qname;  EMPTY >
+<!ATTLIST %gcd.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %lcm.qname;  EMPTY >
+<!ATTLIST %lcm.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % carithoproot             
+     "%root.qname;" >
+
+<!ELEMENT %root.qname;  EMPTY >
+<!ATTLIST %root.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicopquant            
+     "%exists.qname; | %forall.qname;" >
+
+<!ELEMENT %exists.qname;  EMPTY >
+<!ATTLIST %exists.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %forall.qname;  EMPTY >
+<!ATTLIST %forall.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicopnary             
+     "%and.qname; | %or.qname; | %xor.qname;" >
+
+<!ELEMENT %and.qname;  EMPTY >
+<!ATTLIST %and.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %or.qname;  EMPTY >
+<!ATTLIST %or.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %xor.qname;  EMPTY >
+<!ATTLIST %xor.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicop1ary             
+     "%not.qname;" >
+
+<!ELEMENT %not.qname;  EMPTY >
+<!ATTLIST %not.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clogicop2ary             
+     "%implies.qname;" >
+
+<!ELEMENT %implies.qname;  EMPTY >
+<!ATTLIST %implies.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ccalcop                  
+     "%log.qname; | %int.qname; | %diff.qname; | %partialdiff.qname; |
+      %divergence.qname; | %grad.qname; | %curl.qname; | %laplacian.qname;" >
+
+<!ELEMENT %divergence.qname;  EMPTY >
+<!ATTLIST %divergence.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %grad.qname;  EMPTY >
+<!ATTLIST %grad.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %curl.qname;  EMPTY >
+<!ATTLIST %curl.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %laplacian.qname;  EMPTY >
+<!ATTLIST %laplacian.qname;     
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %log.qname;  EMPTY >
+<!ATTLIST %log.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %int.qname;  EMPTY >
+<!ATTLIST %int.qname;    
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %diff.qname;  EMPTY >
+<!ATTLIST %diff.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %partialdiff.qname;  EMPTY >
+<!ATTLIST %partialdiff.qname;  
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ccalcop1ary              
+     "%ln.qname;" >
+
+<!ELEMENT %ln.qname;  EMPTY >
+<!ATTLIST %ln.qname;   
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetop1ary               
+     "%card.qname;" >
+
+<!ELEMENT %card.qname;  EMPTY >
+<!ATTLIST %card.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetop2ary               
+     "%setdiff.qname;" >
+
+<!ELEMENT %setdiff.qname;  EMPTY >
+<!ATTLIST %setdiff.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetopnary               
+     "%union.qname; | %intersect.qname; | %cartesianproduct.qname; " >
+
+<!ELEMENT %union.qname;  EMPTY >
+<!ATTLIST %union.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %intersect.qname;  EMPTY >
+<!ATTLIST %intersect.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cartesianproduct.qname;  EMPTY >
+<!ATTLIST %cartesianproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cseqop                   
+     "%sum.qname; | %product.qname; | %limit.qname;" >
+
+<!ELEMENT %sum.qname;  EMPTY >
+<!ATTLIST %sum.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %product.qname;  EMPTY >
+<!ATTLIST %product.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %limit.qname;  EMPTY >
+<!ATTLIST %limit.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % ctrigop                  
+     "%sin.qname; | %cos.qname; | %tan.qname; 
+      | %sec.qname; | %csc.qname; | %cot.qname; 
+      | %sinh.qname; | %cosh.qname; | %tanh.qname; 
+      | %sech.qname; | %csch.qname; | %coth.qname; 
+      | %arcsin.qname; | %arccos.qname; | %arctan.qname;
+      | %arccosh.qname; | %arccot.qname; | %arccoth.qname;
+      | %arccsc.qname; | %arccsch.qname; | %arcsec.qname;
+      | %arcsech.qname; | %arcsinh.qname; | %arctanh.qname;
+      " >
+
+<!ELEMENT %sin.qname;  EMPTY >
+<!ATTLIST %sin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cos.qname;  EMPTY >
+<!ATTLIST %cos.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %tan.qname;  EMPTY >
+<!ATTLIST %tan.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sec.qname;  EMPTY >
+<!ATTLIST %sec.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %csc.qname;  EMPTY >
+<!ATTLIST %csc.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cot.qname;  EMPTY >
+<!ATTLIST %cot.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sinh.qname;  EMPTY >
+<!ATTLIST %sinh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %cosh.qname;  EMPTY >
+<!ATTLIST %cosh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %tanh.qname;  EMPTY >
+<!ATTLIST %tanh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sech.qname;  EMPTY >
+<!ATTLIST %sech.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %csch.qname;  EMPTY >
+<!ATTLIST %csch.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %coth.qname;  EMPTY >
+<!ATTLIST %coth.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsin.qname;  EMPTY >
+<!ATTLIST %arcsin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccos.qname;  EMPTY >
+<!ATTLIST %arccos.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arctan.qname;  EMPTY >
+<!ATTLIST %arctan.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccosh.qname;  EMPTY >
+<!ATTLIST %arccosh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %arccot.qname;  EMPTY >
+<!ATTLIST %arccot.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccoth.qname;  EMPTY >
+<!ATTLIST %arccoth.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+<!ELEMENT %arccsc.qname;  EMPTY >
+<!ATTLIST %arccsc.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arccsch.qname;  EMPTY >
+<!ATTLIST %arccsch.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsec.qname;  EMPTY >
+<!ATTLIST %arcsec.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsech.qname;  EMPTY >
+<!ATTLIST %arcsech.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arcsinh.qname;  EMPTY >
+<!ATTLIST %arcsinh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %arctanh.qname;  EMPTY >
+<!ATTLIST %arctanh.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+
+
+<!ENTITY % cstatopnary              
+     "%mean.qname; | %sdev.qname; |
+      %variance.qname; | %median.qname; |
+      %mode.qname;" >
+
+<!ELEMENT %mean.qname;  EMPTY >
+<!ATTLIST %mean.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %sdev.qname;  EMPTY >
+<!ATTLIST %sdev.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %variance.qname;  EMPTY >
+<!ATTLIST %variance.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %median.qname;  EMPTY >
+<!ATTLIST %median.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %mode.qname;  EMPTY >
+<!ATTLIST %mode.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cstatopmoment            
+     "%moment.qname;" >
+
+<!ELEMENT %moment.qname;  EMPTY >
+<!ATTLIST %moment.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgop1ary              
+     "%determinant.qname; |
+      %transpose.qname;" >
+
+<!ELEMENT %determinant.qname;  EMPTY >
+<!ATTLIST %determinant.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %transpose.qname;  EMPTY >
+<!ATTLIST %transpose.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgop2ary              
+     "%vectorproduct.qname; 
+      | %scalarproduct.qname; 
+      | %outerproduct.qname;" >
+
+<!ELEMENT %vectorproduct.qname;  EMPTY >
+<!ATTLIST %vectorproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %scalarproduct.qname;  EMPTY >
+<!ATTLIST %scalarproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %outerproduct.qname;  EMPTY >
+<!ATTLIST %outerproduct.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % clalgopnary              
+     "%selector.qname;" >
+
+<!ELEMENT %selector.qname;  EMPTY >
+<!ATTLIST %selector.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!-- Content elements: relations -->
+
+<!ENTITY % cgenrel2ary             
+     "%neq.qname; | %factorof.qname;" >
+
+<!ELEMENT %neq.qname;  EMPTY >
+<!ATTLIST %neq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %factorof.qname;  EMPTY >
+<!ATTLIST %factorof.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cgenrelnary              
+     "%eq.qname; | %leq.qname; | %lt.qname; | %geq.qname; 
+      | %gt.qname;| %equivalent.qname; | %approx.qname;" >
+
+<!ELEMENT %eq.qname;  EMPTY >
+<!ATTLIST %eq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %equivalent.qname;  EMPTY >
+<!ATTLIST %equivalent.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %approx.qname;  EMPTY >
+<!ATTLIST %approx.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %gt.qname;  EMPTY >
+<!ATTLIST %gt.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %lt.qname;  EMPTY >
+<!ATTLIST %lt.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %geq.qname;  EMPTY >
+<!ATTLIST %geq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %leq.qname;  EMPTY >
+<!ATTLIST %leq.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetrel2ary              
+     "%in.qname; | %notin.qname; | %notsubset.qname; | %notprsubset.qname;" >
+
+<!ELEMENT %in.qname;  EMPTY >
+<!ATTLIST %in.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notin.qname;  EMPTY >
+<!ATTLIST %notin.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notsubset.qname;  EMPTY >
+<!ATTLIST %notsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %notprsubset.qname;  EMPTY >
+<!ATTLIST %notprsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % csetrelnary       
+     "%subset.qname; | %prsubset.qname;" >
+
+<!ELEMENT %subset.qname;  EMPTY >
+<!ATTLIST %subset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ELEMENT %prsubset.qname;  EMPTY >
+<!ATTLIST %prsubset.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+>
+
+<!ENTITY % cseqrel2ary              
+     "%tendsto.qname;" >
+
+<!ELEMENT %tendsto.qname;  EMPTY >
+<!ATTLIST %tendsto.qname;
+      %MATHML.Common.attrib;
+      %att-definition;
+      %att-encoding;
+      %att-type;
+>
+
+<!-- Content elements: quantifiers -->
+
+<!ENTITY % cquantifier            
+     "%lowlimit.qname; | %uplimit.qname; | %bvar.qname; 
+      | %degree.qname; | %logbase.qname;
+      | %momentabout.qname; | %domainofapplication.qname; " >
+
+<!ATTLIST %lowlimit.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %uplimit.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %bvar.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %degree.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %logbase.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %momentabout.qname;
+      %MATHML.Common.attrib;
+>
+
+<!ATTLIST %domainofapplication.qname;
+      %MATHML.Common.attrib;
+>
+
+<!-- Operator groups -->
+
+<!ENTITY % cop1ary                  
+     "%cfuncop1ary; | %carithop1ary; | %clogicop1ary; |
+      %ccalcop1ary; | %ctrigop; | %clalgop1ary; |
+      %csetop1ary;" >
+
+<!ENTITY % cop2ary                  
+     "%carithop2ary; | %clogicop2ary;| %clalgop2ary; | %csetop2ary;" >
+
+<!ENTITY % copnary                  
+     "%cfuncopnary; | %carithopnary; | %clogicopnary; |
+      %csetopnary; | %cstatopnary; | %clalgopnary;" >
+
+<!ENTITY % copmisc                  
+     "%carithoproot; | %carithop1or2ary; | %ccalcop; |
+      %cseqop; | %cstatopmoment; | %clogicopquant;" >
+
+<!-- Relation groups -->
+
+<!ENTITY % crel2ary                 
+     "%cgenrel2ary; | %csetrel2ary; | %cseqrel2ary;" >
+
+<!ENTITY % crelnary                 
+     "%cgenrelnary; | %csetrelnary;" >
+
+<!-- Content constructs: all -->
+
+<!ENTITY % Content                  
+     "%ctoken; | %cspecial; | %cother; | %csemantics; | %c0ary;
+      | %cconstructor; | %cquantifier; | %cop1ary; | %cop2ary; 
+      | %copnary; |%copmisc; | %crel2ary; | %crelnary;" >
+
+<!-- Content constructs for substitution in presentation structures -->
+
+<!ENTITY % ContInPres               
+     "%ci.qname; |%csymbol.qname;| %cn.qname; | %c0ary; |
+      %apply.qname; | %fn.qname; |
+      %lambda.qname; | %reln.qname; |
+      %cconstructor; |
+      %semantics.qname; |%declare.qname;" >
+
+<!-- ............................................................. -->
+<!-- Recursive definition for content of expressions. Include
+     presentation constructs at lowest level so presentation
+     layout schemata hold presentation or content elements.
+     Include content constructs at lowest level so content
+     elements hold PCDATA or presentation elements at leaf
+     level (for permitted substitutable elements in context)
+-->
+<![%MathMLstrict;[
+<!-- in strict mode don't allow presentation in content
+     except where allowed by chapter 5:
+     ci, cn, csymbol, semantics
+-->
+  <!ENTITY % ContentExpression  "(%Content;)*" >
+  <!ENTITY % semanticsContentExpression        
+       "(%Content; | %PresInCont; |
+         %annotation.qname; | %annotation-xml.qname;)*" >
+]]>
+<!ENTITY % ContentExpression        
+     "(%Content; | %PresInCont;)*" >
+<!ENTITY % semanticsContentExpression    "%ContentExpression;">    
+
+
+<!ENTITY % PresExpression      
+     "(%Presentation; | %ContInPres;)*" >
+<!ENTITY % MathExpression           
+     "(%PresInCont; | %ContInPres;)*" >
+
+<!-- PCDATA or MathML character elements -->
+<!ENTITY % MathMLCharacters         
+     "#PCDATA | %mglyph.qname; " >
+
+<!-- Content elements: tokens                       -->
+<!-- (may contain embedded presentation constructs) -->
+
+<!ELEMENT %ci.qname;                 (%MathMLCharacters; | %PresInCont;)* >
+<!ELEMENT %csymbol.qname;            (%MathMLCharacters; | %PresInCont;)* >
+<!ELEMENT %cn.qname;                 (%MathMLCharacters; | %sep.qname; | %PresInCont;)* >
+
+<!-- Content elements: special -->
+
+<!ELEMENT %apply.qname;              (%ContentExpression;) >
+<!ELEMENT %reln.qname;               (%ContentExpression;) >
+<!ELEMENT %lambda.qname;             (%ContentExpression;) >
+
+<!-- Content elements: other -->
+
+<!ELEMENT %condition.qname;          (%ContentExpression;) >
+<!ELEMENT %declare.qname;            (%ContentExpression;) >
+
+<!-- Content elements: semantics -->
+
+<!ELEMENT %semantics.qname;          (%semanticsContentExpression;) >
+<!ENTITY % Annotation.content  "( #PCDATA )" >
+<!ELEMENT %annotation.qname;         %Annotation.content; >
+
+<!ENTITY % Annotation-xml.content "ANY" >
+<!ELEMENT %annotation-xml.qname;     %Annotation-xml.content; >
+
+<!-- Content elements: constructors -->
+
+<!ELEMENT %interval.qname;           (%ContentExpression;) >
+<!ELEMENT %set.qname;                (%ContentExpression;) >
+<!ELEMENT %list.qname;               (%ContentExpression;) >
+<!ELEMENT %vector.qname;             (%ContentExpression;) >
+<!ELEMENT %matrix.qname;             (%ContentExpression;) >
+<!ELEMENT %matrixrow.qname;          (%ContentExpression;) >
+
+<!ELEMENT %piecewise.qname;          ((%piece.qname;)*, (%otherwise.qname;)? ) >
+<!ELEMENT %piece.qname;              (%ContentExpression;) >
+<!ELEMENT %otherwise.qname;          (%ContentExpression;) >
+
+<!-- Content elements: operator (user-defined) -->
+
+<!ELEMENT %fn.qname;                 (%ContentExpression;) >
+
+<!-- Content elements: quantifiers -->
+
+<!ELEMENT %lowlimit.qname;           (%ContentExpression;) >
+<!ELEMENT %uplimit.qname;            (%ContentExpression;) >
+<!ELEMENT %bvar.qname;               (%ContentExpression;) >
+<!ELEMENT %degree.qname;             (%ContentExpression;) >
+<!ELEMENT %logbase.qname;            (%ContentExpression;) >
+<!ELEMENT %momentabout.qname;        (%ContentExpression;) >
+<!ELEMENT %domainofapplication.qname; (%ContentExpression;) >
+
+<!-- ............................................................. -->
+<!-- Presentation layout schemata contain tokens,
+     layout and content schemata.
+-->
+
+
+
+<![%MathMLstrict;[
+<!-- In strict mode enforce mfrac has exactly two children
+      same for msub etc -->
+  <!ENTITY % onePresExpression
+       "(%Presentation; | %ContInPres;)" >
+  <!ENTITY % twoPresExpression
+       "(%onePresExpression;,%onePresExpression;)" >
+  <!ENTITY % threePresExpression
+       "(%onePresExpression;,%onePresExpression;,%onePresExpression;)" >
+  <!ENTITY % mtrPresExpression
+       "(%mtr.qname;|%mlabeledtr.qname;)*" >
+  <!ENTITY % mtdPresExpression
+       "(%mtd.qname;)*" >
+  <!ENTITY % prscrPresExpression " (%onePresExpression;,
+  ((%onePresExpression;|%none.qname;),(%onePresExpression;|%none.qname;))*,
+  (%mprescripts.qname;,
+  ((%onePresExpression;|%none.qname;),(%onePresExpression;|%none.qname;))*)?
+  )">
+]]>
+
+
+<!-- By default keep them as they were in MathML 2.0  -->
+<!ENTITY % onePresExpression   "%PresExpression;">
+<!ENTITY % twoPresExpression   "%PresExpression;">
+<!ENTITY % threePresExpression "%PresExpression;">
+<!ENTITY % mtrPresExpression   "%PresExpression;">
+<!ENTITY % mtdPresExpression   "%PresExpression;">
+<!ENTITY % prscrPresExpression "%PresExpression;">
+
+<!ELEMENT %mstyle.qname;             (%PresExpression;) >
+<!ELEMENT %merror.qname;             (%PresExpression;) >
+<!ELEMENT %mphantom.qname;           (%PresExpression;) >
+<!ELEMENT %mrow.qname;               (%PresExpression;) >
+<!ELEMENT %mfrac.qname;              (%twoPresExpression;) >
+<!ELEMENT %msqrt.qname;              (%PresExpression;) >
+<!ELEMENT %menclose.qname;           (%PresExpression;) >
+<!ELEMENT %mroot.qname;              (%twoPresExpression;) >
+<!ELEMENT %msub.qname;               (%twoPresExpression;) >
+<!ELEMENT %msup.qname;               (%twoPresExpression;) >
+<!ELEMENT %msubsup.qname;            (%threePresExpression;) >
+<!ELEMENT %mmultiscripts.qname;      (%prscrPresExpression;) >
+<!ELEMENT %munder.qname;             (%twoPresExpression;) >
+<!ELEMENT %mover.qname;              (%twoPresExpression;) >
+<!ELEMENT %munderover.qname;         (%threePresExpression;) >
+<!ELEMENT %mtable.qname;             (%mtrPresExpression;) >
+<!ELEMENT %mtr.qname;                (%mtdPresExpression;) >
+<!ELEMENT %mlabeledtr.qname;         (%mtdPresExpression;) >
+<!ELEMENT %mtd.qname;                (%PresExpression;) >
+<!ELEMENT %maction.qname;            (%PresExpression;) >
+<!ELEMENT %mfenced.qname;            (%PresExpression;) >
+<!ELEMENT %mpadded.qname;            (%PresExpression;) >
+
+<!-- Presentation elements contain PCDATA or malignmark constructs. -->
+
+<!ELEMENT %mi.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mn.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mo.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %mtext.qname;              (%MathMLCharacters; |
+      %malignmark.qname;)* >
+<!ELEMENT %ms.qname;                 (%MathMLCharacters; |
+      %malignmark.qname;)* >
+
+<!-- Browser interface definition  ............................... -->
+
+<!-- Attributes for top-level element "math" -->
+
+<!ENTITY % att-macros               
+     "macros       CDATA                    #IMPLIED" >
+<!ENTITY % att-mode                 
+     "mode         CDATA                    #IMPLIED" >
+<![%MathMLstrict;[
+  <!ENTITY % att-display
+     "display      ( block | inline )                    'inline'" >
+]]>
+<!ENTITY % att-display                
+     "display      CDATA                    #IMPLIED" >
+
+<!ENTITY % att-schemalocation               
+     "%Schema.prefix;:schemaLocation CDATA  #IMPLIED">		
+
+<!ENTITY % att-topinfo          
+     "%MATHML.Common.attrib;
+      %att-schemalocation;		
+      %att-macros;
+      %att-mode;
+      %att-display;" >
+
+<!-- Attributes for browser interface element -->
+
+<!ENTITY % att-baseline             
+     "baseline     CDATA                    #IMPLIED" >
+<!ENTITY % att-overflow            
+     "overflow  ( scroll | elide | truncate | scale ) 'scroll'" >
+<!ENTITY % att-altimg               
+     "altimg       CDATA                    #IMPLIED" >
+<!ENTITY % att-alttext           
+     "alttext      CDATA                    #IMPLIED" >
+
+<!ENTITY % att-browif           
+     "%att-type;
+      %att-name;
+      %att-height;
+      %att-width;
+      %att-baseline;
+      %att-overflow;
+      %att-altimg;
+      %att-alttext;" >
+
+<!-- ............................................................. -->
+<!-- The top-level element "math" contains MathML encoded
+     mathematics. The "math" element has the browser info
+     attributes iff it is also the browser interface element.
+-->
+
+<!ELEMENT %math.qname;               (%MathExpression;) >
+
+<!ATTLIST %math.qname;
+      %att-topinfo;
+      %att-browif; >
+
+<!-- MathML Character Entities .............................................. -->
+<!ENTITY % mathml-charent.module "INCLUDE" >
+<![%mathml-charent.module;[
+<!-- Entity sets from ISO Technical Report 9573-13 ..... -->
+
+<!ENTITY % ent-isoamsa
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Arrow Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsa.ent" >
+%ent-isoamsa;
+
+<!ENTITY % ent-isoamsb
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Binary Operators for MathML 2.0//EN"
+             "iso9573-13/isoamsb.ent" >
+%ent-isoamsb;
+
+<!ENTITY % ent-isoamsc
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Delimiters for MathML 2.0//EN"
+             "iso9573-13/isoamsc.ent" >
+%ent-isoamsc;
+
+<!ENTITY % ent-isoamsn
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Negated Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsn.ent" >
+%ent-isoamsn;
+
+<!ENTITY % ent-isoamso
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Ordinary for MathML 2.0//EN"
+             "iso9573-13/isoamso.ent" >
+%ent-isoamso;
+
+<!ENTITY % ent-isoamsr
+      PUBLIC "-//W3C//ENTITIES Added Math Symbols: Relations for MathML 2.0//EN"
+             "iso9573-13/isoamsr.ent" >
+%ent-isoamsr;
+
+<!ENTITY % ent-isogrk3
+      PUBLIC "-//W3C//ENTITIES Greek Symbols for MathML 2.0//EN"
+             "iso9573-13/isogrk3.ent" >
+%ent-isogrk3;
+
+<!ENTITY % ent-isomfrk
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Fraktur for MathML 2.0//EN"
+             "iso9573-13/isomfrk.ent" >
+%ent-isomfrk;
+
+<!ENTITY % ent-isomopf
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Open Face for MathML 2.0//EN"
+             "iso9573-13/isomopf.ent" >
+%ent-isomopf;
+
+<!ENTITY % ent-isomscr
+      PUBLIC "-//W3C//ENTITIES Math Alphabets: Script for MathML 2.0//EN"
+             "iso9573-13/isomscr.ent" >
+%ent-isomscr;
+
+<!ENTITY % ent-isotech
+      PUBLIC "-//W3C//ENTITIES General Technical for MathML 2.0//EN"
+             "iso9573-13/isotech.ent" >
+%ent-isotech;
+
+<!-- Entity sets from informative annex to ISO 8879:1986 (SGML) ....... -->
+
+<!ENTITY % ent-isobox
+      PUBLIC "-//W3C//ENTITIES Box and Line Drawing for MathML 2.0//EN"
+             "iso8879/isobox.ent" >
+%ent-isobox;
+
+<!ENTITY % ent-isocyr1
+      PUBLIC "-//W3C//ENTITIES Russian Cyrillic for MathML 2.0//EN"
+             "iso8879/isocyr1.ent" >
+%ent-isocyr1;
+
+<!ENTITY % ent-isocyr2
+      PUBLIC "-//W3C//ENTITIES Non-Russian Cyrillic for MathML 2.0//EN"
+             "iso8879/isocyr2.ent" >
+%ent-isocyr2;
+
+<!ENTITY % ent-isodia
+      PUBLIC "-//W3C//ENTITIES Diacritical Marks for MathML 2.0//EN"
+             "iso8879/isodia.ent" >
+%ent-isodia;
+
+<!ENTITY % ent-isolat1
+      PUBLIC "-//W3C//ENTITIES Added Latin 1 for MathML 2.0//EN"
+             "iso8879/isolat1.ent" >
+%ent-isolat1;
+
+<!ENTITY % ent-isolat2
+      PUBLIC "-//W3C//ENTITIES Added Latin 2 for MathML 2.0//EN"
+             "iso8879/isolat2.ent" >
+%ent-isolat2;
+
+<!ENTITY % ent-isonum
+      PUBLIC "-//W3C//ENTITIES Numeric and Special Graphic for MathML 2.0//EN"
+             "iso8879/isonum.ent" >
+%ent-isonum;
+
+<!ENTITY % ent-isopub
+      PUBLIC "-//W3C//ENTITIES Publishing for MathML 2.0//EN"
+             "iso8879/isopub.ent" >
+%ent-isopub;
+
+<!-- New characters defined by MathML ............................ -->
+
+<!ENTITY % ent-mmlextra
+      PUBLIC "-//W3C//ENTITIES Extra for MathML 2.0//EN"
+             "mathml/mmlextra.ent" >
+%ent-mmlextra;
+
+<!-- MathML aliases for characters defined above ................. -->
+
+<!ENTITY % ent-mmlalias
+      PUBLIC "-//W3C//ENTITIES Aliases for MathML 2.0//EN"
+             "mathml/mmlalias.ent" >
+%ent-mmlalias;
+
+<!-- end of MathML Character Entity section -->]]>
+
+<!-- Revision History:
+
+       Initial draft (syntax = XML) 1997-05-09
+          Stephen Buswell
+       Revised 1997-05-14
+          Robert Miner
+       Revised 1997-06-29 and 1997-07-02
+          Stephen Buswell
+       Revised 1997-12-15
+          Stephen Buswell
+       Revised 1998-02-08
+          Stephen Buswell
+       Revised 1998-04-04
+          Stephen Buswell
+       Entities and small revisions 1999-02-21
+          David Carlisle
+       Added attribute definitionURL to ci and cn 1999-10-11
+          Nico Poppelier
+       Additions for MathML 2  1999-12-16
+          David Carlisle
+       Namespace support 2000-01-14
+          David Carlisle
+       XHTML Compatibility 2000-02-23
+          Murray Altheim
+       New content elements 2000-03-26
+          David Carlisle
+       Further revisions for MathML2 CR draft 2000-07-11
+          David Carlisle
+       Further revisions for MathML2 CR draft 2000-10-31		
+          David Carlisle		
+       Revisions for Unicode 3.2  2002-05-21		
+          David Carlisle		
+       Add width and side attributes to mtable (to align with the specification)  2002-06-05		
+          David Carlisle		
+       Use %XLINK.prefix rather than hardwired xlink:, add xlink:type 2002-06-12		
+          David Carlisle		
+       Add missing numalign and denomalign attributes for mfrac 2002-07-05		
+          David Carlisle		
+       Add MathMLstrict entity and related extra constraints 2002-12-05		
+          David Carlisle		
+       Add support for xi:schemaLocation 2003-04-05		
+          David Carlisle		
+       Removed actiontype from mstyle (to match spec) 2003-04-07		
+          David Carlisle		
+       Additional constraints for MathMLstrict code (From Simon		
+          Pepping on www-math list) 2003-05-22		
+          David Carlisle		
+       Add missing minlabelspacing attribute (From Simon		
+          Pepping on www-math list) 2003-05-22		
+          David Carlisle		
+       Removed restricted menclose notation checking from MathMLstrict 2003-09-08		
+          David Carlisle		
+
+-->
+
+<!-- end of MathML 2.0 DTD  ................................................ -->
+<!-- ....................................................................... -->
+

--- a/publishing/1.1/mathml3-qname1.mod
+++ b/publishing/1.1/mathml3-qname1.mod
@@ -1,0 +1,294 @@
+<!-- ....................................................................... -->
+<!-- MathML Qualified Names Module  ........................................ -->
+<!-- file: mathml3-qname-1.mod
+
+     This is the Mathematical Markup Language (MathML) 2.0, an XML 
+     application for describing mathematical notation and capturing 
+     both its structure and content.
+
+     Copyright 1998-2010 W3C (MIT, INRIA, Keio), All Rights Reserved.
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"
+       SYSTEM "mathml3-qname.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- MathML Qualified Names
+
+     This module is contained in two parts, labeled Section 'A' and 'B':
+
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing 
+       for MathML.
+    
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all MathML element types.
+
+     This module is derived from the XHTML Qualified Names Template module.
+-->
+
+<!-- Section A: XHTML XML Namespace Framework :::::::::::::::::::: -->
+
+<!ENTITY % NS.prefixed     "IGNORE" >
+<!ENTITY % MATHML.prefixed "%NS.prefixed;" >
+
+<!-- XLink ............... -->
+
+<!ENTITY % XLINK.prefix         "xlink" >		
+<!ENTITY % XLINK.xmlns "http://www.w3.org/1999/xlink" >
+<!ENTITY % XLINK.xmlns.attrib
+     "xmlns:%XLINK.prefix;  CDATA           #FIXED '%XLINK.xmlns;'"
+>
+
+<!-- W3C XML Schema ............... -->
+
+<!ENTITY % Schema.prefix         "xsi" >		
+<!ENTITY % Schema.xmlns "http://www.w3.org/2001/XMLSchema-instance" >
+<!ENTITY % Schema.xmlns.attrib
+     "xmlns:%Schema.prefix;  CDATA           #IMPLIED"
+>
+
+<!-- MathML .............. -->
+
+<!ENTITY % MATHML.xmlns    "http://www.w3.org/1998/Math/MathML" >
+<!ENTITY % MATHML.prefix   "m" >
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.xmlns.extra.attrib  "" >
+]]>
+<!ENTITY % MATHML.xmlns.extra.attrib 
+     "%XLINK.xmlns.attrib; 
+      %Schema.xmlns.attrib;" >
+
+<![%MATHML.prefixed;[
+<!ENTITY % MATHML.pfx  "%MATHML.prefix;:" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns:%MATHML.prefix;  CDATA   #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+]]>
+<!ENTITY % MATHML.pfx  "" >
+<!ENTITY % MATHML.xmlns.attrib
+     "xmlns        CDATA           #FIXED '%MATHML.xmlns;'
+      %MATHML.xmlns.extra.attrib;"
+>
+
+<![%NS.prefixed;[
+<!ENTITY % XHTML.xmlns.extra.attrib 
+     "%MATHML.xmlns.attrib;" >
+]]>
+<!ENTITY % XHTML.xmlns.extra.attrib
+     "%XLINK.xmlns.attrib;
+      %Schema.xmlns.attrib;"
+>
+
+
+<!-- ignores subsequent instantiation of this module when
+     used as external subset rather than module fragment.
+     NOTE: Do not modify this parameter entity, otherwise
+     a recursive parsing situation may result.
+-->
+<!ENTITY % mathml-qname.module "IGNORE" >
+
+<!-- Section B: MathML Qualified Names ::::::::::::::::::::::::::::: -->
+
+<!-- 9. This section declares parameter entities used to provide
+        namespace-qualified names for all MathML element types.
+-->
+
+<!ENTITY % abs.qname "%MATHML.pfx;abs" >
+<!ENTITY % and.qname "%MATHML.pfx;and" >
+<!ENTITY % annotation-xml.qname "%MATHML.pfx;annotation-xml" >
+<!ENTITY % annotation.qname "%MATHML.pfx;annotation" >
+<!ENTITY % apply.qname "%MATHML.pfx;apply" >
+<!ENTITY % approx.qname "%MATHML.pfx;approx" >
+<!ENTITY % arccos.qname "%MATHML.pfx;arccos" >
+<!ENTITY % arccosh.qname "%MATHML.pfx;arccosh" >
+<!ENTITY % arccot.qname "%MATHML.pfx;arccot" >
+<!ENTITY % arccoth.qname "%MATHML.pfx;arccoth" >
+<!ENTITY % arccsc.qname "%MATHML.pfx;arccsc" >
+<!ENTITY % arccsch.qname "%MATHML.pfx;arccsch" >
+<!ENTITY % arcsec.qname "%MATHML.pfx;arcsec" >
+<!ENTITY % arcsech.qname "%MATHML.pfx;arcsech" >
+<!ENTITY % arcsin.qname "%MATHML.pfx;arcsin" >
+<!ENTITY % arcsinh.qname "%MATHML.pfx;arcsinh" >
+<!ENTITY % arctan.qname "%MATHML.pfx;arctan" >
+<!ENTITY % arctanh.qname "%MATHML.pfx;arctanh" >
+<!ENTITY % arg.qname "%MATHML.pfx;arg" >
+<!ENTITY % bind.qname "%MATHML.pfx;bind" >
+<!ENTITY % bvar.qname "%MATHML.pfx;bvar" >
+<!ENTITY % card.qname "%MATHML.pfx;card" >
+<!ENTITY % cartesianproduct.qname "%MATHML.pfx;cartesianproduct" >
+<!ENTITY % cbytes.qname "%MATHML.pfx;cbytes" >
+<!ENTITY % ceiling.qname "%MATHML.pfx;ceiling" >
+<!ENTITY % cerror.qname "%MATHML.pfx;cerror" >
+<!ENTITY % ci.qname "%MATHML.pfx;ci" >
+<!ENTITY % cn.qname "%MATHML.pfx;cn" >
+<!ENTITY % codomain.qname "%MATHML.pfx;codomain" >
+<!ENTITY % complexes.qname "%MATHML.pfx;complexes" >
+<!ENTITY % compose.qname "%MATHML.pfx;compose" >
+<!ENTITY % condition.qname "%MATHML.pfx;condition" >
+<!ENTITY % conjugate.qname "%MATHML.pfx;conjugate" >
+<!ENTITY % cos.qname "%MATHML.pfx;cos" >
+<!ENTITY % cosh.qname "%MATHML.pfx;cosh" >
+<!ENTITY % cot.qname "%MATHML.pfx;cot" >
+<!ENTITY % coth.qname "%MATHML.pfx;coth" >
+<!ENTITY % cs.qname "%MATHML.pfx;cs" >
+<!ENTITY % csc.qname "%MATHML.pfx;csc" >
+<!ENTITY % csch.qname "%MATHML.pfx;csch" >
+<!ENTITY % csymbol.qname "%MATHML.pfx;csymbol" >
+<!ENTITY % curl.qname "%MATHML.pfx;curl" >
+<!ENTITY % declare.qname "%MATHML.pfx;declare" >
+<!ENTITY % degree.qname "%MATHML.pfx;degree" >
+<!ENTITY % determinant.qname "%MATHML.pfx;determinant" >
+<!ENTITY % diff.qname "%MATHML.pfx;diff" >
+<!ENTITY % divergence.qname "%MATHML.pfx;divergence" >
+<!ENTITY % divide.qname "%MATHML.pfx;divide" >
+<!ENTITY % domain.qname "%MATHML.pfx;domain" >
+<!ENTITY % domainofapplication.qname "%MATHML.pfx;domainofapplication" >
+<!ENTITY % emptyset.qname "%MATHML.pfx;emptyset" >
+<!ENTITY % eq.qname "%MATHML.pfx;eq" >
+<!ENTITY % equivalent.qname "%MATHML.pfx;equivalent" >
+<!ENTITY % eulergamma.qname "%MATHML.pfx;eulergamma" >
+<!ENTITY % exists.qname "%MATHML.pfx;exists" >
+<!ENTITY % exp.qname "%MATHML.pfx;exp" >
+<!ENTITY % exponentiale.qname "%MATHML.pfx;exponentiale" >
+<!ENTITY % factorial.qname "%MATHML.pfx;factorial" >
+<!ENTITY % factorof.qname "%MATHML.pfx;factorof" >
+<!ENTITY % false.qname "%MATHML.pfx;false" >
+<!ENTITY % floor.qname "%MATHML.pfx;floor" >
+<!ENTITY % fn.qname "%MATHML.pfx;fn" >
+<!ENTITY % forall.qname "%MATHML.pfx;forall" >
+<!ENTITY % gcd.qname "%MATHML.pfx;gcd" >
+<!ENTITY % geq.qname "%MATHML.pfx;geq" >
+<!ENTITY % grad.qname "%MATHML.pfx;grad" >
+<!ENTITY % gt.qname "%MATHML.pfx;gt" >
+<!ENTITY % ident.qname "%MATHML.pfx;ident" >
+<!ENTITY % image.qname "%MATHML.pfx;image" >
+<!ENTITY % imaginary.qname "%MATHML.pfx;imaginary" >
+<!ENTITY % imaginaryi.qname "%MATHML.pfx;imaginaryi" >
+<!ENTITY % implies.qname "%MATHML.pfx;implies" >
+<!ENTITY % in.qname "%MATHML.pfx;in" >
+<!ENTITY % infinity.qname "%MATHML.pfx;infinity" >
+<!ENTITY % int.qname "%MATHML.pfx;int" >
+<!ENTITY % integers.qname "%MATHML.pfx;integers" >
+<!ENTITY % intersect.qname "%MATHML.pfx;intersect" >
+<!ENTITY % interval.qname "%MATHML.pfx;interval" >
+<!ENTITY % inverse.qname "%MATHML.pfx;inverse" >
+<!ENTITY % lambda.qname "%MATHML.pfx;lambda" >
+<!ENTITY % laplacian.qname "%MATHML.pfx;laplacian" >
+<!ENTITY % lcm.qname "%MATHML.pfx;lcm" >
+<!ENTITY % leq.qname "%MATHML.pfx;leq" >
+<!ENTITY % limit.qname "%MATHML.pfx;limit" >
+<!ENTITY % list.qname "%MATHML.pfx;list" >
+<!ENTITY % ln.qname "%MATHML.pfx;ln" >
+<!ENTITY % log.qname "%MATHML.pfx;log" >
+<!ENTITY % logbase.qname "%MATHML.pfx;logbase" >
+<!ENTITY % lowlimit.qname "%MATHML.pfx;lowlimit" >
+<!ENTITY % lt.qname "%MATHML.pfx;lt" >
+<!ENTITY % maction.qname "%MATHML.pfx;maction" >
+<!ENTITY % maligngroup.qname "%MATHML.pfx;maligngroup" >
+<!ENTITY % malignmark.qname "%MATHML.pfx;malignmark" >
+<!ENTITY % math.qname "%MATHML.pfx;math" >
+<!ENTITY % matrix.qname "%MATHML.pfx;matrix" >
+<!ENTITY % matrixrow.qname "%MATHML.pfx;matrixrow" >
+<!ENTITY % max.qname "%MATHML.pfx;max" >
+<!ENTITY % mean.qname "%MATHML.pfx;mean" >
+<!ENTITY % median.qname "%MATHML.pfx;median" >
+<!ENTITY % menclose.qname "%MATHML.pfx;menclose" >
+<!ENTITY % merror.qname "%MATHML.pfx;merror" >
+<!ENTITY % mfenced.qname "%MATHML.pfx;mfenced" >
+<!ENTITY % mfrac.qname "%MATHML.pfx;mfrac" >
+<!ENTITY % mglyph.qname "%MATHML.pfx;mglyph" >
+<!ENTITY % mi.qname "%MATHML.pfx;mi" >
+<!ENTITY % min.qname "%MATHML.pfx;min" >
+<!ENTITY % minus.qname "%MATHML.pfx;minus" >
+<!ENTITY % mlabeledtr.qname "%MATHML.pfx;mlabeledtr" >
+<!ENTITY % mlongdiv.qname "%MATHML.pfx;mlongdiv" >
+<!ENTITY % mmultiscripts.qname "%MATHML.pfx;mmultiscripts" >
+<!ENTITY % mn.qname "%MATHML.pfx;mn" >
+<!ENTITY % mo.qname "%MATHML.pfx;mo" >
+<!ENTITY % mode.qname "%MATHML.pfx;mode" >
+<!ENTITY % moment.qname "%MATHML.pfx;moment" >
+<!ENTITY % momentabout.qname "%MATHML.pfx;momentabout" >
+<!ENTITY % mover.qname "%MATHML.pfx;mover" >
+<!ENTITY % mpadded.qname "%MATHML.pfx;mpadded" >
+<!ENTITY % mphantom.qname "%MATHML.pfx;mphantom" >
+<!ENTITY % mprescripts.qname "%MATHML.pfx;mprescripts" >
+<!ENTITY % mroot.qname "%MATHML.pfx;mroot" >
+<!ENTITY % mrow.qname "%MATHML.pfx;mrow" >
+<!ENTITY % ms.qname "%MATHML.pfx;ms" >
+<!ENTITY % mscarries.qname "%MATHML.pfx;mscarries" >
+<!ENTITY % mscarry.qname "%MATHML.pfx;mscarry" >
+<!ENTITY % msgroup.qname "%MATHML.pfx;msgroup" >
+<!ENTITY % msline.qname "%MATHML.pfx;msline" >
+<!ENTITY % mspace.qname "%MATHML.pfx;mspace" >
+<!ENTITY % msqrt.qname "%MATHML.pfx;msqrt" >
+<!ENTITY % msrow.qname "%MATHML.pfx;msrow" >
+<!ENTITY % mstack.qname "%MATHML.pfx;mstack" >
+<!ENTITY % mstyle.qname "%MATHML.pfx;mstyle" >
+<!ENTITY % msub.qname "%MATHML.pfx;msub" >
+<!ENTITY % msubsup.qname "%MATHML.pfx;msubsup" >
+<!ENTITY % msup.qname "%MATHML.pfx;msup" >
+<!ENTITY % mtable.qname "%MATHML.pfx;mtable" >
+<!ENTITY % mtd.qname "%MATHML.pfx;mtd" >
+<!ENTITY % mtext.qname "%MATHML.pfx;mtext" >
+<!ENTITY % mtr.qname "%MATHML.pfx;mtr" >
+<!ENTITY % munder.qname "%MATHML.pfx;munder" >
+<!ENTITY % munderover.qname "%MATHML.pfx;munderover" >
+<!ENTITY % naturalnumbers.qname "%MATHML.pfx;naturalnumbers" >
+<!ENTITY % neq.qname "%MATHML.pfx;neq" >
+<!ENTITY % none.qname "%MATHML.pfx;none" >
+<!ENTITY % not.qname "%MATHML.pfx;not" >
+<!ENTITY % notanumber.qname "%MATHML.pfx;notanumber" >
+<!ENTITY % notin.qname "%MATHML.pfx;notin" >
+<!ENTITY % notprsubset.qname "%MATHML.pfx;notprsubset" >
+<!ENTITY % notsubset.qname "%MATHML.pfx;notsubset" >
+<!ENTITY % or.qname "%MATHML.pfx;or" >
+<!ENTITY % otherwise.qname "%MATHML.pfx;otherwise" >
+<!ENTITY % outerproduct.qname "%MATHML.pfx;outerproduct" >
+<!ENTITY % partialdiff.qname "%MATHML.pfx;partialdiff" >
+<!ENTITY % pi.qname "%MATHML.pfx;pi" >
+<!ENTITY % piece.qname "%MATHML.pfx;piece" >
+<!ENTITY % piecewise.qname "%MATHML.pfx;piecewise" >
+<!ENTITY % plus.qname "%MATHML.pfx;plus" >
+<!ENTITY % power.qname "%MATHML.pfx;power" >
+<!ENTITY % primes.qname "%MATHML.pfx;primes" >
+<!ENTITY % product.qname "%MATHML.pfx;product" >
+<!ENTITY % prsubset.qname "%MATHML.pfx;prsubset" >
+<!ENTITY % quotient.qname "%MATHML.pfx;quotient" >
+<!ENTITY % rationals.qname "%MATHML.pfx;rationals" >
+<!ENTITY % real.qname "%MATHML.pfx;real" >
+<!ENTITY % reals.qname "%MATHML.pfx;reals" >
+<!ENTITY % reln.qname "%MATHML.pfx;reln" >
+<!ENTITY % rem.qname "%MATHML.pfx;rem" >
+<!ENTITY % root.qname "%MATHML.pfx;root" >
+<!ENTITY % scalarproduct.qname "%MATHML.pfx;scalarproduct" >
+<!ENTITY % sdev.qname "%MATHML.pfx;sdev" >
+<!ENTITY % sec.qname "%MATHML.pfx;sec" >
+<!ENTITY % sech.qname "%MATHML.pfx;sech" >
+<!ENTITY % selector.qname "%MATHML.pfx;selector" >
+<!ENTITY % semantics.qname "%MATHML.pfx;semantics" >
+<!ENTITY % sep.qname "%MATHML.pfx;sep" >
+<!ENTITY % set.qname "%MATHML.pfx;set" >
+<!ENTITY % setdiff.qname "%MATHML.pfx;setdiff" >
+<!ENTITY % share.qname "%MATHML.pfx;share" >
+<!ENTITY % sin.qname "%MATHML.pfx;sin" >
+<!ENTITY % sinh.qname "%MATHML.pfx;sinh" >
+<!ENTITY % subset.qname "%MATHML.pfx;subset" >
+<!ENTITY % sum.qname "%MATHML.pfx;sum" >
+<!ENTITY % tan.qname "%MATHML.pfx;tan" >
+<!ENTITY % tanh.qname "%MATHML.pfx;tanh" >
+<!ENTITY % tendsto.qname "%MATHML.pfx;tendsto" >
+<!ENTITY % times.qname "%MATHML.pfx;times" >
+<!ENTITY % transpose.qname "%MATHML.pfx;transpose" >
+<!ENTITY % true.qname "%MATHML.pfx;true" >
+<!ENTITY % union.qname "%MATHML.pfx;union" >
+<!ENTITY % uplimit.qname "%MATHML.pfx;uplimit" >
+<!ENTITY % variance.qname "%MATHML.pfx;variance" >
+<!ENTITY % vector.qname "%MATHML.pfx;vector" >
+<!ENTITY % vectorproduct.qname "%MATHML.pfx;vectorproduct" >
+<!ENTITY % xor.qname "%MATHML.pfx;xor" >

--- a/publishing/1.1/mathml3.dtd
+++ b/publishing/1.1/mathml3.dtd
@@ -1,0 +1,1682 @@
+<!-- ================================================================= -->
+<!-- IEEE NISO JATS MODS                    Name Collisions 03/02/2012
+
+The following changes have been made (with the permission of the
+W3C MathML Committee, to this DTD):
+
+1) %product.class; is defined below and also defined in 
+JATS-default-classes.ent. Renamed class in the MathML DTD
+until JATS names can be changed. Renamed the parameter entity
+to "mml-product.class".
+
+2) The parameter entity named "name" was commented out. It is never
+used in the MathML 3.0 DTD, and its presence causes processing
+errors in the Mulberry Tag LIbrary software.
+
+3) id CDATA #IMPLIED ==> id ID #implied
+
+-->
+<!-- ================================================================= -->
+
+<!-- MathML 3.0 DTD  ....................................................... -->
+<!-- file: mathml3.dtd
+-->
+
+<!-- MathML 3.0 DTD
+
+     This is the Mathematical Markup Language (MathML) 3.0, an XML
+     application for describing mathematical notation and capturing
+     both its structure and content.
+
+     Copyright &#xa9; 1998-2010 W3C&#xae; (MIT, ERCIM, Keio), All Rights 
+     Reserved. W3C liability, trademark, document use and software
+     licensing rules apply. 
+
+     Permission to use, copy, modify and distribute the MathML 2.0 DTD and
+     its accompanying documentation for any purpose and without fee is
+     hereby granted in perpetuity, provided that the above copyright notice
+     and this paragraph appear in all copies.  The copyright holders make
+     no representation about the suitability of the DTD for any purpose.
+
+     It is provided "as is" without expressed or implied warranty.
+
+     This entity may be identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//DTD MathML 3.0//EN"
+       SYSTEM "mathml3.dtd"
+
+     Revisions: editor and revision history at EOF
+-->
+<!-- Entity used to enable marked sections which enforces stricter		
+     checking of MathML syntax rules		
+-->
+<!ENTITY % MathMLstrict "IGNORE">		
+
+<!-- MathML Qualified Names module ............................... -->
+<!ENTITY % mathml-qname.module "INCLUDE" >
+<![%mathml-qname.module;[
+<!ENTITY % mathml-qname.mod
+     PUBLIC "-//W3C//ENTITIES MathML 3.0 Qualified Names 1.0//EN"
+            "mathml3-qname.mod" >
+%mathml-qname.mod;]]>
+
+<!-- if %NS.prefixed; is INCLUDE, include all NS attributes, 
+     otherwise just those associated with MathML
+-->
+<![%NS.prefixed;[
+  <!ENTITY % MATHML.NamespaceDecl.attrib 
+         "%NamespaceDecl.attrib;"
+>
+]]>
+<!ENTITY % MATHML.NamespaceDecl.attrib 
+     "%MATHML.xmlns.attrib;"
+>
+
+
+<!-- MathML Character Entities .............................................. -->
+<!ENTITY % mathml-charent.module "INCLUDE" >
+<![%mathml-charent.module;[
+
+
+<!ENTITY % isobox PUBLIC "-//W3C//ENTITIES Box and Line Drawing//EN" "isobox.ent">
+%isobox;
+<!ENTITY % isocyr1 PUBLIC "-//W3C//ENTITIES Russian Cyrillic//EN" "isocyr1.ent">
+%isocyr1;
+<!ENTITY % isocyr2 PUBLIC "-//W3C//ENTITIES Non-Russian Cyrillic//EN" "isocyr2.ent">
+%isocyr2;
+<!ENTITY % isodia PUBLIC "-//W3C//ENTITIES Diacritical Marks//EN" "isodia.ent">
+%isodia;
+<!ENTITY % isolat1 PUBLIC "-//W3C//ENTITIES Added Latin 1//EN" "isolat1.ent">
+%isolat1;
+<!ENTITY % isolat2 PUBLIC "-//W3C//ENTITIES Added Latin 2//EN" "isolat2.ent">
+%isolat2;
+<!ENTITY % isonum PUBLIC "-//W3C//ENTITIES Numeric and Special Graphic//EN" "isonum.ent">
+%isonum;
+<!ENTITY % isopub PUBLIC "-//W3C//ENTITIES Publishing//EN" "isopub.ent">
+%isopub;
+<!ENTITY % isoamsa PUBLIC "-//W3C//ENTITIES Added Math Symbols: Arrow Relations//EN" "isoamsa.ent">
+%isoamsa;
+<!ENTITY % isoamsb PUBLIC "-//W3C//ENTITIES Added Math Symbols: Binary Operators//EN" "isoamsb.ent">
+%isoamsb;
+<!ENTITY % isoamsc PUBLIC "-//W3C//ENTITIES Added Math Symbols: Delimiters//EN" "isoamsc.ent">
+%isoamsc;
+<!ENTITY % isoamsn PUBLIC "-//W3C//ENTITIES Added Math Symbols: Negated Relations//EN" "isoamsn.ent">
+%isoamsn;
+<!ENTITY % isoamso PUBLIC "-//W3C//ENTITIES Added Math Symbols: Ordinary//EN" "isoamso.ent">
+%isoamso;
+<!ENTITY % isoamsr PUBLIC "-//W3C//ENTITIES Added Math Symbols: Relations//EN" "isoamsr.ent">
+%isoamsr;
+<!ENTITY % isogrk3 PUBLIC "-//W3C//ENTITIES Greek Symbols//EN" "isogrk3.ent">
+%isogrk3;
+<!ENTITY % isomfrk PUBLIC "-//W3C//ENTITIES Math Alphabets: Fraktur//EN" "isomfrk.ent">
+%isomfrk;
+<!ENTITY % isomopf PUBLIC "-//W3C//ENTITIES Math Alphabets: Open Face//EN" "isomopf.ent">
+%isomopf;
+<!ENTITY % isomscr PUBLIC "-//W3C//ENTITIES Math Alphabets: Script//EN" "isomscr.ent">
+%isomscr;
+<!ENTITY % isotech PUBLIC "-//W3C//ENTITIES General Technical//EN" "isotech.ent">
+%isotech;
+<!ENTITY % mmlextra PUBLIC "-//W3C//ENTITIES Additional MathML Symbols//EN" "mmlextra.ent">
+%mmlextra;
+<!ENTITY % mmlalias PUBLIC "-//W3C//ENTITIES MathML Aliases//EN" "mmlalias.ent">
+%mmlalias;
+
+<!-- end of MathML Character Entity section -->]]>
+
+
+
+<!ENTITY % MalignExpression "%maligngroup.qname;|%malignmark.qname;">
+
+<!ENTITY % TokenExpression "%mi.qname;|%mn.qname;|%mo.qname;|%mtext.qname;
+                            |%mspace.qname;|%ms.qname;">
+
+<!ENTITY % PresentationExpression "%TokenExpression;|%MalignExpression;
+                                   |%mrow.qname;|%mfrac.qname;|%msqrt.qname;
+                                   |%mroot.qname;|%mstyle.qname;
+                                   |%merror.qname;|%mpadded.qname;
+                                   |%mphantom.qname;|%mfenced.qname;
+                                   |%menclose.qname;|%msub.qname;|%msup.qname;
+                                   |%msubsup.qname;|%munder.qname;
+                                   |%mover.qname;|%munderover.qname;
+                                   |%mmultiscripts.qname;|%mtable.qname;
+                                   |%mstack.qname;|%mlongdiv.qname;
+                                   |%maction.qname;">
+
+<!-- end of mathml3-strict-content.rng -->
+
+<!ENTITY % cn.content "(#PCDATA|%mglyph.qname;|%sep.qname;
+                        |%PresentationExpression;)*">
+
+<!-- start of mathml3-content.rng -->
+
+<!-- start of mathml3-strict-content.rng -->
+
+<!ELEMENT %cn.qname; %cn.content;>
+
+<!ENTITY % ci.content "(#PCDATA|%mglyph.qname;
+                        |%PresentationExpression;)*">
+
+<!ELEMENT %ci.qname; %ci.content;>
+
+<!ENTITY % csymbol.content "(#PCDATA|%mglyph.qname;
+                             |%PresentationExpression;)*">
+
+<!ELEMENT %csymbol.qname; %csymbol.content;>
+
+<!ENTITY % SymbolName "#PCDATA">
+
+<!ENTITY % BvarQ "(%bvar.qname;)*">
+
+<!ENTITY % DomainQ "(%domainofapplication.qname;|%condition.qname;
+                     |(%lowlimit.qname;,%uplimit.qname;?))*">
+
+<!ENTITY % constant-arith.class "%exponentiale.qname;|%imaginaryi.qname;
+                                 |%notanumber.qname;|%true.qname;
+                                 |%false.qname;|%pi.qname;|%eulergamma.qname;
+                                 |%infinity.qname;">
+
+<!ENTITY % constant-set.class "%integers.qname;|%reals.qname;
+                               |%rationals.qname;|%naturalnumbers.qname;
+                               |%complexes.qname;|%primes.qname;
+                               |%emptyset.qname;">
+
+<!ENTITY % binary-linalg.class "%vectorproduct.qname;|%scalarproduct.qname;
+                                |%outerproduct.qname;">
+
+<!ENTITY % nary-linalg.class "%selector.qname;">
+
+<!ENTITY % unary-linalg.class "%determinant.qname;|%transpose.qname;">
+
+<!ENTITY % nary-constructor.class "%vector.qname;|%matrix.qname;
+                                   |%matrixrow.qname;">
+
+<!ENTITY % nary-stats.class "%mean.qname;|%sdev.qname;|%variance.qname;
+                             |%median.qname;|%mode.qname;">
+
+<!ENTITY % unary-elementary.class "%sin.qname;|%cos.qname;|%tan.qname;
+                                   |%sec.qname;|%csc.qname;|%cot.qname;
+                                   |%sinh.qname;|%cosh.qname;|%tanh.qname;
+                                   |%sech.qname;|%csch.qname;|%coth.qname;
+                                   |%arcsin.qname;|%arccos.qname;
+                                   |%arctan.qname;|%arccosh.qname;
+                                   |%arccot.qname;|%arccoth.qname;
+                                   |%arccsc.qname;|%arccsch.qname;
+                                   |%arcsec.qname;|%arcsech.qname;
+                                   |%arcsinh.qname;|%arctanh.qname;">
+
+<!ENTITY % limit.class "%limit.qname;">
+
+<!ENTITY % mml-product.class "%product.qname;">
+
+<!ENTITY % sum.class "%sum.qname;">
+
+<!ENTITY % unary-set.class "%card.qname;">
+
+<!ENTITY % nary-set-reln.class "%subset.qname;|%prsubset.qname;">
+
+<!ENTITY % binary-set.class "%in.qname;|%notin.qname;|%notsubset.qname;
+                             |%notprsubset.qname;|%setdiff.qname;">
+
+<!ENTITY % nary-set.class "%union.qname;|%intersect.qname;
+                           |%cartesianproduct.qname;">
+
+<!ENTITY % nary-setlist-constructor.class "%set.qname;|%list.qname;">
+
+<!ENTITY % unary-veccalc.class "%divergence.qname;|%grad.qname;|%curl.qname;
+                                |%laplacian.qname;">
+
+<!ENTITY % partialdiff.class "%partialdiff.qname;">
+
+<!ENTITY % Differential-Operator.class "%diff.qname;">
+
+<!ENTITY % int.class "%int.qname;">
+
+<!ENTITY % binary-reln.class "%neq.qname;|%approx.qname;|%factorof.qname;
+                              |%tendsto.qname;">
+
+<!ENTITY % nary-reln.class "%eq.qname;|%gt.qname;|%lt.qname;|%geq.qname;
+                            |%leq.qname;">
+
+<!ENTITY % quantifier.class "%forall.qname;|%exists.qname;">
+
+<!ENTITY % binary-logical.class "%implies.qname;|%equivalent.qname;">
+
+<!ENTITY % unary-logical.class "%not.qname;">
+
+<!ENTITY % nary-logical.class "%and.qname;|%or.qname;|%xor.qname;">
+
+<!ENTITY % nary-arith.class "%plus.qname;|%times.qname;|%gcd.qname;
+                             |%lcm.qname;">
+
+<!ENTITY % nary-minmax.class "%max.qname;|%min.qname;">
+
+<!ENTITY % unary-arith.class "%factorial.qname;|%abs.qname;|%conjugate.qname;
+                              |%arg.qname;|%real.qname;|%imaginary.qname;
+                              |%floor.qname;|%ceiling.qname;|%exp.qname;">
+
+<!ENTITY % binary-arith.class "%quotient.qname;|%divide.qname;|%minus.qname;
+                               |%power.qname;|%rem.qname;|%root.qname;">
+
+<!ENTITY % nary-functional.class "%compose.qname;">
+
+<!ENTITY % lambda.class "%lambda.qname;">
+
+<!ENTITY % unary-functional.class "%inverse.qname;|%ident.qname;
+                                   |%domain.qname;|%codomain.qname;
+                                   |%image.qname;|%ln.qname;|%log.qname;
+                                   |%moment.qname;">
+
+<!ENTITY % interval.class "%interval.qname;">
+
+<!ENTITY % DeprecatedContExp "%reln.qname;|%fn.qname;|%declare.qname;">
+
+<!ENTITY % CommonDeprecatedAtt "
+  other CDATA #IMPLIED">
+
+<!ENTITY % Qualifier "(%DomainQ;)|%degree.qname;|%momentabout.qname;
+                      |%logbase.qname;">
+
+<!ENTITY % ContExp "%piecewise.qname;|%DeprecatedContExp;|%interval.class;
+                    |%unary-functional.class;|%lambda.class;
+                    |%nary-functional.class;|%binary-arith.class;
+                    |%unary-arith.class;|%nary-minmax.class;
+                    |%nary-arith.class;|%nary-logical.class;
+                    |%unary-logical.class;|%binary-logical.class;
+                    |%quantifier.class;|%nary-reln.class;
+                    |%binary-reln.class;|%int.class;
+                    |%Differential-Operator.class;|%partialdiff.class;
+                    |%unary-veccalc.class;
+                    |%nary-setlist-constructor.class;|%nary-set.class;
+                    |%binary-set.class;|%nary-set-reln.class;
+                    |%unary-set.class;|%sum.class;|%mml-product.class;
+                    |%limit.class;|%unary-elementary.class;
+                    |%nary-stats.class;|%nary-constructor.class;
+                    |%unary-linalg.class;|%nary-linalg.class;
+                    |%binary-linalg.class;|%constant-set.class;
+                    |%constant-arith.class;|%semantics.qname;|%cn.qname;
+                    |%ci.qname;|%csymbol.qname;|%apply.qname;|%bind.qname;
+                    |%share.qname;|%cerror.qname;|%cbytes.qname;|%cs.qname;">
+
+<!ENTITY % CommonAtt "
+%MATHML.NamespaceDecl.attrib;
+   %XLINK.prefix;:href   CDATA #IMPLIED	
+  %XLINK.prefix;:type   CDATA #IMPLIED
+  xml:lang   CDATA #IMPLIED
+  xml:space   (default|preserve) #IMPLIED
+  id ID #IMPLIED
+  xref CDATA #IMPLIED
+  class CDATA #IMPLIED
+  style CDATA #IMPLIED
+  href CDATA #IMPLIED
+  %CommonDeprecatedAtt;">
+
+<!ENTITY % apply.content "(%ContExp;),(%BvarQ;),(%Qualifier;)*,
+                          (%ContExp;)*">
+
+<!ELEMENT %apply.qname; (%apply.content;)>
+<!ATTLIST %apply.qname;
+  %CommonAtt;>
+
+<!ENTITY % bind.content "%apply.content;">
+
+<!ELEMENT %bind.qname; (%bind.content;)>
+<!ATTLIST %bind.qname;
+  %CommonAtt;>
+
+<!ENTITY % src "
+  src CDATA #IMPLIED">
+
+<!ELEMENT %share.qname; EMPTY>
+<!ATTLIST %share.qname;
+  %CommonAtt;
+  %src;>
+
+<!ELEMENT %cerror.qname; (%csymbol.qname;,(%ContExp;)*)>
+
+<!ATTLIST %cerror.qname;
+  %CommonAtt;>
+
+<!ELEMENT %cbytes.qname; (#PCDATA)>
+
+<!ENTITY % base64 "CDATA">
+
+<!ELEMENT %cs.qname; (#PCDATA)>
+
+<!ENTITY % DefEncAtt "
+  encoding CDATA #IMPLIED
+  definitionURL CDATA #IMPLIED">
+
+<!ATTLIST %cn.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED
+  base CDATA #IMPLIED>
+
+<!ATTLIST %ci.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ENTITY % ci.type "
+  type CDATA #REQUIRED">
+
+<!ATTLIST %csymbol.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED
+  cd CDATA #IMPLIED>
+
+<!ELEMENT %bvar.qname; ((%degree.qname;,(%ci.qname;|%semantics.qname;))
+                      |((%ci.qname;|%semantics.qname;),(%degree.qname;)?))>
+
+<!ATTLIST %cbytes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ATTLIST %cs.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ENTITY % base "
+  base CDATA #REQUIRED">
+
+<!ELEMENT %sep.qname; EMPTY>
+
+<!ELEMENT %domainofapplication.qname; (%ContExp;)>
+
+<!ELEMENT %condition.qname; (%ContExp;)>
+
+<!ELEMENT %uplimit.qname; (%ContExp;)>
+
+<!ELEMENT %lowlimit.qname; (%ContExp;)>
+
+<!ELEMENT %degree.qname; (%ContExp;)>
+
+<!ELEMENT %momentabout.qname; (%ContExp;)>
+
+<!ELEMENT %logbase.qname; (%ContExp;)>
+
+<!ENTITY % type "
+  type CDATA #REQUIRED">
+
+<!ENTITY % order "
+  order (numeric|lexicographic) #REQUIRED">
+
+<!ENTITY % closure "
+  closure CDATA #REQUIRED">
+
+<!ELEMENT %piecewise.qname; (%piece.qname;|%otherwise.qname;)*>
+<!ATTLIST %piecewise.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %piece.qname; ((%ContExp;),(%ContExp;))>
+<!ATTLIST %piece.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %otherwise.qname; (%ContExp;)>
+<!ATTLIST %otherwise.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %reln.qname; (%ContExp;)*>
+
+<!ELEMENT %fn.qname; (%ContExp;)>
+
+<!ELEMENT %declare.qname; (%ContExp;)+>
+<!ATTLIST %declare.qname;
+  type CDATA #IMPLIED
+  scope CDATA #IMPLIED
+  nargs CDATA #IMPLIED
+  occurrence (prefix|infix|function-model) #IMPLIED
+  %DefEncAtt;>
+
+<!ELEMENT %interval.qname; ((%ContExp;),(%ContExp;))>
+<!ATTLIST %interval.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  closure CDATA #IMPLIED>
+
+<!ELEMENT %inverse.qname; EMPTY>
+<!ATTLIST %inverse.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ident.qname; EMPTY>
+<!ATTLIST %ident.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %domain.qname; EMPTY>
+<!ATTLIST %domain.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %codomain.qname; EMPTY>
+<!ATTLIST %codomain.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %image.qname; EMPTY>
+<!ATTLIST %image.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ln.qname; EMPTY>
+<!ATTLIST %ln.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %log.qname; EMPTY>
+<!ATTLIST %log.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %moment.qname; EMPTY>
+<!ATTLIST %moment.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lambda.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;))>
+<!ATTLIST %lambda.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %compose.qname; EMPTY>
+<!ATTLIST %compose.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %quotient.qname; EMPTY>
+<!ATTLIST %quotient.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %divide.qname; EMPTY>
+<!ATTLIST %divide.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %minus.qname; EMPTY>
+<!ATTLIST %minus.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %power.qname; EMPTY>
+<!ATTLIST %power.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %rem.qname; EMPTY>
+<!ATTLIST %rem.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %root.qname; EMPTY>
+<!ATTLIST %root.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %factorial.qname; EMPTY>
+<!ATTLIST %factorial.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %abs.qname; EMPTY>
+<!ATTLIST %abs.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %conjugate.qname; EMPTY>
+<!ATTLIST %conjugate.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arg.qname; EMPTY>
+<!ATTLIST %arg.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %real.qname; EMPTY>
+<!ATTLIST %real.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %imaginary.qname; EMPTY>
+<!ATTLIST %imaginary.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %floor.qname; EMPTY>
+<!ATTLIST %floor.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %ceiling.qname; EMPTY>
+<!ATTLIST %ceiling.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exp.qname; EMPTY>
+<!ATTLIST %exp.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %max.qname; EMPTY>
+<!ATTLIST %max.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %min.qname; EMPTY>
+<!ATTLIST %min.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %plus.qname; EMPTY>
+<!ATTLIST %plus.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %times.qname; EMPTY>
+<!ATTLIST %times.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %gcd.qname; EMPTY>
+<!ATTLIST %gcd.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lcm.qname; EMPTY>
+<!ATTLIST %lcm.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %and.qname; EMPTY>
+<!ATTLIST %and.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %or.qname; EMPTY>
+<!ATTLIST %or.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %xor.qname; EMPTY>
+<!ATTLIST %xor.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %not.qname; EMPTY>
+<!ATTLIST %not.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %implies.qname; EMPTY>
+<!ATTLIST %implies.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %equivalent.qname; EMPTY>
+<!ATTLIST %equivalent.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %forall.qname; EMPTY>
+<!ATTLIST %forall.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exists.qname; EMPTY>
+<!ATTLIST %exists.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %eq.qname; EMPTY>
+<!ATTLIST %eq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %gt.qname; EMPTY>
+<!ATTLIST %gt.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %lt.qname; EMPTY>
+<!ATTLIST %lt.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %geq.qname; EMPTY>
+<!ATTLIST %geq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %leq.qname; EMPTY>
+<!ATTLIST %leq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %neq.qname; EMPTY>
+<!ATTLIST %neq.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %approx.qname; EMPTY>
+<!ATTLIST %approx.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %factorof.qname; EMPTY>
+<!ATTLIST %factorof.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tendsto.qname; EMPTY>
+<!ATTLIST %tendsto.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ELEMENT %int.qname; EMPTY>
+<!ATTLIST %int.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %diff.qname; EMPTY>
+<!ATTLIST %diff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %partialdiff.qname; EMPTY>
+<!ATTLIST %partialdiff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %divergence.qname; EMPTY>
+<!ATTLIST %divergence.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %grad.qname; EMPTY>
+<!ATTLIST %grad.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %curl.qname; EMPTY>
+<!ATTLIST %curl.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %laplacian.qname; EMPTY>
+<!ATTLIST %laplacian.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %set.qname; ((%BvarQ;)*,(%DomainQ;)*,(%ContExp;)*)>
+<!ATTLIST %set.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  type CDATA #IMPLIED>
+
+<!ELEMENT %list.qname; ((%BvarQ;)*,(%DomainQ;)*,(%ContExp;)*)>
+<!ATTLIST %list.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  order (numeric|lexicographic) #IMPLIED>
+
+<!ELEMENT %union.qname; EMPTY>
+<!ATTLIST %union.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %intersect.qname; EMPTY>
+<!ATTLIST %intersect.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cartesianproduct.qname; EMPTY>
+<!ATTLIST %cartesianproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %in.qname; EMPTY>
+<!ATTLIST %in.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notin.qname; EMPTY>
+<!ATTLIST %notin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notsubset.qname; EMPTY>
+<!ATTLIST %notsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notprsubset.qname; EMPTY>
+<!ATTLIST %notprsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %setdiff.qname; EMPTY>
+<!ATTLIST %setdiff.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %subset.qname; EMPTY>
+<!ATTLIST %subset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %prsubset.qname; EMPTY>
+<!ATTLIST %prsubset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %card.qname; EMPTY>
+<!ATTLIST %card.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sum.qname; EMPTY>
+<!ATTLIST %sum.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %product.qname; EMPTY>
+<!ATTLIST %product.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %limit.qname; EMPTY>
+<!ATTLIST %limit.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sin.qname; EMPTY>
+<!ATTLIST %sin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cos.qname; EMPTY>
+<!ATTLIST %cos.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tan.qname; EMPTY>
+<!ATTLIST %tan.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sec.qname; EMPTY>
+<!ATTLIST %sec.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %csc.qname; EMPTY>
+<!ATTLIST %csc.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cot.qname; EMPTY>
+<!ATTLIST %cot.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sinh.qname; EMPTY>
+<!ATTLIST %sinh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %cosh.qname; EMPTY>
+<!ATTLIST %cosh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %tanh.qname; EMPTY>
+<!ATTLIST %tanh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sech.qname; EMPTY>
+<!ATTLIST %sech.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %csch.qname; EMPTY>
+<!ATTLIST %csch.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %coth.qname; EMPTY>
+<!ATTLIST %coth.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsin.qname; EMPTY>
+<!ATTLIST %arcsin.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccos.qname; EMPTY>
+<!ATTLIST %arccos.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arctan.qname; EMPTY>
+<!ATTLIST %arctan.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccosh.qname; EMPTY>
+<!ATTLIST %arccosh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccot.qname; EMPTY>
+<!ATTLIST %arccot.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccoth.qname; EMPTY>
+<!ATTLIST %arccoth.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccsc.qname; EMPTY>
+<!ATTLIST %arccsc.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arccsch.qname; EMPTY>
+<!ATTLIST %arccsch.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsec.qname; EMPTY>
+<!ATTLIST %arcsec.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsech.qname; EMPTY>
+<!ATTLIST %arcsech.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arcsinh.qname; EMPTY>
+<!ATTLIST %arcsinh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %arctanh.qname; EMPTY>
+<!ATTLIST %arctanh.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %mean.qname; EMPTY>
+<!ATTLIST %mean.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %sdev.qname; EMPTY>
+<!ATTLIST %sdev.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %variance.qname; EMPTY>
+<!ATTLIST %variance.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %median.qname; EMPTY>
+<!ATTLIST %median.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %mode.qname; EMPTY>
+<!ATTLIST %mode.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %vector.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %vector.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %matrix.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %matrix.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %matrixrow.qname; ((%BvarQ;),(%DomainQ;),(%ContExp;)*)>
+<!ATTLIST %matrixrow.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %determinant.qname; EMPTY>
+<!ATTLIST %determinant.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %transpose.qname; EMPTY>
+<!ATTLIST %transpose.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %selector.qname; EMPTY>
+<!ATTLIST %selector.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %vectorproduct.qname; EMPTY>
+<!ATTLIST %vectorproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %scalarproduct.qname; EMPTY>
+<!ATTLIST %scalarproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %outerproduct.qname; EMPTY>
+<!ATTLIST %outerproduct.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %integers.qname; EMPTY>
+<!ATTLIST %integers.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %reals.qname; EMPTY>
+<!ATTLIST %reals.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %rationals.qname; EMPTY>
+<!ATTLIST %rationals.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %naturalnumbers.qname; EMPTY>
+<!ATTLIST %naturalnumbers.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %complexes.qname; EMPTY>
+<!ATTLIST %complexes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %primes.qname; EMPTY>
+<!ATTLIST %primes.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %emptyset.qname; EMPTY>
+<!ATTLIST %emptyset.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %exponentiale.qname; EMPTY>
+<!ATTLIST %exponentiale.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %imaginaryi.qname; EMPTY>
+<!ATTLIST %imaginaryi.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %notanumber.qname; EMPTY>
+<!ATTLIST %notanumber.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %true.qname; EMPTY>
+<!ATTLIST %true.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %false.qname; EMPTY>
+<!ATTLIST %false.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %pi.qname; EMPTY>
+<!ATTLIST %pi.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %eulergamma.qname; EMPTY>
+<!ATTLIST %eulergamma.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!ELEMENT %infinity.qname; EMPTY>
+<!ATTLIST %infinity.qname;
+  %CommonAtt;
+  %DefEncAtt;>
+
+<!-- end of mathml3-common.rng -->
+
+<!ENTITY % MathExpression "%ContExp;|%PresentationExpression;">
+
+<!-- end of mathml3-content.rng -->
+
+<!-- start of mathml3-presentation.rng -->
+
+<!ENTITY % ImpliedMrow "(%MathExpression;)*">
+
+<!ENTITY % TableRowExpression "%mtr.qname;|%mlabeledtr.qname;">
+
+<!ENTITY % TableCellExpression "%mtd.qname;">
+
+<!ENTITY % MstackExpression "%MathExpression;|%mscarries.qname;
+                             |%msline.qname;|%msrow.qname;|%msgroup.qname;">
+
+<!ENTITY % MsrowExpression "%MathExpression;|%none.qname;">
+
+<!ENTITY % MultiScriptExpression "(%MathExpression;|%none.qname;),
+                                  (%MathExpression;|%none.qname;)">
+
+<!ENTITY % mpadded-length "CDATA">
+
+<!ENTITY % linestyle "none|solid|dashed">
+
+<!ENTITY % verticalalign "top|bottom|center|baseline|axis">
+
+<!ENTITY % columnalignstyle "left|center|right">
+
+<!ENTITY % notationstyle "longdiv|actuarial|radical|box|roundedbox
+                          |circle|left|right|top|bottom|updiagonalstrike
+                          |downdiagonalstrike|verticalstrike
+                          |horizontalstrike|madruwb">
+
+<!ENTITY % idref "#PCDATA">
+
+<!ENTITY % unsigned-integer "CDATA">
+
+<!ENTITY % integer "CDATA">
+
+<!ENTITY % number "CDATA">
+
+<!ENTITY % character "CDATA">
+
+<!ENTITY % color "CDATA">
+
+<!ENTITY % group-alignment "left|center|right|decimalpoint">
+
+<!ENTITY % group-alignment-list "#PCDATA">
+
+<!ENTITY % group-alignment-list-list "#PCDATA">
+
+<!ENTITY % positive-integer "CDATA">
+
+<!ENTITY % token.content "#PCDATA|%mglyph.qname;|%malignmark.qname;">
+
+<!ELEMENT %mi.qname; (%token.content;)*>
+
+<!ENTITY % length "CDATA">
+
+<!ENTITY % DeprecatedTokenAtt "
+  fontfamily CDATA #IMPLIED
+  fontweight (normal|bold) #IMPLIED
+  fontstyle (normal|italic) #IMPLIED
+  fontsize %length; #IMPLIED
+  color %color; #IMPLIED
+  background CDATA #IMPLIED">
+
+<!ENTITY % TokenAtt "
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  mathsize CDATA #IMPLIED
+  dir (ltr|rtl) #IMPLIED
+  %DeprecatedTokenAtt;">
+
+<!ENTITY % CommonPresAtt "
+  mathcolor %color; #IMPLIED
+  mathbackground CDATA #IMPLIED">
+
+<!ATTLIST %mi.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mn.qname; (%token.content;)*>
+
+<!ATTLIST %mn.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mo.qname; (%token.content;)*>
+
+<!ATTLIST %mo.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  form (prefix|infix|postfix) #IMPLIED
+  fence (true|false) #IMPLIED
+  separator (true|false) #IMPLIED
+  lspace %length; #IMPLIED
+  rspace %length; #IMPLIED
+  stretchy (true|false) #IMPLIED
+  symmetric (true|false) #IMPLIED
+  maxsize CDATA #IMPLIED
+  minsize %length; #IMPLIED
+  largeop (true|false) #IMPLIED
+  movablelimits (true|false) #IMPLIED
+  accent (true|false) #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak) #IMPLIED
+  lineleading %length; #IMPLIED
+  linebreakstyle (before|after|duplicate|infixlinebreakstyle) #IMPLIED
+  linebreakmultchar CDATA #IMPLIED
+  indentalign (left|center|right|auto|id) #IMPLIED
+  indentshift %length; #IMPLIED
+  indenttarget CDATA #IMPLIED
+  indentalignfirst (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftfirst CDATA #IMPLIED
+  indentalignlast (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshiftlast CDATA #IMPLIED>
+
+<!ELEMENT %mtext.qname; (%token.content;)*>
+
+<!ATTLIST %mtext.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;>
+
+<!ELEMENT %mspace.qname; EMPTY>
+
+<!ATTLIST %mspace.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  width %length; #IMPLIED
+  height %length; #IMPLIED
+  depth %length; #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak
+             |indentingnewline) #IMPLIED>
+
+<!ELEMENT %ms.qname; (%token.content;)*>
+
+<!ATTLIST %ms.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %TokenAtt;
+  lquote CDATA #IMPLIED
+  rquote CDATA #IMPLIED>
+
+<!ENTITY % mglyph.deprecatedattributes "
+  index %integer; #IMPLIED
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  mathsize CDATA #IMPLIED
+  %DeprecatedTokenAtt;">
+
+<!ENTITY % mglyph.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  src CDATA #IMPLIED
+  width %length; #IMPLIED
+  height %length; #IMPLIED
+  valign %length; #IMPLIED
+  alt CDATA #IMPLIED">
+
+<!ELEMENT %mglyph.qname; EMPTY>
+<!ATTLIST %mglyph.qname;
+  %mglyph.attributes;
+  %mglyph.deprecatedattributes;>
+
+<!ELEMENT %msline.qname; EMPTY>
+
+<!ATTLIST %msline.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  length %unsigned-integer; #IMPLIED
+  leftoverhang %length; #IMPLIED
+  rightoverhang %length; #IMPLIED
+  mslinethickness CDATA #IMPLIED>
+
+<!ELEMENT %none.qname; EMPTY>
+
+<!ATTLIST %none.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mprescripts.qname; EMPTY>
+
+<!ATTLIST %mprescripts.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %malignmark.qname; EMPTY>
+
+<!ATTLIST %malignmark.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  edge (left|right) #IMPLIED>
+
+<!ELEMENT %maligngroup.qname; EMPTY>
+
+<!ATTLIST %maligngroup.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  groupalign (left|center|right|decimalpoint) #IMPLIED>
+
+<!ELEMENT %mrow.qname; (%MathExpression;)*>
+
+<!ATTLIST %mrow.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  dir (ltr|rtl) #IMPLIED>
+
+<!ELEMENT %mfrac.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mfrac.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  linethickness CDATA #IMPLIED
+  numalign (left|center|right) #IMPLIED
+  denomalign (left|center|right) #IMPLIED
+  bevelled (true|false) #IMPLIED>
+
+<!ELEMENT %msqrt.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %msqrt.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mroot.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mroot.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mstyle.qname; (%ImpliedMrow;)>
+
+<!ENTITY % mstyle.deprecatedattributes "
+  %DeprecatedTokenAtt;
+  veryverythinmathspace %length; #IMPLIED
+  verythinmathspace %length; #IMPLIED
+  thinmathspace %length; #IMPLIED
+  mediummathspace %length; #IMPLIED
+  thickmathspace %length; #IMPLIED
+  verythickmathspace %length; #IMPLIED
+  veryverythickmathspace %length; #IMPLIED">
+
+<!ENTITY % mstyle.generalattributes "
+  accent (true|false) #IMPLIED
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED
+  alignmentscope CDATA #IMPLIED
+  bevelled (true|false) #IMPLIED
+  charalign (left|center|right) #IMPLIED
+  charspacing CDATA #IMPLIED
+  close CDATA #IMPLIED
+  columnalign CDATA #IMPLIED
+  columnlines CDATA #IMPLIED
+  columnspacing CDATA #IMPLIED
+  columnspan %positive-integer; #IMPLIED
+  columnwidth CDATA #IMPLIED
+  crossout CDATA #IMPLIED
+  denomalign (left|center|right) #IMPLIED
+  depth %length; #IMPLIED
+  dir (ltr|rtl) #IMPLIED
+  edge (left|right) #IMPLIED
+  equalcolumns (true|false) #IMPLIED
+  equalrows (true|false) #IMPLIED
+  fence (true|false) #IMPLIED
+  form (prefix|infix|postfix) #IMPLIED
+  frame (%linestyle;) #IMPLIED
+  framespacing CDATA #IMPLIED
+  groupalign CDATA #IMPLIED
+  height %length; #IMPLIED
+  indentalign (left|center|right|auto|id) #IMPLIED
+  indentalignfirst (left|center|right|auto|id|indentalign) #IMPLIED
+  indentalignlast (left|center|right|auto|id|indentalign) #IMPLIED
+  indentshift %length; #IMPLIED
+  indentshiftfirst CDATA #IMPLIED
+  indentshiftlast CDATA #IMPLIED
+  indenttarget CDATA #IMPLIED
+  largeop (true|false) #IMPLIED
+  leftoverhang %length; #IMPLIED
+  length %unsigned-integer; #IMPLIED
+  linebreak (auto|newline|nobreak|goodbreak|badbreak) #IMPLIED
+  linebreakmultchar CDATA #IMPLIED
+  linebreakstyle (before|after|duplicate|infixlinebreakstyle) #IMPLIED
+  lineleading %length; #IMPLIED
+  linethickness CDATA #IMPLIED
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  longdivstyle CDATA #IMPLIED
+  lquote CDATA #IMPLIED
+  lspace %length; #IMPLIED
+  mathsize CDATA #IMPLIED
+  mathvariant (normal|bold|italic|bold-italic|double-struck|bold-fraktur
+               |script|bold-script|fraktur|sans-serif|bold-sans-serif
+               |sans-serif-italic|sans-serif-bold-italic|monospace
+               |initial|tailed|looped|stretched) #IMPLIED
+  maxsize CDATA #IMPLIED
+  minlabelspacing %length; #IMPLIED
+  minsize %length; #IMPLIED
+  movablelimits (true|false) #IMPLIED
+  mslinethickness CDATA #IMPLIED
+  notation CDATA #IMPLIED
+  numalign (left|center|right) #IMPLIED
+  open CDATA #IMPLIED
+  position %integer; #IMPLIED
+  rightoverhang %length; #IMPLIED
+  rowalign CDATA #IMPLIED
+  rowlines CDATA #IMPLIED
+  rowspacing CDATA #IMPLIED
+  rowspan %positive-integer; #IMPLIED
+  rquote CDATA #IMPLIED
+  rspace %length; #IMPLIED
+  selection %positive-integer; #IMPLIED
+  separator (true|false) #IMPLIED
+  separators CDATA #IMPLIED
+  shift %integer; #IMPLIED
+  side (left|right|leftoverlap|rightoverlap) #IMPLIED
+  stackalign (left|center|right|decimalpoint) #IMPLIED
+  stretchy (true|false) #IMPLIED
+  subscriptshift %length; #IMPLIED
+  superscriptshift %length; #IMPLIED
+  symmetric (true|false) #IMPLIED
+  valign %length; #IMPLIED
+  width %length; #IMPLIED">
+
+<!ENTITY % mstyle.specificattributes "
+  scriptlevel %integer; #IMPLIED
+  displaystyle (true|false) #IMPLIED
+  scriptsizemultiplier %number; #IMPLIED
+  scriptminsize %length; #IMPLIED
+  infixlinebreakstyle (before|after|duplicate) #IMPLIED
+  decimalpoint %character; #IMPLIED">
+
+<!ATTLIST %mstyle.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  %mstyle.specificattributes;
+  %mstyle.generalattributes;
+  %mstyle.deprecatedattributes;>
+
+<!ELEMENT %merror.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %merror.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mpadded.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mpadded.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  height %mpadded-length; #IMPLIED
+  depth %mpadded-length; #IMPLIED
+  width %mpadded-length; #IMPLIED
+  lspace %mpadded-length; #IMPLIED
+  voffset %mpadded-length; #IMPLIED>
+
+<!ELEMENT %mphantom.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mphantom.qname;
+  %CommonAtt;
+  %CommonPresAtt;>
+
+<!ELEMENT %mfenced.qname; (%MathExpression;)*>
+
+<!ATTLIST %mfenced.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  open CDATA #IMPLIED
+  close CDATA #IMPLIED
+  separators CDATA #IMPLIED>
+
+<!ELEMENT %menclose.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %menclose.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  notation CDATA #IMPLIED>
+
+<!ELEMENT %msub.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %msub.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  subscriptshift %length; #IMPLIED>
+
+<!ELEMENT %msup.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %msup.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  superscriptshift %length; #IMPLIED>
+
+<!ENTITY % msubsup.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  subscriptshift %length; #IMPLIED
+  superscriptshift %length; #IMPLIED">
+
+<!ELEMENT %msubsup.qname; ((%MathExpression;),(%MathExpression;),
+                         (%MathExpression;))>
+<!ATTLIST %msubsup.qname;
+  %msubsup.attributes;>
+
+<!ELEMENT %munder.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %munder.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %mover.qname; ((%MathExpression;),(%MathExpression;))>
+
+<!ATTLIST %mover.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accent (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %munderover.qname; ((%MathExpression;),(%MathExpression;),
+                            (%MathExpression;))>
+
+<!ATTLIST %munderover.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  accent (true|false) #IMPLIED
+  accentunder (true|false) #IMPLIED
+  align (left|right|center) #IMPLIED>
+
+<!ELEMENT %mmultiscripts.qname; ((%MathExpression;),
+                               (%MultiScriptExpression;)*,
+                               (%mprescripts.qname;,
+                                (%MultiScriptExpression;)*)?)>
+
+<!ATTLIST %mmultiscripts.qname;
+  %msubsup.attributes;>
+
+<!ELEMENT %mtable.qname; (%TableRowExpression;)*>
+
+<!ATTLIST %mtable.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  align CDATA #IMPLIED
+  rowalign CDATA #IMPLIED
+  columnalign CDATA #IMPLIED
+  groupalign CDATA #IMPLIED
+  alignmentscope CDATA #IMPLIED
+  columnwidth CDATA #IMPLIED
+  width CDATA #IMPLIED
+  rowspacing CDATA #IMPLIED
+  columnspacing CDATA #IMPLIED
+  rowlines CDATA #IMPLIED
+  columnlines CDATA #IMPLIED
+  frame (%linestyle;) #IMPLIED
+  framespacing CDATA #IMPLIED
+  equalrows (true|false) #IMPLIED
+  equalcolumns (true|false) #IMPLIED
+  displaystyle (true|false) #IMPLIED
+  side (left|right|leftoverlap|rightoverlap) #IMPLIED
+  minlabelspacing %length; #IMPLIED>
+
+<!ELEMENT %mlabeledtr.qname; (%TableCellExpression;)+>
+
+<!ENTITY % mtr.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  rowalign (top|bottom|center|baseline|axis) #IMPLIED
+  columnalign CDATA #IMPLIED
+  groupalign CDATA #IMPLIED">
+
+<!ATTLIST %mlabeledtr.qname;
+  %mtr.attributes;>
+
+<!ELEMENT %mtr.qname; (%TableCellExpression;)*>
+<!ATTLIST %mtr.qname;
+  %mtr.attributes;>
+
+<!ELEMENT %mtd.qname; (%ImpliedMrow;)>
+
+<!ATTLIST %mtd.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  rowspan %positive-integer; #IMPLIED
+  columnspan %positive-integer; #IMPLIED
+  rowalign (top|bottom|center|baseline|axis) #IMPLIED
+  columnalign (%columnalignstyle;) #IMPLIED
+  groupalign CDATA #IMPLIED>
+
+<!ELEMENT %mstack.qname; (%MstackExpression;)*>
+
+<!ATTLIST %mstack.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  align CDATA #IMPLIED
+  stackalign (left|center|right|decimalpoint) #IMPLIED
+  charalign (left|center|right) #IMPLIED
+  charspacing CDATA #IMPLIED>
+
+<!ELEMENT %mlongdiv.qname; ((%MstackExpression;),(%MstackExpression;),
+                          (%MstackExpression;)+)>
+
+<!ENTITY % msgroup.attributes "
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  shift %integer; #IMPLIED">
+
+<!ATTLIST %mlongdiv.qname;
+  %msgroup.attributes;
+  longdivstyle CDATA #IMPLIED>
+
+<!ELEMENT %msgroup.qname; (%MstackExpression;)*>
+<!ATTLIST %msgroup.qname;
+  %msgroup.attributes;>
+
+<!ELEMENT %msrow.qname; (%MsrowExpression;)*>
+
+<!ATTLIST %msrow.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED>
+
+<!ELEMENT %mscarries.qname; (%MsrowExpression;|%mscarry.qname;)*>
+
+<!ATTLIST %mscarries.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  position %integer; #IMPLIED
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  crossout CDATA #IMPLIED
+  scriptsizemultiplier %number; #IMPLIED>
+
+<!ELEMENT %mscarry.qname; (%MsrowExpression;)*>
+
+<!ATTLIST %mscarry.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  location (w|nw|n|ne|e|se|s|sw) #IMPLIED
+  crossout CDATA #IMPLIED>
+
+<!ELEMENT %maction.qname; (%MathExpression;)+>
+
+<!ATTLIST %maction.qname;
+  %CommonAtt;
+  %CommonPresAtt;
+  actiontype CDATA #IMPLIED
+  selection %positive-integer; #IMPLIED>
+
+<!-- end of mathml3-presentation.rng -->
+
+<!-- start of mathml3-common.rng -->
+
+<!ELEMENT %math.qname; (%MathExpression;)*>
+
+<!ENTITY % NonMathMLAtt "">
+
+<!ENTITY % math.deprecatedattributes "
+  mode CDATA #IMPLIED
+  macros CDATA #IMPLIED">
+
+<!ATTLIST %math.qname;
+  %CommonAtt;
+  display (block|inline) #IMPLIED
+  maxwidth %length; #IMPLIED
+  overflow (linebreak|scroll|elide|truncate|scale) #IMPLIED
+  altimg CDATA #IMPLIED
+  altimg-width %length; #IMPLIED
+  altimg-height %length; #IMPLIED
+  altimg-valign CDATA #IMPLIED
+  alttext CDATA #IMPLIED
+  cdgroup CDATA #IMPLIED
+  %math.deprecatedattributes;
+  %CommonPresAtt;
+  %mstyle.specificattributes;
+  %mstyle.generalattributes;>
+
+<!--<!ENTITY % name "
+  name CDATA #REQUIRED">
+-->
+<!ENTITY % cd "
+  cd CDATA #REQUIRED">
+
+<!ENTITY % annotation.attributes "
+  %CommonAtt;
+  cd CDATA #IMPLIED
+  name CDATA #IMPLIED
+  %DefEncAtt;
+  src CDATA #IMPLIED">
+
+<!ELEMENT %annotation.qname; (#PCDATA)>
+<!ATTLIST %annotation.qname;
+  %annotation.attributes;>
+
+<!ENTITY % annotation-xml.model "(%MathExpression;)*">
+
+<!ENTITY % anyElement "">
+
+<!ELEMENT %annotation-xml.qname; (%annotation-xml.model;)>
+<!ATTLIST %annotation-xml.qname;
+  %annotation.attributes;>
+
+<!ELEMENT %semantics.qname; ((%MathExpression;),
+                           (%annotation.qname;|%annotation-xml.qname;)*)>
+
+<!ATTLIST %semantics.qname;
+  %CommonAtt;
+  %DefEncAtt;
+  cd CDATA #IMPLIED
+  name CDATA #IMPLIED>
+

--- a/publishing/1.1/oasis-exchange.ent
+++ b/publishing/1.1/oasis-exchange.ent
@@ -1,0 +1,449 @@
+<!-- ============================================================= -->
+<!--  MODULE:    JATS Namespaced OASIS XML Table Module            -->
+<!--  VERSION:   NISO 1.1                                          -->
+<!--  DATE:      December 2015                                     -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                        TYPICAL INVOCATION                     -->
+<!--
+"-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+     Delivered as file "oasis-exchange.ent"                        -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!-- SYSTEM:     JATS DTD Suite                                    -->
+<!--                                                               -->
+<!-- PURPOSE:    Duplicates the OASIS Open exchange CALS table     -->
+<!--             model (XML version) with only one addition, the   -->
+<!--             elements have been assigned an namespace,         -->
+<!--             typically:                                        -->
+<!--               xmlns:oasis   CDATA   #FIXED                    -->
+<!--         "http://docs.oasis-open.org/ns/oasis-exchange/table"  -->
+<!--                                                               -->
+<!-- ============================================================= -->
+
+
+<!-- ============================================================= -->
+<!--                    DTD VERSION/CHANGE HISTORY                 -->
+<!-- ============================================================= -->
+<!--
+Version  Reason/Occasion                   (who) vx.x (yyyy-mm-dd)
+     =============================================================
+     JATS Version 1.1                (DAL/BTU) v1.1  (2015-12-15)
+
+     JATS is a continuing maintenance NISO Standard, which
+     requires voting by the ANSI and NISO memberships to be changed. 
+     JATS 1.1 was approved in late 2015, so the formal public 
+     identifiers were changed in the modules and the catalogs.
+     No model or attribute changes were made at this time. 
+ 
+  8. JATS became version "1.1" and "v1.1 20151215"
+
+     =============================================================
+     JATS Version 1.1d3             (DAL/BTU) v1.1d3  (2015-03-01)
+   
+     The changes in this release are in response to NISO 
+     License and Indicators Recommended Practice.
+
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d3 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This draft DTD represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+  
+  7. ERROR IN COMMENT FIXED
+     The 'Typical Invocation' comment at the top of the document
+     has an in correct fpi:
+     "-//NLM//DTD JATS Namespaced OASIS XML Table Module v1.1d2 
+      20140930//EN"
+     comment was changed to the correct:
+     "-//OASIS//DTD XML Exchange Table Model 19990315//EN"
+ 
+  6. JATS became version "1.1d3" and "v1.1 20150301//EN"
+
+     =============================================================
+     JATS Version 1.1d2              (DAL/BTU) v1.1d2 (2014-09-30)
+   
+     NISO JATS is a continuing maintenance NISO Standard, which 
+     requires voting by the NISO membership to be changed. This
+     Committee Draft 1.1d2 will be sent to the NISO voting
+     membership, to become (if approved) NISO JATS 1.1.
+     
+     This catalog represents an interim version of the
+     non-normative JATS DTD Suite, as an indication to JATS users
+     the decisions that have been made by the JATS Standing
+     Committee.
+
+  5. JATS became version "1.1d2" and "v1.1d2 20140930//EN"
+  
+     =============================================================
+     NISO JATS Version 1.0             (DAL/BTU) v1.0 (2012-xx-xx)
+   
+     If approved by the voting members of NISO, this will become the
+     Version 1.0 NISO JATS Z39.96-2012 NISO Standard. 
+   
+  4. Updated the DTD-version attribute to "1.0" and the formal
+     public identifier to the date: "v1.0 20120330//EN".
+
+     =============================================================
+     Version 0.4                       (DAL/BTU) v0.4 (2011-01-31)
+   
+     This Tag Set is in the process of becoming a NISO standard.
+     The version numbers are starting over from 0.4", as a Trial
+     Use Draft, to be made into "Version 1.0" when the Tag Suite 
+     becomes a NISO standard. Thus, the version number that would
+     have been "NLM Version 3.1 Draft" has become NISO JATS
+     "Version 0.4".
+
+     Details on NISO Trial Use Draft Version 0.4 are available at
+           http://jats.nlm.nih.gov/JATS-0.4.
+   
+  3. Updated the DTD-version attribute to "0.4" 
+   
+  2. Updated the public identifier to "v0.4 20110131", 
+     modified the formal public identifier to include "JATS (Z39.96)",
+     and the filename as delivered to include "JATS" and the
+     new version number "0".
+
+     =============================================================
+     Version 3.0                       (DAL/BTU) v3.0 (2007-10-31)
+
+     Version 3.0 is the first non-backward-compatible release.
+     In addition to the usual incremental changes, some
+     elements and attributes have been renamed and/or remodeled
+     to better meet user needs and to increase tag set consistency.
+     All module change histories are available through the Tag Suite
+     web site at http://dtd.nlm.nih.gov.
+
+     Details on version 3.0 are available at
+           http://jats.nlm.nih.gov./3.0.
+
+  1. Updated public identifier to "v3.0 20080202//EN"              -->
+
+<!-- ============================================================= -->
+
+
+<!-- XML EXCHANGE TABLE MODEL DECLARATION MODULE -->
+
+<!-- This set of declarations defines the XML version of the Exchange
+     Table Model as of the date shown in the Formal Public Identifier
+     (FPI) for this entity.
+
+     This set of declarations may be referred to using a public external
+     entity declaration and reference as shown in the following three
+     lines-
+
+     <!ENTITY % calstblx
+       PUBLIC "-//OASIS//DTD XML Exchange Table Model 19990315//EN">
+       %calstblx;
+
+     If various parameter entities used within this set of declarations
+     are to be given non-default values, the appropriate declarations
+     should be given before calling in this package (i.e., before the
+     "%calstblx;" reference).
+-->
+
+<!-- The motivation for this XML version of the Exchange Table Model
+     is simply to create an XML version of the SGML Exchange Table
+     Model. By design, no effort has been made to "improve" the model.
+
+     This XML version incorporates the logical bare minimum changes
+     necessary to make the Exchange Table Model a valid XML DTD.
+-->
+
+<!-- The XML version of the Exchange Table Model differs from
+     the SGML version in the following ways-
+
+     The following parameter entities have been removed-
+
+       - tbl.table.excep, tbl.hdft.excep, tbl.row.excep, tbl.entry.excep
+         There are no exceptions in XML. The following normative
+         statement is made in lieu of exceptions- the exchange table model
+         explicitly forbids a table from occurring within another table.
+         If the content model of an entry includes a table element, then this
+         cannot be enforced by the DTD, but it is a deviation from the
+         exchange table model to include a table within a table.
+
+       - tbl.hdft.name, tbl.hdft.mdl, tbl.hdft.excep, tbl.hdft.att
+         The motivation for these elements was to change the table
+         header/footer elements. Since XML does not allow element
+         declarations to contain name groups, and the exchange table model
+         does not allow a table to contain footers, the continued presence
+         of these attributes seems unnecessary.
+
+     The following parameter entity has been added-
+
+       - tbl.thead.att
+         This entity parameterizes the attributes on thead. It replaces
+         the tbl.hdft.att parameter entity.
+
+     Other miscellaneous changes-
+
+       - Tag omission indicators have been removed
+       - Comments have been removed from declarations
+       - NUMBER attributes have been changed to NMTOKEN
+       - NUTOKEN attributes have been to changed to NMTOKEN
+       - Removed the grouping characters around the content model
+         parameter entry for the 'entry' element. This is necessary
+         so that an entry can contain #PCDATA and be defined as an
+         optional, repeatable OR group beginning with #PCDATA.
+-->
+
+<!-- This entity includes a set of element and attribute declarations
+     that partially defines the Exchange table model.  However, the
+     model is not well-defined without the accompanying natural language
+     description of the semantics (meanings) of these various elements,
+     attributes, and attribute values.  The semantic writeup, also
+     available from SGML Open, should be used in conjunction with this entity.
+-->
+
+<!-- In order to use the Exchange table model, various parameter entity
+     declarations are required.  A brief description is as follows-
+
+
+     ENTITY NAME      WHERE USED              WHAT IT IS
+
+     %yesorno         In ATTLIST of-          An attribute declared value
+                      almost all elements     for a "boolean" attribute
+
+     ENTITY NAME      WHERE USED              WHAT IT IS
+
+     %yesorno         In ATTLIST of-          An attribute declared value
+                      almost all elements     for a "boolean" attribute
+
+     %paracon         In content model of-    The "text" (logical content)
+                      <entry>                 of the model group for <entry>
+
+     %titles          In content model of-    The "title" part of the model
+                      table element           group for the table element
+
+     %tbl.table.name  In declaration of-      The name of the "table"
+                      table element           element
+
+     %tbl.table-titles.mdl In content model of- The model group for the title
+                      table elements          part of the content model for
+                                              table element
+
+     %tbl.table.mdl   In content model of-    The model group for the content
+                      table elements          model for table element, often
+                                              (and by default) defined
+                                              in terms of %tbl.table-titles.mdl
+                                              and tgroup
+
+     %tbl.table.att   In ATTLIST of-          Additional attributes on the
+                      table element           table element
+
+     %bodyatt         In ATTLIST of-          Additional attributes on the
+                      table element           table element (for backward
+                                              compatibility with the SGML model)
+
+     %tbl.tgroup.mdl  In content model of-    The model group for the content
+                      <tgroup>                model for <tgroup>
+
+     %tbl.tgroup.att  In ATTLIST of-          Additional attributes on the
+                      <tgroup>                <tgroup> element
+
+     %tbl.thead.att   In ATTLIST of-          Additional attributes on the
+                      <thead>                 <thead> element
+
+     %tbl.tbody.att   In ATTLIST of-          Additional attributes on the
+                      <tbody>                 <tbody> element
+
+     %tbl.colspec.att In ATTLIST of-          Additional attributes on the
+                      <colspec>               <colspec> element
+
+     %tbl.row.mdl     In content model of-    The model group for the content
+                      <row>                   model for <row>
+
+     %tbl.row.att     In ATTLIST of-          Additional attributes on the
+                      <row>                   <row> element
+
+     %tbl.entry.mdl   In content model of-    The model group for the content
+                      <entry>                 model for <entry>
+
+     %tbl.entry.att   In ATTLIST of-          Additional attributes on the
+                      <entry>                 <entry> element
+
+     This set of declarations will use the default definitions shown below
+     for any of these parameter entities that are not declared before this
+     set of declarations is referenced.
+-->
+
+<!-- These definitions are not directly related to the table model, but are
+     used in the default CALS table model and may be defined elsewhere (and
+     prior to the inclusion of this table module) in the referencing DTD. -->
+
+<!ENTITY % yesorno 'NMTOKEN'> <!-- no if zero(s), yes if any other value -->
+<!ENTITY % titles  'title?'>
+<!ENTITY % paracon '#PCDATA'>
+<!-- default for use in entry content -->
+
+<!--
+The parameter entities as defined below change and simplify the CALS
+table model as published (as part of the Example DTD) in MIL-HDBK-28001.
+The resulting simplified DTD has support from the SGML Open vendors and is
+therefore more interoperable among different systems.
+
+These following declarations provide the Exchange default definitions
+for these entities.  However, these entities can be redefined (by giving
+the appropriate parameter entity declaration(s) prior to the reference
+to this Table Model declaration set entity) to fit the needs of the
+current application.
+
+Note, however, that changes may have significant effect on the ability
+to interchange table information.  These changes may manifest themselves
+in usability, presentation, and possible structure information
+degradation.
+-->
+
+<!ENTITY % tbl.table.name       "table">
+<!ENTITY % tbl.table-titles.mdl "%titles;,">
+<!ENTITY % tbl.table-main.mdl   "tgroup+">
+<!ENTITY % tbl.table.mdl        "%tbl.table-titles.mdl; %tbl.table-main.mdl;">
+<!ENTITY % tbl.table.att        "
+    pgwide      %yesorno;       #IMPLIED ">
+<!ENTITY % bodyatt              "">
+<!ENTITY % tbl.tgroup.mdl       "colspec*,thead?,tbody">
+<!ENTITY % tbl.tgroup.att       "">
+<!ENTITY % tbl.thead.att        "">
+<!ENTITY % tbl.tbody.att        "">
+<!ENTITY % tbl.colspec.att      "">
+<!ENTITY % tbl.row.mdl          "entry+">
+<!ENTITY % tbl.row.att          "">
+<!ENTITY % tbl.entry.mdl        "(%paracon;)*">
+<!ENTITY % tbl.entry.att        "">
+
+<!-- =====  Element and attribute declarations follow. =====  -->
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.table.name       "table"
+     ENTITY % tbl.table-titles.mdl "%titles;,"
+     ENTITY % tbl.table.mdl        "%tbl.table-titles; tgroup+"
+     ENTITY % tbl.table.att        "
+ pgwide          %yesorno;       #IMPLIED "
+-->
+
+<!ELEMENT  %tbl.table.name; (%tbl.table.mdl;) >
+
+<!ATTLIST  %tbl.table.name;
+        frame           (top|bottom|topbot|all|sides|none)      #IMPLIED
+        colsep          %yesorno;        #IMPLIED
+        rowsep          %yesorno;        #IMPLIED
+        %tbl.table.att;
+        %bodyatt;
+>
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.tgroup.mdl    "colspec*,thead?,tbody"
+     ENTITY % tbl.tgroup.att    ""
+-->
+
+<!ELEMENT  %otgroup.qname; (%tbl.tgroup.mdl;) >
+
+<!ATTLIST  %otgroup.qname;
+        cols            NMTOKEN          #REQUIRED
+        colsep          %yesorno;        #IMPLIED
+        rowsep          %yesorno;        #IMPLIED
+        align           (left|right|center|justify|char)        #IMPLIED
+        %tbl.tgroup.att;
+>
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.colspec.att   ""
+-->
+
+<!ELEMENT  %ocolspec.qname; EMPTY >
+
+<!ATTLIST  %ocolspec.qname;
+        colnum          NMTOKEN          #IMPLIED
+        colname         NMTOKEN          #IMPLIED
+        colwidth        CDATA            #IMPLIED
+        colsep          %yesorno;        #IMPLIED
+        rowsep          %yesorno;        #IMPLIED
+        align           (left|right|center|justify|char)        #IMPLIED
+        char            CDATA            #IMPLIED
+        charoff         NMTOKEN          #IMPLIED
+        %tbl.colspec.att;
+>
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.thead.att      ""
+-->
+
+<!ELEMENT  %othead.qname; ((%orow.qname;)+) >
+
+<!ATTLIST  %othead.qname;
+        valign          (top|middle|bottom)                     #IMPLIED
+        %tbl.thead.att;
+>
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.tbody.att     ""
+-->
+
+<!ELEMENT  %otbody.qname; ((%orow.qname;)+) >
+
+<!ATTLIST  %otbody.qname;
+        valign          (top|middle|bottom)                     #IMPLIED
+        %tbl.tbody.att;
+>
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % tbl.row.mdl       "entry+"
+     ENTITY % tbl.row.att       ""
+-->
+
+<!ELEMENT  %orow.qname; (%tbl.row.mdl;)>
+
+<!ATTLIST  %orow.qname;
+        rowsep          %yesorno;        #IMPLIED
+        valign          (top|middle|bottom)                     #IMPLIED
+        %tbl.row.att;
+>
+
+
+<!--
+     Default declarations previously defined in this entity and
+     referenced below include-
+     ENTITY % paracon           "#PCDATA"
+     ENTITY % tbl.entry.mdl     "(%paracon;)*"
+     ENTITY % tbl.entry.att     ""
+-->
+
+<!ELEMENT  %oentry.qname; %tbl.entry.mdl;>
+
+<!ATTLIST  %oentry.qname;
+        colname         NMTOKEN          #IMPLIED
+        namest          NMTOKEN          #IMPLIED
+        nameend         NMTOKEN          #IMPLIED
+        morerows        NMTOKEN          #IMPLIED
+        colsep          %yesorno;        #IMPLIED
+        rowsep          %yesorno;        #IMPLIED
+        align           (left|right|center|justify|char)        #IMPLIED
+        char            CDATA            #IMPLIED
+        charoff         NMTOKEN          #IMPLIED
+        valign          (top|middle|bottom)                     #IMPLIED
+        %tbl.entry.att;
+>
+
+
+<!-- ================== End OASIS Exchange Module ================== -->

--- a/publishing/1.1/xhtml-inlstyle-1.mod
+++ b/publishing/1.1/xhtml-inlstyle-1.mod
@@ -1,0 +1,34 @@
+<!-- ...................................................................... -->
+<!-- XHTML Inline Style Module  ........................................... -->
+<!-- file: xhtml-inlstyle-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-inlstyle-1.mod,v 4.0 2001/04/02 22:42:49 altheim Exp $
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ENTITIES XHTML Inline Style 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-inlstyle-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Inline Style
+
+     This module declares the 'style' attribute, used to support inline
+     style markup. This module must be instantiated prior to the XHTML
+     Common Attributes module in order to be included in %Core.attrib;.
+-->
+
+<!ENTITY % style.attrib
+     "style        CDATA                    #IMPLIED"
+>
+
+
+<!ENTITY % Core.extra.attrib
+     "%style.attrib;"
+>
+
+<!-- end of xhtml-inlstyle-1.mod -->

--- a/publishing/1.1/xhtml-table-1.mod
+++ b/publishing/1.1/xhtml-table-1.mod
@@ -1,0 +1,333 @@
+<!-- ...................................................................... -->
+<!-- XHTML Table Module  .................................................. -->
+<!-- file: xhtml-table-1.mod
+
+     This is XHTML, a reformulation of HTML as a modular XML application.
+     Copyright 1998-2005 W3C (MIT, ERCIM, Keio), All Rights Reserved.
+     Revision: $Id: xhtml-table-1.mod,v 4.1 2001/04/10 09:42:30 altheim Exp $ SMI
+
+     This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+       PUBLIC "-//W3C//ELEMENTS XHTML Tables 1.0//EN"
+       SYSTEM "http://www.w3.org/MarkUp/DTD/xhtml-table-1.mod"
+
+     Revisions:
+     (none)
+     ....................................................................... -->
+
+<!-- Tables
+
+        table, caption, thead, tfoot, tbody, colgroup, col, tr, th, td
+
+     This module declares element types and attributes used to provide
+     table markup similar to HTML 4, including features that enable
+     better accessibility for non-visual user agents.
+-->
+
+<!-- declare qualified element type names:
+-->
+<!ENTITY % table.qname  "table" >
+<!ENTITY % caption.qname  "caption" >
+<!ENTITY % thead.qname  "thead" >
+<!ENTITY % tfoot.qname  "tfoot" >
+<!ENTITY % tbody.qname  "tbody" >
+<!ENTITY % colgroup.qname  "colgroup" >
+<!ENTITY % col.qname  "col" >
+<!ENTITY % tr.qname  "tr" >
+<!ENTITY % th.qname  "th" >
+<!ENTITY % td.qname  "td" >
+
+<!-- The frame attribute specifies which parts of the frame around
+     the table should be rendered. The values are not the same as
+     CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % frame.attrib
+     "frame        ( void
+                   | above
+                   | below
+                   | hsides
+                   | lhs
+                   | rhs
+                   | vsides
+                   | box
+                   | border )               #IMPLIED"
+>
+
+<!-- The rules attribute defines which rules to draw between cells:
+
+     If rules is absent then assume:
+
+       "none" if border is absent or border="0" otherwise "all"
+-->
+<!ENTITY % rules.attrib
+     "rules        ( none
+                   | groups
+                   | rows
+                   | cols
+                   | all )                  #IMPLIED"
+>
+
+<!-- horizontal alignment attributes for cell contents
+-->
+<!ENTITY % CellHAlign.attrib
+     "align        ( left
+                   | center
+                   | right
+                   | justify
+                   | char )                 #IMPLIED
+      char         %Character.datatype;     #IMPLIED
+      charoff      %Length.datatype;        #IMPLIED"
+>
+
+<!-- vertical alignment attribute for cell contents
+-->
+<!ENTITY % CellVAlign.attrib
+     "valign       ( top
+                   | middle
+                   | bottom
+                   | baseline )             #IMPLIED"
+>
+
+<!-- scope is simpler than axes attribute for common tables
+-->
+<!ENTITY % scope.attrib
+     "scope        ( row
+                   | col
+                   | rowgroup
+                   | colgroup )             #IMPLIED"
+>
+
+<!-- table: Table Element .............................. -->
+
+<!ENTITY % table.element  "INCLUDE" >
+<![%table.element;[
+<!ENTITY % table.content
+     "( %caption.qname;?, ( %col.qname;* | %colgroup.qname;* ),
+      (( %thead.qname;?, %tfoot.qname;?, %tbody.qname;+ ) | ( %tr.qname;+ )))"
+>
+<!ELEMENT %table.qname;  %table.content; >
+<!-- end of table.element -->]]>
+
+<!ENTITY % table.attlist  "INCLUDE" >
+<![%table.attlist;[
+<!ATTLIST %table.qname;
+      %Common.attrib;
+      summary      %Text.datatype;          #IMPLIED
+      width        %Length.datatype;        #IMPLIED
+      border       %Pixels.datatype;        #IMPLIED
+      %frame.attrib;
+      %rules.attrib;
+      cellspacing  %Length.datatype;        #IMPLIED
+      cellpadding  %Length.datatype;        #IMPLIED
+>
+<!-- end of table.attlist -->]]>
+
+<!-- caption: Table Caption ............................ -->
+
+<!ENTITY % caption.element  "INCLUDE" >
+<![%caption.element;[
+<!ENTITY % caption.content
+     "( #PCDATA | %Inline.mix; )*"
+>
+<!ELEMENT %caption.qname;  %caption.content; >
+<!-- end of caption.element -->]]>
+
+<!ENTITY % caption.attlist  "INCLUDE" >
+<![%caption.attlist;[
+<!ATTLIST %caption.qname;
+      %Common.attrib;
+>
+<!-- end of caption.attlist -->]]>
+
+<!-- thead: Table Header ............................... -->
+
+<!-- Use thead to duplicate headers when breaking table
+     across page boundaries, or for static headers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % thead.element  "INCLUDE" >
+<![%thead.element;[
+<!ENTITY % thead.content  "( %tr.qname; )+" >
+<!ELEMENT %thead.qname;  %thead.content; >
+<!-- end of thead.element -->]]>
+
+<!ENTITY % thead.attlist  "INCLUDE" >
+<![%thead.attlist;[
+<!ATTLIST %thead.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of thead.attlist -->]]>
+
+<!-- tfoot: Table Footer ............................... -->
+
+<!-- Use tfoot to duplicate footers when breaking table
+     across page boundaries, or for static footers when
+     tbody sections are rendered in scrolling panel.
+-->
+
+<!ENTITY % tfoot.element  "INCLUDE" >
+<![%tfoot.element;[
+<!ENTITY % tfoot.content  "( %tr.qname; )+" >
+<!ELEMENT %tfoot.qname;  %tfoot.content; >
+<!-- end of tfoot.element -->]]>
+
+<!ENTITY % tfoot.attlist  "INCLUDE" >
+<![%tfoot.attlist;[
+<!ATTLIST %tfoot.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tfoot.attlist -->]]>
+
+<!-- tbody: Table Body ................................. -->
+
+<!-- Use multiple tbody sections when rules are needed
+     between groups of table rows.
+-->
+
+<!ENTITY % tbody.element  "INCLUDE" >
+<![%tbody.element;[
+<!ENTITY % tbody.content  "( %tr.qname; )+" >
+<!ELEMENT %tbody.qname;  %tbody.content; >
+<!-- end of tbody.element -->]]>
+
+<!ENTITY % tbody.attlist  "INCLUDE" >
+<![%tbody.attlist;[
+<!ATTLIST %tbody.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tbody.attlist -->]]>
+
+<!-- colgroup: Table Column Group ...................... -->
+
+<!-- colgroup groups a set of col elements. It allows you
+     to group several semantically-related columns together.
+-->
+
+<!ENTITY % colgroup.element  "INCLUDE" >
+<![%colgroup.element;[
+<!ENTITY % colgroup.content  "( %col.qname; )*" >
+<!ELEMENT %colgroup.qname;  %colgroup.content; >
+<!-- end of colgroup.element -->]]>
+
+<!ENTITY % colgroup.attlist  "INCLUDE" >
+<![%colgroup.attlist;[
+<!ATTLIST %colgroup.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of colgroup.attlist -->]]>
+
+<!-- col: Table Column ................................. -->
+
+<!-- col elements define the alignment properties for
+     cells in one or more columns.
+
+     The width attribute specifies the width of the
+     columns, e.g.
+
+       width="64"        width in screen pixels
+       width="0.5*"      relative width of 0.5
+
+     The span attribute causes the attributes of one
+     col element to apply to more than one column.
+-->
+
+<!ENTITY % col.element  "INCLUDE" >
+<![%col.element;[
+<!ENTITY % col.content  "EMPTY" >
+<!ELEMENT %col.qname;  %col.content; >
+<!-- end of col.element -->]]>
+
+<!ENTITY % col.attlist  "INCLUDE" >
+<![%col.attlist;[
+<!ATTLIST %col.qname;
+      %Common.attrib;
+      span         %Number.datatype;        '1'
+      width        %MultiLength.datatype;   #IMPLIED
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of col.attlist -->]]>
+
+<!-- tr: Table Row ..................................... -->
+
+<!ENTITY % tr.element  "INCLUDE" >
+<![%tr.element;[
+<!ENTITY % tr.content  "( %th.qname; | %td.qname; )+" >
+<!ELEMENT %tr.qname;  %tr.content; >
+<!-- end of tr.element -->]]>
+
+<!ENTITY % tr.attlist  "INCLUDE" >
+<![%tr.attlist;[
+<!ATTLIST %tr.qname;
+      %Common.attrib;
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of tr.attlist -->]]>
+
+<!-- th: Table Header Cell ............................. -->
+
+<!-- th is for header cells, td for data,
+     but for cells acting as both use td
+-->
+
+<!ENTITY % th.element  "INCLUDE" >
+<![%th.element;[
+<!ENTITY % th.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %th.qname;  %th.content; >
+<!-- end of th.element -->]]>
+
+<!ENTITY % th.attlist  "INCLUDE" >
+<![%th.attlist;[
+<!ATTLIST %th.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of th.attlist -->]]>
+
+<!-- td: Table Data Cell ............................... -->
+
+<!ENTITY % td.element  "INCLUDE" >
+<![%td.element;[
+<!ENTITY % td.content
+     "( #PCDATA | %Flow.mix; )*"
+>
+<!ELEMENT %td.qname;  %td.content; >
+<!-- end of td.element -->]]>
+
+<!ENTITY % td.attlist  "INCLUDE" >
+<![%td.attlist;[
+<!ATTLIST %td.qname;
+      %Common.attrib;
+      abbr         %Text.datatype;          #IMPLIED
+      axis         CDATA                    #IMPLIED
+      headers      IDREFS                   #IMPLIED
+      %scope.attrib;
+      rowspan      %Number.datatype;        '1'
+      colspan      %Number.datatype;        '1'
+      %CellHAlign.attrib;
+      %CellVAlign.attrib;
+>
+<!-- end of td.attlist -->]]>
+
+<!-- end of xhtml-table-1.mod -->

--- a/publishing/1.1/xmlchars/isogrk1.ent
+++ b/publishing/1.1/xmlchars/isogrk1.ent
@@ -1,0 +1,70 @@
+
+<!--
+     File isogrk1.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Agr              "&#x00391;" ><!--=capital Alpha, Greek -->
+<!ENTITY agr              "&#x003B1;" ><!--=small alpha, Greek -->
+<!ENTITY Bgr              "&#x00392;" ><!--=capital Beta, Greek -->
+<!ENTITY bgr              "&#x003B2;" ><!--=small beta, Greek -->
+<!ENTITY Dgr              "&#x00394;" ><!--=capital Delta, Greek -->
+<!ENTITY dgr              "&#x003B4;" ><!--=small delta, Greek -->
+<!ENTITY EEgr             "&#x00397;" ><!--=capital Eta, Greek -->
+<!ENTITY eegr             "&#x003B7;" ><!--=small eta, Greek -->
+<!ENTITY Egr              "&#x00395;" ><!--=capital Epsilon, Greek -->
+<!ENTITY egr              "&#x003B5;" ><!--=small epsilon, Greek -->
+<!ENTITY Ggr              "&#x00393;" ><!--=capital Gamma, Greek -->
+<!ENTITY ggr              "&#x003B3;" ><!--=small gamma, Greek -->
+<!ENTITY Igr              "&#x00399;" ><!--=capital Iota, Greek -->
+<!ENTITY igr              "&#x003B9;" ><!--=small iota, Greek -->
+<!ENTITY Kgr              "&#x0039A;" ><!--=capital Kappa, Greek -->
+<!ENTITY kgr              "&#x003BA;" ><!--=small kappa, Greek -->
+<!ENTITY KHgr             "&#x003A7;" ><!--=capital Chi, Greek -->
+<!ENTITY khgr             "&#x003C7;" ><!--=small chi, Greek -->
+<!ENTITY Lgr              "&#x0039B;" ><!--=capital Lambda, Greek -->
+<!ENTITY lgr              "&#x003BB;" ><!--=small lambda, Greek -->
+<!ENTITY Mgr              "&#x0039C;" ><!--=capital Mu, Greek -->
+<!ENTITY mgr              "&#x003BC;" ><!--=small mu, Greek -->
+<!ENTITY Ngr              "&#x0039D;" ><!--=capital Nu, Greek -->
+<!ENTITY ngr              "&#x003BD;" ><!--=small nu, Greek -->
+<!ENTITY Ogr              "&#x0039F;" ><!--=capital Omicron, Greek -->
+<!ENTITY ogr              "&#x003BF;" ><!--=small omicron, Greek -->
+<!ENTITY OHgr             "&#x003A9;" ><!--=capital Omega, Greek -->
+<!ENTITY ohgr             "&#x003C9;" ><!--=small omega, Greek -->
+<!ENTITY Pgr              "&#x003A0;" ><!--=capital Pi, Greek -->
+<!ENTITY pgr              "&#x003C0;" ><!--=small pi, Greek -->
+<!ENTITY PHgr             "&#x003A6;" ><!--=capital Phi, Greek -->
+<!ENTITY phgr             "&#x003C6;" ><!--=small phi, Greek -->
+<!ENTITY PSgr             "&#x003A8;" ><!--=capital Psi, Greek -->
+<!ENTITY psgr             "&#x003C8;" ><!--=small psi, Greek -->
+<!ENTITY Rgr              "&#x003A1;" ><!--=capital Rho, Greek -->
+<!ENTITY rgr              "&#x003C1;" ><!--=small rho, Greek -->
+<!ENTITY sfgr             "&#x003C2;" ><!--=final small sigma, Greek -->
+<!ENTITY Sgr              "&#x003A3;" ><!--=capital Sigma, Greek -->
+<!ENTITY sgr              "&#x003C3;" ><!--=small sigma, Greek -->
+<!ENTITY Tgr              "&#x003A4;" ><!--=capital Tau, Greek -->
+<!ENTITY tgr              "&#x003C4;" ><!--=small tau, Greek -->
+<!ENTITY THgr             "&#x00398;" ><!--=capital Theta, Greek -->
+<!ENTITY thgr             "&#x003B8;" ><!--=small theta, Greek -->
+<!ENTITY Ugr              "&#x003A5;" ><!--=capital Upsilon, Greek -->
+<!ENTITY ugr              "&#x003C5;" ><!--=small upsilon, Greek -->
+<!ENTITY Xgr              "&#x0039E;" ><!--=capital Xi, Greek -->
+<!ENTITY xgr              "&#x003BE;" ><!--=small xi, Greek -->
+<!ENTITY Zgr              "&#x00396;" ><!--=capital Zeta, Greek -->
+<!ENTITY zgr              "&#x003B6;" ><!--=small zeta, Greek -->

--- a/publishing/1.1/xmlchars/isogrk2.ent
+++ b/publishing/1.1/xmlchars/isogrk2.ent
@@ -1,0 +1,41 @@
+
+<!--
+     File isogrk2.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY Aacgr            "&#x00386;" ><!--=capital Alpha, accent, Greek -->
+<!ENTITY aacgr            "&#x003AC;" ><!--=small alpha, accent, Greek -->
+<!ENTITY Eacgr            "&#x00388;" ><!--=capital Epsilon, accent, Greek -->
+<!ENTITY eacgr            "&#x003AD;" ><!--=small epsilon, accent, Greek -->
+<!ENTITY EEacgr           "&#x00389;" ><!--=capital Eta, accent, Greek -->
+<!ENTITY eeacgr           "&#x003AE;" ><!--=small eta, accent, Greek -->
+<!ENTITY Iacgr            "&#x0038A;" ><!--=capital Iota, accent, Greek -->
+<!ENTITY iacgr            "&#x003AF;" ><!--=small iota, accent, Greek -->
+<!ENTITY idiagr           "&#x00390;" ><!--=small iota, dieresis, accent, Greek -->
+<!ENTITY Idigr            "&#x003AA;" ><!--=capital Iota, dieresis, Greek -->
+<!ENTITY idigr            "&#x003CA;" ><!--=small iota, dieresis, Greek -->
+<!ENTITY Oacgr            "&#x0038C;" ><!--=capital Omicron, accent, Greek -->
+<!ENTITY oacgr            "&#x003CC;" ><!--=small omicron, accent, Greek -->
+<!ENTITY OHacgr           "&#x0038F;" ><!--=capital Omega, accent, Greek -->
+<!ENTITY ohacgr           "&#x003CE;" ><!--=small omega, accent, Greek -->
+<!ENTITY Uacgr            "&#x0038E;" ><!--=capital Upsilon, accent, Greek -->
+<!ENTITY uacgr            "&#x003CD;" ><!--=small upsilon, accent, Greek -->
+<!ENTITY udiagr           "&#x003B0;" ><!--=small upsilon, dieresis, accent, Greek -->
+<!ENTITY Udigr            "&#x003AB;" ><!--=capital Upsilon, dieresis, Greek -->
+<!ENTITY udigr            "&#x003CB;" ><!--=small upsilon, dieresis, Greek -->

--- a/publishing/1.1/xmlchars/isogrk4.ent
+++ b/publishing/1.1/xmlchars/isogrk4.ent
@@ -1,0 +1,66 @@
+
+<!--
+     File isogrk4.ent produced by the XSL script characters.xsl
+     from input data in unicode.xml.
+
+     Please report any errors to David Carlisle
+     via the public W3C list www-math@w3.org.
+
+     The numeric character values assigned to each entity
+     (should) match the Unicode assignments in Unicode 4.0.
+
+     Entity names in this file are derived from files carrying the
+     following notice:
+
+     (C) International Organization for Standardization 1991
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+
+-->
+
+<!ENTITY % plane1D  "&#38;#38;#x1D">
+
+<!ENTITY b.alpha          "%plane1D;6C2;" ><!--small alpha, Greek -->
+<!ENTITY b.beta           "%plane1D;6C3;" ><!--small beta, Greek -->
+<!ENTITY b.chi            "%plane1D;6D8;" ><!--small chi, Greek -->
+<!ENTITY b.Delta          "%plane1D;6AB;" ><!--capital delta, Greek -->
+<!ENTITY b.delta          "%plane1D;6C5;" ><!--small delta, Greek -->
+<!ENTITY b.epsi           "%plane1D;6C6;" ><!--small epsilon, Greek -->
+<!ENTITY b.epsiv          "%plane1D;6DC;" ><!--variant epsilon -->
+<!ENTITY b.eta            "%plane1D;6C8;" ><!--small eta, Greek -->
+<!ENTITY b.Gamma          "%plane1D;6AA;" ><!--capital gamma, Greek -->
+<!ENTITY b.gamma          "%plane1D;6C4;" ><!--small gamma, Greek -->
+<!ENTITY b.Gammad         "&#x003DC;" ><!--capital Digamma -->
+<!ENTITY b.gammad         "&#x003DD;" ><!--digamma -->
+<!ENTITY b.iota           "%plane1D;6CA;" ><!--small iota, Greek -->
+<!ENTITY b.kappa          "%plane1D;6CB;" ><!--small kappa, Greek -->
+<!ENTITY b.kappav         "%plane1D;6DE;" ><!--variant kappa -->
+<!ENTITY b.Lambda         "%plane1D;6B2;" ><!--capital Lambda, Greek -->
+<!ENTITY b.lambda         "%plane1D;6CC;" ><!--small lambda, Greek -->
+<!ENTITY b.mu             "%plane1D;6CD;" ><!--small mu, Greek -->
+<!ENTITY b.nu             "%plane1D;6CE;" ><!--small nu, Greek -->
+<!ENTITY b.Omega          "%plane1D;6C0;" ><!--capital Omega, Greek -->
+<!ENTITY b.omega          "%plane1D;6DA;" ><!--small omega, Greek -->
+<!ENTITY b.Phi            "%plane1D;6BD;" ><!--capital Phi, Greek -->
+<!ENTITY b.phi            "%plane1D;6D7;" ><!--small phi, Greek -->
+<!ENTITY b.phiv           "%plane1D;6DF;" ><!--variant phi -->
+<!ENTITY b.Pi             "%plane1D;6B7;" ><!--capital Pi, Greek -->
+<!ENTITY b.pi             "%plane1D;6D1;" ><!--small pi, Greek -->
+<!ENTITY b.piv            "%plane1D;6E1;" ><!--variant pi -->
+<!ENTITY b.Psi            "%plane1D;6BF;" ><!--capital Psi, Greek -->
+<!ENTITY b.psi            "%plane1D;6D9;" ><!--small psi, Greek -->
+<!ENTITY b.rho            "%plane1D;6D2;" ><!--small rho, Greek -->
+<!ENTITY b.rhov           "%plane1D;6E0;" ><!--variant rho -->
+<!ENTITY b.Sigma          "%plane1D;6BA;" ><!--capital Sigma, Greek -->
+<!ENTITY b.sigma          "%plane1D;6D4;" ><!--small sigma, Greek -->
+<!ENTITY b.sigmav         "%plane1D;6D3;" ><!--variant sigma -->
+<!ENTITY b.tau            "%plane1D;6D5;" ><!--small tau, Greek -->
+<!ENTITY b.Theta          "%plane1D;6AF;" ><!--capital Theta, Greek -->
+<!ENTITY b.thetas         "%plane1D;6C9;" ><!--straight theta, Greek -->
+<!ENTITY b.thetav         "%plane1D;6DD;" ><!--variant theta -->
+<!ENTITY b.Upsi           "%plane1D;6BC;" ><!--capital Upsilon, Greek -->
+<!ENTITY b.upsi           "%plane1D;6D6;" ><!--small upsilon, Greek -->
+<!ENTITY b.Xi             "%plane1D;6B5;" ><!--capital Xi, Greek -->
+<!ENTITY b.xi             "%plane1D;6CF;" ><!--small xi, Greek -->
+<!ENTITY b.zeta           "%plane1D;6C7;" ><!--small zeta, Greek -->


### PR DESCRIPTION
I'm not sure where should be considered the 'canonical' source, but assuming that's the [FTP server](ftp://ftp.ncbi.nih.gov/pub/jats/), I've added a Makefile (with helper script for collecting the multiple OASIS/MathML3 variants) for documenting the provenance of the publishing/1.1 files.

I haven't added (backported) similar provenance for existing DTDs, but that might be useful if this resource is truly a derivative of the FTP source?
